### PR TITLE
docs: embed the CI artifact now both repos are public; require PR + green CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
 on:
+  # Feature-branch pushes are covered by `pull_request`. Without the branch
+  # filter both events fire on every PR commit and the whole suite runs twice.
   push:
+    branches: [master]
   pull_request:
 
 env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,35 @@
 
 Extends the global `~/.claude/CLAUDE.md`. Project: a DIY **lean-to-steer self-balancing board** (rideable inverted pendulum) — Rust real-time control on PREEMPT_RT Linux, off-the-shelf smart drive (torque mode) + hoverboard hub motors, sim-first. A deferred companion **PX4 drone** lives in its own Notion doc. Full context: memory `[[balance-board-project]]`.
 
+## Repo boundary
+- **This repo is controls only** — Rust, sim, hardware, design docs. The public landing page and all
+  brand/marketing assets live in the sibling repo **`overboard-web`** (`~/projects/overboard-web`).
+  Keep them separate: no HTML/marketing here, no control code there.
+- The two are coupled by **facts, not code**. When a capability ships or a phase turns over, the
+  `overboard-web` page status must be updated in the same pass (Requirements `SR-WEB-4`, and the
+  lock-step rule in [M0](https://app.notion.com/p/3a8472a5fb6981ffbf73ee8297e62f07)).
+- Local multi-repo work: open `~/projects/overboard.code-workspace` to get both folders at once.
+
+## Git workflow — feature branches + PR, CI is the gate (HARD)
+- **Never commit to `master`.** All work goes on a feature branch (`feat/…`, `fix/…`, `docs/…`)
+  and lands via PR. `master` is protected: linear history, no force-push, no deletion.
+- **CI success is the merge gate.** `rust` and `sim` are required status checks and the branch
+  must be up to date with `master` before merging. A red build cannot be merged.
+- Required approvals are set to **0 deliberately** — GitHub forbids approving your own PR, so on a
+  solo repo any non-zero count would permanently block every merge. Mike still reviews; CI is the
+  hard gate. Add approvals if a second contributor ever joins.
+- `publish-sim-artifact` is deliberately **not** a required check: it only runs on push to `master`,
+  so requiring it would hang every PR forever waiting for a check that never reports.
+- `enforce_admins` is off, so Mike can break glass in an emergency. Claude must not.
+- Open the PR with a body that states what changed and *why*, and call out any acceptance criteria
+  that moved. Wait for CI, then merge (squash) — do not merge red or bypass protection.
+
+## Public artifacts
+- Both repos are **public**. CI publishes the sim render + metrics to the rolling `sim-latest`
+  release on every green `master` push; that URL is the single source for the README embed, the
+  Notion design doc video, and (later) the landing page. Never check binaries into git —
+  `sim/out/` is gitignored and the artifacts are regenerated every build.
+
 ## Docs & source of truth
 - **Notion is the PRIMARY home** for vision, design, and project/roadmap docs. The repo `docs/` holds **Markdown+Mermaid mirrors that track the implementation**; Notion may drift during heavy dev. Run a periodic cleanup pass to reconcile Notion vision/early-design with what shipped.
 - **No production code** until the design-doc set passes the ready-to-code gate (numeric acceptance criteria — see D0).

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ loop does not step MuJoCo yet (a later milestone, tracked as a TODO in
 `crates/sim-backend`), so the scenario is open-loop — which makes it the
 baseline the controller has to beat.
 
-> 🎬 **Watch it:** the rendered clip (mp4/webm/gif), poster, plot and metrics are
-> published to the rolling [`sim-latest`](https://github.com/MikePaNtZ/overboard/releases/tag/sim-latest)
-> release on every green mainline push, and an interactive replay is embedded in the
-> [Notion design doc](https://app.notion.com/p/3a8472a5fb6981d8b9e6f749517498dd).
->
-> The clip is deliberately *not* inlined here. `sim/out/` is gitignored — the artifacts
-> are regenerated every build and committing a 2 MB binary per push would bloat history.
-> Linking the release asset instead would render broken while this repo is **private**
-> (GitHub's image proxy cannot authenticate). Inline it once the repo goes public.
+<!-- Served live from the rolling `sim-latest` release, which CI republishes on
+     every green mainline push — so this is always the current mainline's result,
+     never a stale checked-in copy. `sim/out/` stays gitignored: the artifacts are
+     regenerated every build and committing 2 MB per push would bloat history. -->
+[![Impulse disturbance response](https://github.com/MikePaNtZ/overboard/releases/download/sim-latest/impulse_open_loop.gif)](https://github.com/MikePaNtZ/overboard/releases/download/sim-latest/impulse_open_loop.mp4)
+
+<sub>▶ [Full 1280×720 clip](https://github.com/MikePaNtZ/overboard/releases/download/sim-latest/impulse_open_loop.mp4) ·
+[response plot](https://github.com/MikePaNtZ/overboard/releases/download/sim-latest/impulse_pitch.png) ·
+[metrics](https://github.com/MikePaNtZ/overboard/releases/download/sim-latest/impulse_metrics.json) ·
+[all artifacts](https://github.com/MikePaNtZ/overboard/releases/tag/sim-latest)</sub>
 
 A driverless onewheel at rest is **stable** — the battery and hub motor put the
 centre of mass below the axle. So it is kicked with a 20 N·s impulse, and with


### PR DESCRIPTION
Both repos are now **public**, so the rolling `sim-latest` release assets are publicly fetchable. That removes the reason the clip was not inlined.

### What changed
- **README embeds the CI-produced GIF directly**, linking through to the full mp4, plot and metrics. Served live from the release, so it is always the *current mainline's* result rather than a stale checked-in copy. `sim/out/` stays gitignored — no binary enters git.
- The same release URL is what the [Notion design doc](https://app.notion.com/p/3a8472a5fb6981d8b9e6f749517498dd) video block points at, and what the landing page will embed. **One artifact, three surfaces.**
- Records the git workflow now enforced by branch protection: feature branch → PR → green CI → merge, linear history, no force-push.

### Two branch-protection settings that look wrong but aren't
- **Required approvals = 0.** GitHub forbids approving your own PR, so any non-zero count would *permanently block every merge* on a solo repo. CI is the hard gate; add approvals when a second contributor joins.
- **`publish-sim-artifact` is not a required check.** It only runs on push to `master`, so requiring it would hang every PR forever waiting for a check that never reports. Only `rust` and `sim` are required.

Also includes the previously uncommitted "Repo boundary" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)