### PR TITLE
feat(estimator): feedforward can use MEASURED current — a hardware gap the sim cannot show

### DIFF
--- a/crates/control-core/src/lib.rs
+++ b/crates/control-core/src/lib.rs
@@ -357,14 +357,30 @@ impl CommandFeedforward {
         CommandFeedforward { gain_m_s2_per_a }
     }
 
-    /// Predicted forward acceleration, m/s², from the last commanded current.
+    /// Predicted forward acceleration, m/s², from motor current.
     ///
-    /// Takes the *commanded* current rather than a measured one so it stays
-    /// usable on hardware that cannot report phase current, and so it carries
-    /// no sensing delay. Where measured current is available it is the better
-    /// input and can be passed here instead — the arithmetic is the same.
-    pub fn predict(&self, commanded_a: f32) -> f32 {
-        self.gain_m_s2_per_a * commanded_a
+    /// **Pass the MEASURED current wherever the drive reports one.** An earlier
+    /// version of this comment argued for the commanded value, on the grounds
+    /// that it carries no sensing delay and works on drives that cannot report
+    /// phase current. That reasoning does not survive contact with the drive
+    /// this project actually selected.
+    ///
+    /// A VESC silently derates commanded torque through at least six cutback
+    /// layers — battery voltage sag, input-current limits, FET and motor
+    /// temperature, ERPM limits. Fed the *commanded* value during a cutback,
+    /// this function subtracts an acceleration that is not happening, and the
+    /// error lands directly on the accelerometer's gravity reference. That is
+    /// the same corruption the estimator work removed, re-entering through the
+    /// actuator instead of the sensor — and it would appear under load, on a
+    /// hill, at low state of charge, with a rider aboard. The sim cannot show
+    /// it, because the sim has no cutback.
+    ///
+    /// The commanded value remains the fallback for a drive with no current
+    /// telemetry, and the *difference* between the two is worth reporting as a
+    /// fault in its own right: it is exactly the cutback detector such a drive
+    /// needs anyway.
+    pub fn predict(&self, current_a: f32) -> f32 {
+        self.gain_m_s2_per_a * current_a
     }
 }
 

--- a/crates/control-ffi/include/overboard_control.h
+++ b/crates/control-ffi/include/overboard_control.h
@@ -60,6 +60,15 @@ typedef struct {
      * Buys immunity to shoves the aiding cannot see, at the cost of running
      * open-loop on the gyro while tripped. */
     float    accel_trust_band_m_s2;
+    /* Which current the mode-2 feedforward believes.
+     *   0 = commanded (previous cycle's cmd.amps)
+     *   1 = measured  (obs.motor_current_a)
+     * HARDWARE SHOULD USE 1. A VESC derates commanded torque silently
+     * through several cutback layers; a feedforward fed the command during
+     * a cutback subtracts acceleration that is not happening, straight onto
+     * the attitude estimate. Defaults to 0 so a backend that never populates
+     * motor_current_a cannot silently feed the estimator a constant zero. */
+    uint32_t accel_ff_current_source;
 } ob_params_v1;
 
 typedef struct {

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -132,6 +132,18 @@ pub struct ObParamsV1 {
     /// Buys disturbance immunity at the cost of running open-loop on the gyro
     /// while tripped, so too narrow a band is worse than none.
     pub accel_trust_band_m_s2: f32,
+    /// Which current the mode-2 feedforward believes. **0 = commanded**
+    /// (`cmd.amps` from the previous cycle), **1 = measured**
+    /// (`obs.motor_current_a`).
+    ///
+    /// **Hardware should use 1.** The VESC derates commanded torque silently
+    /// through half a dozen cutback layers, and a feedforward fed the command
+    /// during a cutback subtracts acceleration that is not happening. Defaults
+    /// to 0 only because a backend that does not populate `motor_current_a`
+    /// would otherwise feed the estimator a constant zero — which is precisely
+    /// the "optional field quietly left at its default" failure this codebase
+    /// has already been bitten by once.
+    pub accel_ff_current_source: u32,
 }
 
 /// One cycle of plant state.
@@ -196,6 +208,9 @@ pub struct ObController {
     wheel_accel: Option<WheelAccelEstimator>,
     /// Mode 2's aiding source. Mutually exclusive with `wheel_accel`.
     accel_ff: Option<CommandFeedforward>,
+    /// True when the feedforward should believe `obs.motor_current_a` rather
+    /// than the command we issued last cycle.
+    accel_ff_measured: bool,
     /// Last current commanded, amps — the feedforward's input. One cycle old
     /// by construction: it is what we asked for on the previous tick, which is
     /// what the plant has been acting on since.
@@ -276,6 +291,7 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
         } else {
             None
         },
+        accel_ff_measured: p.accel_ff_current_source == 1,
         last_amps: 0.0,
         estimator: if p.use_estimator != 0 {
             Some(ComplementaryFilter::with_trust_band(
@@ -381,7 +397,11 @@ pub unsafe extern "C" fn ob_controller_update(
     // `estimator_accel_aiding`. At most one is Some.
     let aiding = match (ctl.wheel_accel.as_mut(), ctl.accel_ff.as_ref()) {
         (Some(w), _) => w.update(o.wheel_rate_rad_s * ctl.r_eff_m, dt_s),
-        (None, Some(ff)) => ff.predict(ctl.last_amps),
+        (None, Some(ff)) => ff.predict(if ctl.accel_ff_measured {
+            o.motor_current_a
+        } else {
+            ctl.last_amps
+        }),
         (None, None) => 0.0,
     };
 
@@ -463,6 +483,7 @@ mod tests {
             wheel_accel_tau_s: 0.05,
             accel_ff_gain_m_s2_per_a: 0.0,
             accel_trust_band_m_s2: 0.0,
+            accel_ff_current_source: 0,
         }
     }
 

--- a/sim/scenarios/impulse_response.py
+++ b/sim/scenarios/impulse_response.py
@@ -340,6 +340,11 @@ def run(
     # current-loop lag, gyro noise, wheel-rate quantisation (ICD 12).
     imp = ImperfectionState(profile=profile, dt_s=dt)
     m.imperfection_profile_id = profile.profile_id
+    # What actually flowed last step -- post delay, post current-loop lag. The
+    # ICD calls this "measured, not commanded" and it is NOT the same signal as
+    # the command: on hardware a VESC derates silently, and in sim the lag and
+    # delay already separate the two.
+    flowing_a = 0.0
 
     for _ in range(n_steps):
         data.xfrc_applied[frame] = 0.0
@@ -363,10 +368,12 @@ def run(
                 float(data.time), pitch, sensed_rate, sensed_wheel,
                 gyro_rad_s=imp.gyro_vec(true_gyro),
                 accel_m_s2=imp.accel_vec(true_accel),
+                motor_current_a=flowing_a,
             ))
 
         # Delay and current-loop lag live here, not in the controller.
         current = imp.apply_current(proposed)
+        flowing_a = current
 
         # ctrl is TORQUE (motor actuator, gear=1); the controller speaks amps.
         data.ctrl[0] = current * KT_NM_PER_A

--- a/sim/scenarios/rust_controller.py
+++ b/sim/scenarios/rust_controller.py
@@ -69,6 +69,7 @@ class ObParams(ctypes.Structure):
         ("wheel_accel_tau_s", ctypes.c_float),
         ("accel_ff_gain_m_s2_per_a", ctypes.c_float),
         ("accel_trust_band_m_s2", ctypes.c_float),
+        ("accel_ff_current_source", ctypes.c_uint32),
     ]
 
 
@@ -157,6 +158,7 @@ class RustController:
         wheel_accel_tau_s: float = 0.05,
         accel_ff_gain_m_s2_per_a: float = 0.0,
         accel_trust_band_m_s2: float = 0.0,
+        accel_ff_current_source: int = 0,
         lib_path: Path | None = None,
     ) -> None:
         path = lib_path or library_path()
@@ -209,6 +211,7 @@ class RustController:
             wheel_accel_tau_s=wheel_accel_tau_s,
             accel_ff_gain_m_s2_per_a=accel_ff_gain_m_s2_per_a,
             accel_trust_band_m_s2=accel_trust_band_m_s2,
+            accel_ff_current_source=int(accel_ff_current_source),
         )
         self._handle = lib.ob_controller_new(ctypes.byref(params))
         if not self._handle:
@@ -246,12 +249,19 @@ class RustController:
         wheel_rate_rad_s: float,
         gyro_rad_s=None,
         accel_m_s2=None,
+        motor_current_a: float | None = None,
     ) -> float:
         o, c = self._obs, self._cmd
         if gyro_rad_s is not None:
             o.gyro_rad_s[0], o.gyro_rad_s[1], o.gyro_rad_s[2] = gyro_rad_s
         if accel_m_s2 is not None:
             o.accel_m_s2[0], o.accel_m_s2[1], o.accel_m_s2[2] = accel_m_s2
+        # MEASURED current -- what actually flowed during the last step, after
+        # actuation delay and current-loop lag. ICD: "measured, not commanded".
+        # Left at zero by callers that cannot supply it, which is why the
+        # feedforward does not default to trusting it.
+        if motor_current_a is not None:
+            o.motor_current_a = motor_current_a
         o.t_ns = int(t_s * 1e9)
         o.pitch_rad = pitch_rad
         o.pitch_rate_rad_s = pitch_rate_rad_s

--- a/sim/scenarios/shuttle_run.py
+++ b/sim/scenarios/shuttle_run.py
@@ -317,6 +317,8 @@ def run(
     # which is the signature of a transient rather than a sensor problem.
     mujoco.mj_forward(model, data)
 
+    # Post-delay, post-lag current -- see the note in impulse_response.run.
+    flowing_a = 0.0
     ts, pos, pos_cmd, vs, vrefs, pitches, prefs, currents = [], [], [], [], [], [], [], []
     states: list[np.ndarray] = []
     commanded_pos = 0.0
@@ -344,7 +346,9 @@ def run(
                 t, pitch, rate, wheel,
                 gyro_rad_s=imp.gyro_vec(true_gyro),
                 accel_m_s2=imp.accel_vec(true_accel),
+                motor_current_a=flowing_a,
             )))
+            flowing_a = current
             data.ctrl[0] = current * KT_NM_PER_A
             mujoco.mj_step(model, data)
 

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -216,7 +216,8 @@ def test_the_shuttle_hands_the_controller_a_live_imu():
         def __exit__(self, *exc):
             return False
 
-        def __call__(self, t, pitch, rate, wheel, gyro_rad_s=None, accel_m_s2=None):
+        def __call__(self, t, pitch, rate, wheel, gyro_rad_s=None,
+                     accel_m_s2=None, motor_current_a=None):
             seen.append((gyro_rad_s, accel_m_s2))
             return 0.0
 
@@ -286,4 +287,116 @@ def test_a_long_crossover_is_the_other_way_to_survive_and_costs_accuracy():
     assert long_tau.metrics.return_error_m > 5 * good.metrics.return_error_m, (
         "the tau trade should be visible: surviving via a long crossover ought to "
         "drift substantially further than surviving via better aiding"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Which current the feedforward believes (DR-CTRL-5)
+# ---------------------------------------------------------------------------
+
+COMMANDED, MEASURED = 0, 1
+
+
+def test_the_default_current_source_survives_a_backend_that_reports_nothing():
+    """Why the default is `commanded` even though hardware wants `measured`.
+
+    `motor_current_a` is an optional-in-practice field: a backend that never
+    populates it leaves a plausible-looking ZERO, and a feedforward told to
+    trust it then predicts no acceleration at all -- silently degrading to no
+    aiding, which at tau = 2 s does not fly. This codebase has already lost a
+    day to exactly that shape of bug (the shuttle's unwired IMU), so the
+    default must be the one that cannot fail quietly.
+    """
+    from sim.scenarios.shuttle_run import ShuttleParams
+    from sim.scenarios.shuttle_run import run as shuttle_run
+
+    class Blind(RustController):
+        """A backend that forgets to report measured current."""
+
+        def __call__(self, t, pitch, rate, wheel, gyro_rad_s=None,
+                     accel_m_s2=None, motor_current_a=None):
+            return super().__call__(t, pitch, rate, wheel, gyro_rad_s=gyro_rad_s,
+                                    accel_m_s2=accel_m_s2, motor_current_a=None)
+
+    r = shuttle_run(
+        ShuttleParams(),
+        controller_factory=lambda vp: Blind(
+            **SHUTTLE_GAINS, v_ref_fn=vp.v_ref, use_estimator=1,
+            estimator_tau_s=2.0, estimator_accel_aiding=COMMAND_FEEDFORWARD,
+            accel_ff_current_source=MEASURED),
+    )
+    assert r.metrics.nose_strike, (
+        "trusting an unpopulated motor_current_a should fail LOUDLY. If this "
+        "now survives, the default in ObParamsV1 can safely become MEASURED"
+    )
+
+
+def test_sim_cannot_tell_the_two_current_sources_apart():
+    """**A negative result, recorded so it is not mistaken for a positive one.**
+
+    On hardware the feedforward must use MEASURED current, because a VESC
+    derates commanded torque silently through half a dozen cutback layers
+    (DR-CTRL-5). In sim the two are nearly identical, differing only by the
+    actuation delay and current-loop lag -- **because the sim has no cutback
+    model at all**.
+
+    So this test does not vindicate the hardware choice; it documents that the
+    sim is incapable of vindicating it. Making that case testable needs a
+    PROPORTIONAL derate row in the imperfection profile. The existing hard
+    current cap is not a substitute: capping hard enough to matter destroys
+    torque authority, and the resulting crash is the missing torque rather than
+    the corrupted estimate.
+    """
+    from sim.scenarios.shuttle_run import ShuttleParams
+    from sim.scenarios.shuttle_run import run as shuttle_run
+
+    def go(source):
+        return shuttle_run(
+            ShuttleParams(),
+            controller_factory=lambda vp: RustController(
+                **SHUTTLE_GAINS, v_ref_fn=vp.v_ref, use_estimator=1,
+                estimator_tau_s=2.0, estimator_accel_aiding=COMMAND_FEEDFORWARD,
+                accel_ff_current_source=source),
+        )
+
+    cmd, meas = go(COMMANDED), go(MEASURED)
+    assert not cmd.metrics.nose_strike and not meas.metrics.nose_strike
+    assert abs(cmd.metrics.return_error_m - meas.metrics.return_error_m) < 0.01, (
+        "if these have diverged, the sim has gained something cutback-like and "
+        "this test should become a real comparison rather than a caveat"
+    )
+
+
+def test_the_scenarios_report_a_measured_current_that_is_not_the_command():
+    """The field exists, is populated, and is genuinely a different signal.
+
+    It was declared in the observation from the start and left at zero by every
+    scenario -- so any backend consuming it would have read a constant zero.
+    """
+    import numpy as np
+
+    from sim.scenarios.shuttle_run import ShuttleParams
+    from sim.scenarios.shuttle_run import run as shuttle_run
+
+    seen = []
+
+    class Spy(RustController):
+        def __call__(self, t, pitch, rate, wheel, gyro_rad_s=None,
+                     accel_m_s2=None, motor_current_a=None):
+            amps = super().__call__(t, pitch, rate, wheel, gyro_rad_s=gyro_rad_s,
+                                    accel_m_s2=accel_m_s2,
+                                    motor_current_a=motor_current_a)
+            seen.append((amps, motor_current_a))
+            return amps
+
+    shuttle_run(ShuttleParams(),
+                controller_factory=lambda vp: Spy(**SHUTTLE_GAINS, v_ref_fn=vp.v_ref))
+
+    measured = np.array([m for _, m in seen], dtype=float)
+    commanded = np.array([c for c, _ in seen], dtype=float)
+    assert np.abs(measured).max() > 1.0, "measured current is still all zeros"
+    # Delay plus current-loop lag: they track, but they are not the same series.
+    assert np.abs(measured - commanded).max() > 0.5, (
+        "measured current is echoing the command -- ICD 12 calls that "
+        "non-conforming, because it hides the lag the controller must tolerate"
     )


### PR DESCRIPTION
Found by reviewing the shipped estimator **against the hardware BoM** rather than against the sim — the question being whether the drive we are actually buying can support the controller that now works in simulation.

## The finding

`CommandFeedforward` justified taking the **commanded** current *"so it stays usable on hardware that cannot report phase current."* That justification does not survive the drive we chose. The [BoM's own VESC blocker table](https://app.notion.com/p/3a8472a5fb698129be78d4dab4c5de88) already says why:

> *Cutback layers silently scale commanded torque — `l_battery_cut_start/end` (voltage sag → linear derate to zero; this is literally the nosedive mechanism), `l_in_current_max/min`, `l_temp_fet_*`… **works on the bench, nosedives at 60% SoC**.*

Fed the command during a cutback, the feedforward subtracts an acceleration that is not happening and drops the error straight onto the gravity reference — the same corruption PR #7 removed, re-entering through the actuator instead of the sensor. Under load, on a hill, with a rider aboard.

Same defect class as the `WheelAccelEstimator` comment corrected in #7: a plausible justification in a docstring, wrong for reasons the sim cannot show.

## Changes

- **`accel_ff_current_source`** — 0 = commanded, 1 = measured. `hw-backend` must populate `motor_current_a` from VESC status frame 1. The commanded/measured divergence is *also* exactly the cutback detector the BoM independently requires — one comparison, two requirements.
- **Default stays 0, deliberately.** A backend that never populates `motor_current_a` leaves a plausible **zero**, and trusting it silently degrades to no aiding at all — the shuttle's unwired-IMU bug again. The default must be the one that cannot fail quietly, and a test pins that it fails loudly.
- **The scenarios now publish measured current** — the post-delay, post-lag value that actually flowed. The field was declared in the observation from the start and **left at zero by every scenario**, so any consumer would have read a constant zero.

## Negative result, recorded as one

**Sim cannot tell the two sources apart** — 0.0226 m vs 0.0224 m return error. It has no cutback model, so they differ only by actuation delay and current-loop lag. The existing hard current cap is not a substitute: capping hard enough to matter destroys torque authority, and both sources then fail on *missing torque* rather than a corrupted estimate.

`test_sim_cannot_tell_the_two_current_sources_apart` exists so the passing test is not mistaken for evidence. Making this genuinely testable needs a **proportional derate** row in the imperfection profile.

## Requirements added

| | |
|---|---|
| **DR-CTRL-5** | Aiding uses measured current; commanded/measured divergence is reported as a fault |
| **DR-CTRL-6** | Power-on gyro bias calibration — τ moved 1 s → 2 s in #7, **doubling** the `b·τ` term |
| **DR-HW-1** | IMU rigidly mounted to the frame near the axle, offset recorded; it must **not** move off-board with the tethered Pi |

## Consistency defects found, not fixed here

- 🔴 **`ctrlrange="-28 28"` is still live** in `overboard_onewheel.xml`. Flagged in the BoM previously and never fixed. Verified still present, and worse than it looked: the nominal impulse now saturates at **exactly 40.00 A = 28.00 N·m**, so envelope and plant clamps coincide precisely — invisible today, active the instant anyone raises `max_current_a`, and **below the ≥30 N·m requirement the BoM states**. Left alone because changing it moves the CI baselines and deserves its own change.
- ✅ BoM's *"SR-SIM-3 … fix it while parts ship"* is now stale — SR-SIM-3 was met.

Full suite: 79 Rust, 79 pytest + 1 xfail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
