### PR TITLE
feat(ops): decision record, ownership map, and a policy CI gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,102 @@
+# CODEOWNERS — path ownership map for the Overboard org
+#
+# STATUS: PROPOSED. See docs/decisions/ADR-0002-path-ownership-map.md and the
+# Escalations row it names. This file is the current working assumption; a role
+# that disagrees with a boundary files a row rather than editing around it.
+#
+# GitHub CODEOWNERS can only name real accounts, and this org has exactly one
+# human. So @MikePaNtZ is the reviewer on every rule, and the ROLE is carried in
+# the `# role:` tag above each block. Those tags are the authoritative map that
+# the `policy` CI job parses and that the "do not edit paths another role owns"
+# rule refers to. Do not remove them.
+#
+# Known roles (the policy check rejects any other value):
+#   CEO, COO, CMO, Sr. Mechanical & Systems, Senior Controls,
+#   Digital Content Production
+#
+# Last matching pattern wins, so specific rules go BELOW general ones.
+
+# --------------------------------------------------------------------------
+# Default. Anything not explicitly claimed belongs to the CEO, which is the
+# right default because unclaimed territory is a scoping question, not a
+# technical one.
+# --------------------------------------------------------------------------
+# role: CEO
+*                               @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# Project rules, public front door, and the licence. Public claims and the
+# licence are one-way doors; both stay with the CEO.
+# --------------------------------------------------------------------------
+# role: CEO
+/README.md                      @MikePaNtZ
+# role: CEO
+/CLAUDE.md                      @MikePaNtZ
+# role: CEO
+/LICENSE                        @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# Cross-role operations: the decision record, the escalation machinery, and CI.
+# --------------------------------------------------------------------------
+# role: COO
+/.github/                       @MikePaNtZ
+# role: COO
+/docs/                          @MikePaNtZ
+# role: COO
+/docs/decisions/                @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# The control law and the Rust workspace it lives in.
+# --------------------------------------------------------------------------
+# role: Senior Controls
+/crates/                        @MikePaNtZ
+# role: Senior Controls
+/Cargo.toml                     @MikePaNtZ
+# role: Senior Controls
+/Cargo.lock                     @MikePaNtZ
+# role: Senior Controls
+/rust-toolchain.toml            @MikePaNtZ
+# role: Senior Controls
+/notebooks/                     @MikePaNtZ
+# role: Senior Controls
+/tests/                         @MikePaNtZ
+# role: Senior Controls
+/sim/                           @MikePaNtZ
+# role: Senior Controls
+/scripts/                       @MikePaNtZ
+# role: Senior Controls
+/requirements-sim.txt           @MikePaNtZ
+# role: Senior Controls
+/docs/sim-impulse-response.md   @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# Plant models, the bench rig, and the sim-to-hardware fidelity contract.
+# Per the Sr. Mechanical & Systems handoff: this role owns where model numbers
+# come from and which are measured versus asserted. The control law is NOT
+# owned here, which is why the split runs through sim/ rather than around it.
+# --------------------------------------------------------------------------
+# role: Sr. Mechanical & Systems
+/sim/models/                    @MikePaNtZ
+# role: Sr. Mechanical & Systems
+/sim/scenarios/bench_*.py       @MikePaNtZ
+# role: Sr. Mechanical & Systems
+/tests/test_bench_*.py          @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# Renders and published media. Per the Digital Content Production handoff this
+# role does NOT own the landing page's markup or CSS — that lives in the
+# overboard-web repo under a separate session.
+# --------------------------------------------------------------------------
+# role: Digital Content Production
+/scripts/render_scenario.py     @MikePaNtZ
+# role: Digital Content Production
+/docs/web-artifact-pipeline.md  @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# UNRESOLVED — flagged, not assigned.
+#
+# /overboard-logo.html is a brand asset sitting in a controls-only repo, which
+# the project rules say should not happen (brand lives in overboard-web). It
+# falls to the CEO default above until the CMO and CEO settle where it goes.
+# Raised in ADR-0002; not moved here, because moving it is CMO turf.
+# --------------------------------------------------------------------------

--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Policy gate for the Overboard repo.
+
+Four hard checks that fail the build, plus one advisory report that does not.
+See docs/decisions/ADR-0003-policy-ci-gate.md for why each one exists and why
+the advisory one is deliberately not hard yet.
+
+Run it locally before opening a PR:
+
+    python3 .github/policy_check.py
+
+Stdlib only, on purpose: the policy gate must not be able to fail because a
+dependency moved.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DECISIONS = REPO / "docs" / "decisions"
+CODEOWNERS = REPO / ".github" / "CODEOWNERS"
+
+KNOWN_ROLES = {
+    "CEO",
+    "COO",
+    "CMO",
+    "Sr. Mechanical & Systems",
+    "Senior Controls",
+    "Digital Content Production",
+}
+
+VALID_ADR_STATUS = re.compile(
+    r"^\s*-\s*\*\*Status:\*\*\s*(Proposed|Accepted|Rejected|Superseded by ADR-\d{4})\s*$",
+    re.MULTILINE,
+)
+
+# A requirement ID: UR-13, SR-WEB-4, DR-SIM-1.
+REQ_ID = re.compile(r"\b(?:UR|SR|DR)-[A-Z0-9]*-?\d+\b")
+
+# Absolutes the program committed to never saying in public. Deliberately tight:
+# a broad list produces false positives, and a gate that cries wolf gets removed.
+BANNED = [
+    (re.compile(r"production[- ]ready", re.I), "the project is explicitly not production-ready"),
+    (re.compile(r"\bcertified\b", re.I), "nothing here is certified by anyone"),
+    (re.compile(r"guarantee[sd]?\s+(?:to\s+be\s+)?safe", re.I), "safety is not guaranteed"),
+    (re.compile(r"safe\s+to\s+ride", re.I), "no ridden operation has cleared the D5 review"),
+    (re.compile(r"perfectly\s+safe", re.I), "no."),
+    (re.compile(r"crash[- ]proof", re.I), "no."),
+    (re.compile(r"fully\s+autonomous", re.I), "overclaims the control stack"),
+    (re.compile(r"medical[- ]grade|\bFDA\b"), "not a regulated device; do not borrow the language"),
+]
+
+# Capability language that SHOULD trace to a requirement. Advisory for now.
+CAPABILITY = re.compile(
+    r"self[- ]balanc\w*|balances?\s+itself|rides?\s+itself|riderless|driverless"
+    r"|autonomous|\bproven\b",
+    re.I,
+)
+
+failures: list[str] = []
+advisories: list[str] = []
+
+
+def fail(check: str, msg: str) -> None:
+    failures.append(f"{check}: {msg}")
+
+
+def public_markdown() -> list[Path]:
+    """Markdown that forms the repo's public face.
+
+    docs/decisions/ is excluded on purpose. ADRs are internal engineering
+    records and must be able to QUOTE the banned words in order to ban them --
+    ADR-0003 lists every one of them. Scanning them would make the gate
+    self-defeating on its own charter.
+    """
+    out = [REPO / "README.md"]
+    out += [p for p in sorted((REPO / "docs").rglob("*.md")) if DECISIONS not in p.parents]
+    return [p for p in out if p.is_file()]
+
+
+def sections(text: str) -> list[tuple[str, str, int]]:
+    """Split markdown into (heading, body, heading_line_number)."""
+    lines = text.splitlines()
+    out: list[tuple[str, str, int]] = []
+    heading, buf, start = "(preamble)", [], 1
+    for i, line in enumerate(lines, 1):
+        if re.match(r"^#{1,6}\s", line):
+            out.append((heading, "\n".join(buf), start))
+            heading, buf, start = line.lstrip("# ").strip(), [], i
+        else:
+            buf.append(line)
+    out.append((heading, "\n".join(buf), start))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. ADR index integrity
+# ---------------------------------------------------------------------------
+def check_adr_index() -> None:
+    index = DECISIONS / "INDEX.md"
+    if not index.is_file():
+        fail("adr-index", "docs/decisions/INDEX.md is missing")
+        return
+
+    index_text = index.read_text(encoding="utf-8")
+    on_disk = {p.name for p in DECISIONS.glob("ADR-*.md") if p.name != "ADR-TEMPLATE.md"}
+
+    for name in sorted(on_disk):
+        if name not in index_text:
+            fail("adr-index", f"{name} exists but is not listed in INDEX.md")
+
+    for ref in sorted(set(re.findall(r"ADR-\d{4}-[a-z0-9-]+\.md", index_text))):
+        if not (DECISIONS / ref).is_file():
+            fail("adr-index", f"INDEX.md references {ref}, which does not exist")
+
+    for name in sorted(on_disk):
+        body = (DECISIONS / name).read_text(encoding="utf-8")
+        if not VALID_ADR_STATUS.search(body):
+            fail("adr-index", f"{name} has no recognised '- **Status:**' line")
+
+    numbers = sorted(re.match(r"ADR-(\d{4})", n).group(1) for n in on_disk)
+    if len(numbers) != len(set(numbers)):
+        fail("adr-index", "duplicate ADR numbers on disk; numbers are never reused")
+
+
+# ---------------------------------------------------------------------------
+# 2. Ownership coverage and role tags
+# ---------------------------------------------------------------------------
+def check_codeowners() -> None:
+    if not CODEOWNERS.is_file():
+        fail("ownership", ".github/CODEOWNERS is missing")
+        return
+
+    patterns: list[str] = []
+    pending_role: str | None = None
+
+    for lineno, raw in enumerate(CODEOWNERS.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            m = re.match(r"#\s*role:\s*(.+?)\s*$", line)
+            if m:
+                if m.group(1) not in KNOWN_ROLES:
+                    fail("ownership", f"CODEOWNERS:{lineno} unknown role {m.group(1)!r}")
+                pending_role = m.group(1)
+            continue
+
+        # A rule line.
+        if pending_role is None:
+            fail("ownership", f"CODEOWNERS:{lineno} rule {line.split()[0]!r} has no '# role:' tag above it")
+        pending_role = None
+        patterns.append(line.split()[0])
+
+    explicit = {p.strip("/") for p in patterns if p != "*"}
+
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=REPO, capture_output=True, text=True, check=True
+    ).stdout.split()
+    top_dirs = sorted({p.split("/")[0] for p in tracked if "/" in p})
+
+    for d in top_dirs:
+        if d not in explicit:
+            fail(
+                "ownership",
+                f"top-level directory {d!r} has no explicit CODEOWNERS rule "
+                f"(the '*' catch-all does not count -- assign it deliberately)",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3 + 4 + 5. Public claim checks
+# ---------------------------------------------------------------------------
+def check_claims() -> None:
+    for path in public_markdown():
+        rel = path.relative_to(REPO)
+        text = path.read_text(encoding="utf-8")
+
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for pattern, why in BANNED:
+                if pattern.search(line):
+                    fail("banned-absolute", f"{rel}:{lineno} {pattern.pattern!r} -- {why}")
+
+        for heading, body, lineno in sections(text):
+            if "claim" in heading.lower():
+                if not REQ_ID.search(body) and not REQ_ID.search(heading):
+                    fail(
+                        "claim-trace",
+                        f"{rel}:{lineno} section {heading!r} makes claims but cites no "
+                        f"requirement ID (UR-/SR-/DR-)",
+                    )
+            elif CAPABILITY.search(body) and not REQ_ID.search(body):
+                hit = CAPABILITY.search(body)
+                advisories.append(
+                    f"{rel}:{lineno} section {heading!r} uses {hit.group(0)!r} "
+                    f"with no requirement ID in scope"
+                )
+
+
+def main() -> int:
+    check_adr_index()
+    check_codeowners()
+    check_claims()
+
+    if advisories:
+        print("Advisory -- capability language with no requirement ID in scope.")
+        print("Not a failure. Input to a future ADR that tightens this into a hard check.\n")
+        for a in advisories:
+            print(f"  ~ {a}")
+        print()
+
+    if failures:
+        print(f"POLICY FAILED -- {len(failures)} problem(s):\n")
+        for f in failures:
+            print(f"  x {f}")
+        print("\nSee docs/decisions/ADR-0003-policy-ci-gate.md")
+        return 1
+
+    print("policy: all hard checks pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,47 @@ jobs:
         run: pytest tests/ -v
 
   # ---------------------------------------------------------------------
+  # Policy gate. Stdlib-only Python, no install step, a couple of seconds.
+  #
+  # Checks the decision record has not drifted from its own index, that every
+  # top-level directory has a named owner, and that public-facing markdown
+  # neither uses the absolutes this project committed to never saying nor
+  # makes claims without a requirement ID behind them. Full rationale, and
+  # why the capability-language check is advisory rather than hard, is in
+  # docs/decisions/ADR-0003-policy-ci-gate.md.
+  #
+  # Deliberately NOT a required status check yet: it has to pass green at
+  # least once first. Required checks stay `rust` and `sim`. It is also not a
+  # `needs:` of the publish job -- a policy failure should not be able to
+  # suppress an artifact whose physics passed.
+  #
+  # Run it locally before opening a PR: python3 .github/policy_check.py
+  # ---------------------------------------------------------------------
+  policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      # The fence is opened and closed around the run so the summary stays
+      # readable on failure too. PIPESTATUS rather than the pipeline's own
+      # status: `tee` succeeds even when the check does not, and a policy gate
+      # that reports green because its logger worked would be worse than none.
+      - name: Policy gate
+        run: |
+          { echo '### Policy gate'; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          set +e
+          python3 .github/policy_check.py 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          status=${PIPESTATUS[0]}
+          set -e
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+  # ---------------------------------------------------------------------
   # Film the scenario and publish it, always behind a green gate -- the landing
   # page eventually consumes this artifact, so a clip must never be published
   # for a commit whose physics did not pass.

--- a/docs/decisions/ADR-0001-decision-record-and-escalation-queue.md
+++ b/docs/decisions/ADR-0001-decision-record-and-escalation-queue.md
@@ -1,0 +1,65 @@
+# ADR-0001 — Establish the decision record and the escalation queue
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Ratified by:** COO
+- **Closes:** none — this is the scaffolding the queue itself needs, directed by the CEO
+- **Constrains:** every role
+- **Enforced by:** `policy` CI job (ADR index integrity); convention for the rest
+
+## Context
+
+Overboard is built by parallel Claude sessions with no ability to message one another. They
+share only Notion, the git repos, and Mike. Before this ADR the org had **neither** of the
+two artifacts its own protocol assumed: there was no `docs/decisions/` directory anywhere in
+the repository's history, and no Escalations database in Notion.
+
+The practical failure this creates is specific. A session that compacted, or one started
+fresh tomorrow, has no way to learn that a decision was made yesterday. It will re-derive
+it, contradict it, or silently build on a superseded assumption — and nothing will catch
+that, because a Notion page nobody opened is not a control.
+
+## Decision
+
+Two artifacts, with a hard line between them.
+
+1. **The Escalations database** in Notion is the *queue*. One row per decision meeting
+   Promise, Door, or Turf. Every row carries a **default action** and a **deadline**, both
+   mandatory. Options, rationale and Oracle verdicts go in the page body, never in columns.
+2. **`docs/decisions/`** in this repo is the *record*. Only an ADR here binds anyone.
+
+`Answered` is an opinion recorded in Notion. **`Ratified` means it exists in git** — an ADR,
+plus a CI check whenever the decision constrains code or public claims.
+
+**Ratification is the COO's to close, not the implementer's.** The COO writes the ADR, adds
+the check, and reports which sessions need restarting. The org has no broadcast primitive
+except restart, so a decision that is not written to git and announced has not landed.
+
+## Options considered
+
+- **Notion-only record.** Rejected. A session must be *told* to read Notion, and a stale
+  session by definition was not told. Notion cannot produce a red build.
+- **Git-only record, no queue.** Rejected. Escalation needs an asynchronous inbox with
+  deadlines that Mike can answer between sessions; a PR comment thread is not that, and
+  git has no notion of "unanswered by Thursday, so I proceeded".
+- **Both, with the split above.** Chosen. The queue is where a decision is *argued*; the
+  record is where it becomes *binding*. Cost of the losing options: either decisions do not
+  reach a fresh session, or they never get made because someone is parked waiting.
+
+## Consequences
+
+- Every role must read `docs/decisions/INDEX.md` before opening a PR. This is cheap — the
+  index is one screen.
+- The COO becomes a serialisation point for ratification. That is deliberate: it is the
+  only way a decision gets the same treatment regardless of which role made it.
+- A decision can now be *stale-proof*: if it constrains code, the CI check outlives the
+  session that agreed to it.
+- Nobody blocks. The default action fires at the deadline, and the record distinguishes
+  "agreed" from "went unopposed" — those are different facts and were previously conflated.
+
+## How this is enforced
+
+The `policy` CI job checks that every `ADR-*.md` file appears in `INDEX.md` and that every
+ADR referenced by the index exists, so the index cannot silently drift from the record it
+indexes. Everything else here is convention, and depends on `INDEX.md` actually being read
+before a PR is opened.

--- a/docs/decisions/ADR-0002-path-ownership-map.md
+++ b/docs/decisions/ADR-0002-path-ownership-map.md
@@ -1,0 +1,73 @@
+# ADR-0002 — Map repository paths to roles
+
+- **Status:** Proposed
+- **Date:** 2026-07-26
+- **Ratified by:** *(not yet — awaiting CEO, see Escalations row)*
+- **Closes:** [Escalations — "Confirm the path ownership map"](https://app.notion.com/p/150eb337e89349948f980d2bb06bab80)
+- **Constrains:** every role's "do not edit paths another role owns" rule
+- **Enforced by:** `policy` CI job (coverage and role-tag validity only — it cannot check that a boundary is *correct*)
+
+## Context
+
+The org protocol tells each role not to edit paths another role owns, and to file a row
+instead. No such map existed. Without one, "turf" is unfalsifiable: a session cannot tell
+whether it is trespassing, so it either freezes or guesses.
+
+This ADR is marked **Proposed**, not Accepted, on purpose. A path map binds every other
+role, which makes it a Promise under the escalation rule — the COO does not get to set it
+unilaterally just because the COO owns the file it lives in.
+
+## Decision
+
+The map lives in `.github/CODEOWNERS`, with the role carried in a `# role:` tag above each
+rule. GitHub's format can only name real accounts and this org has one human, so
+`@MikePaNtZ` is the reviewer on every rule and the tags carry the actual assignment.
+
+Boundaries are taken **from what the handoff documents already assert**, not invented:
+
+| Path | Role | Evidence |
+|---|---|---|
+| `*` (default) | CEO | Unclaimed territory is a scoping question |
+| `README.md`, `CLAUDE.md`, `LICENSE` | CEO | Public claims and licence are one-way doors |
+| `.github/`, `docs/`, `docs/decisions/` | COO | This role owns cross-role ops and the record |
+| `crates/`, `Cargo.*`, `notebooks/`, `tests/`, `sim/`, `scripts/` | Senior Controls | The control law and its harness |
+| `sim/models/`, `sim/scenarios/bench_*`, `tests/test_bench_*` | Sr. Mechanical & Systems | Handoff: owns the bench rig, the MuJoCo plant model, and the sim-to-hardware fidelity contract |
+| `scripts/render_scenario.py`, `docs/web-artifact-pipeline.md` | Digital Content Production | Handoff: owns renders; explicitly does *not* own page markup or CSS |
+
+The boundary deliberately runs **through** `sim/` rather than around it. Mechanical owns
+where plant numbers come from; Controls owns the law tuned against them. Drawing the line at
+the directory would have handed one role the other's work.
+
+## Options considered
+
+- **Map at directory granularity only.** Simpler, and wrong here: `sim/` and `tests/`
+  genuinely contain two roles' work, and the bench-rig files are exactly the ones most
+  likely to be edited by the wrong session.
+- **Leave ownership implicit and rely on the handoff docs.** Rejected. Handoffs are prose in
+  Notion; a session that did not read them cannot be caught by them, and nothing fails.
+- **File-level map with a CEO default.** Chosen. Cost of the losing options: turf collisions
+  that surface as merge conflicts or, worse, as a silently reverted decision.
+
+## Open boundary questions this raises
+
+1. **`scripts/`** is split by a single file. If the render pipeline grows, it should become
+   its own directory rather than accumulating exceptions.
+2. **`docs/`** defaults to COO because it is the mirror surface, but individual documents are
+   authored by the role that owns the subject. Two are called out explicitly; more will need
+   the same treatment as `docs/` grows.
+3. **`overboard-logo.html`** is a brand asset in a repo whose own rules say brand assets live
+   in `overboard-web`. It is left on the CEO default and flagged rather than moved, because
+   moving it is CMO territory. **This one wants a decision.**
+
+## Consequences
+
+- A new top-level directory now fails `policy` until someone assigns it. That tax is the
+  point: the moment a new directory appears is the cheapest moment to decide who owns it.
+- If a boundary here is wrong, the correction is a row — not an edit to this file by the
+  role that disagrees with it.
+
+## How this is enforced
+
+`policy` checks that every top-level path has an explicit rule and that every `# role:` tag
+names a known role. It **cannot** check that a boundary is correct; that is what the
+Proposed status and the escalation row are for.

--- a/docs/decisions/ADR-0003-policy-ci-gate.md
+++ b/docs/decisions/ADR-0003-policy-ci-gate.md
@@ -1,0 +1,79 @@
+# ADR-0003 — Add a `policy` CI gate for public claims and record integrity
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Ratified by:** COO
+- **Closes:** none — directed by the CEO
+- **Constrains:** anyone editing `README.md`, `docs/**.md`, `docs/decisions/`, or `.github/CODEOWNERS`
+- **Enforced by:** the `policy` job in `.github/workflows/ci.yml`
+
+## Context
+
+The program's lock-step rule says a capability claim may not appear publicly unless a
+requirement backs it, and a claim that becomes false in engineering comes off in the same
+pass. Until now that rule lived only in Notion prose. This repo is public, so its `README.md`
+and mirrored `docs/` **are** a public surface — the rule already applied here and nothing
+checked it.
+
+The same gap applies to the decision record itself: an index that drifts from the ADRs it
+lists is worse than no index, because it is trusted.
+
+## Decision
+
+Add a third CI job, `policy`, running four **hard** checks and one **advisory** report.
+
+Hard — these fail the build:
+
+1. **ADR index integrity.** Every `docs/decisions/ADR-*.md` appears in `INDEX.md`; every ADR
+   the index references exists; every ADR carries a recognised `Status`.
+2. **Ownership coverage.** Every top-level directory has an explicit `CODEOWNERS` rule —
+   not merely the `*` catch-all — so a new top-level directory forces an ownership decision
+   instead of defaulting silently. Every rule carries a `# role:` tag naming a known role.
+3. **Banned absolutes.** The words the program committed to never saying in public —
+   `production-ready`, `certified`, `guaranteed`, `safe to ride`, `FDA` and similar — appear
+   nowhere in public-facing markdown.
+4. **Claims-section traceability.** Any section whose heading contains "claim" must cite a
+   requirement ID matching `(UR|SR|DR)-[A-Z0-9-]*[0-9]`. The README's *"What the sim results
+   here do and do not claim"* section already satisfies this via `UR-13`; the check stops
+   that traceability from being quietly deleted.
+
+"Public-facing markdown" means `README.md` and `docs/**.md` **excluding `docs/decisions/`**.
+ADRs are internal engineering records and have to be able to quote the banned words in order
+to ban them — this very document lists every one of them. Scanning them would make the gate
+fail on its own charter.
+
+Advisory — reported in the job summary, **does not fail**:
+
+5. Capability-claim phrases (`self-balancing`, `riderless`, `autonomous`, `proven`, …) whose
+   enclosing section carries no requirement ID.
+
+**`policy` is deliberately not a required status check yet.** Per the CEO's instruction it
+must pass green at least once first. Required checks stay `rust` and `sim`.
+
+## Options considered
+
+- **Fail on every untraced capability phrase immediately.** Rejected for v1: the README's
+  opening line calls Overboard a "DIY self-balancing onewheel" in a section with no
+  requirement ID. That is a description of intent, not a capability claim, and a check that
+  forces either a wrong edit to a CEO-owned file or an ever-growing allowlist is a check
+  that gets disabled. It is reported as advisory instead, so the decision about that line is
+  made by a person with the data in front of them.
+- **Advisory-only for everything.** Rejected. A check that cannot fail is theatre. The four
+  hard checks were chosen precisely because they are deterministic, currently green, and
+  would genuinely catch the failure modes they name.
+- **The four hard checks plus an advisory report.** Chosen. Cost of the losing options:
+  either the gate gets switched off within a month, or it never catches anything.
+
+## Consequences
+
+- Adding a top-level directory now requires a `CODEOWNERS` edit — a small, intentional tax
+  on exactly the change that creates turf ambiguity.
+- The advisory list is the input to a future ADR that tightens check 5 into a hard one.
+- The check logic lives in `.github/policy_check.py`, inside COO-owned territory, so
+  tightening it never requires editing another role's paths.
+
+## How this is enforced
+
+`.github/policy_check.py`, invoked by the `policy` job. It is plain-stdlib Python and runs
+locally with `python3 .github/policy_check.py` — run it before opening a PR rather than
+discovering it in CI.

--- a/docs/decisions/ADR-TEMPLATE.md
+++ b/docs/decisions/ADR-TEMPLATE.md
@@ -1,0 +1,31 @@
+# ADR-NNNN — Title in the imperative
+
+- **Status:** Proposed | Accepted | Superseded by ADR-NNNN | Rejected
+- **Date:** YYYY-MM-DD
+- **Ratified by:** COO
+- **Closes:** link to the Escalations row (or `none — decided in role and logged`)
+- **Constrains:** which roles now have to do something differently
+- **Enforced by:** CI check name, or `none — convention only`
+
+## Context
+
+What was true that made this decision necessary. Written for a session that has none of the
+originating context.
+
+## Decision
+
+The decision, stated so that a reader can tell whether a given change complies.
+
+## Options considered
+
+At least two, with the cost of the losing option stated. A decision with one option was not
+a decision.
+
+## Consequences
+
+What becomes easier, what becomes harder, and which role now has to move.
+
+## How this is enforced
+
+The CI check, the CODEOWNERS entry, or an honest statement that it is convention only and
+therefore relies on this file being read.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -1,0 +1,53 @@
+# Decision record — INDEX
+
+**Read this before opening a PR.** A stale session that violates a later ADR gets a red
+build, and that is the only interrupt this org has that reliably works.
+
+The org runs as parallel Claude sessions serving one human CEO. Sessions cannot message
+each other. They share Notion, these repos, and Mike. This file is how a decision made in
+one session binds a session that never saw it.
+
+## Answered is not Ratified
+
+| State | Where it lives | Binds anyone? |
+|---|---|---|
+| **Open** | A row in the Notion [Escalations](https://app.notion.com/p/150eb337e89349948f980d2bb06bab80) database | No |
+| **Answered** | The `Decision` column of that row | **No.** It is an opinion in Notion |
+| **Ratified** | An ADR in this directory, plus a CI check if it constrains code or public claims | **Yes** |
+
+Ratification is the **COO's** to close, not the implementer's. The COO writes the ADR, adds
+the check, and tells Mike which sessions need restarting — restart is the only broadcast
+primitive the org has.
+
+## The ADRs
+
+| # | Title | Status | Constrains |
+|---|---|---|---|
+| [0001](ADR-0001-decision-record-and-escalation-queue.md) | Decision record and escalation queue | Accepted | Every role's process |
+| [0002](ADR-0002-path-ownership-map.md) | Path ownership map | **Proposed** | Who may edit which directory |
+| [0003](ADR-0003-policy-ci-gate.md) | `policy` CI gate | Accepted | Public claims in this repo |
+
+## Conventions
+
+- Filename `ADR-NNNN-kebab-title.md`, numbered in order of ratification, never reused.
+- Status is one of `Proposed`, `Accepted`, `Superseded by ADR-NNNN`, `Rejected`.
+- An ADR is never edited to reverse it. Write a new one and mark the old one superseded.
+- Every ADR names the Escalations row it closes, so the reasoning stays reachable.
+- `Proposed` ADRs are visible on purpose: they are the current working assumption, and a
+  role that disagrees files a row rather than editing around it.
+
+## Escalate when any one is true — Promise, Door, or Turf
+
+- **Promise** — it changes something outside your role relies on: a public claim, a
+  requirement, an acceptance criterion, an interface/ICD, or a doc another role owns.
+- **Door** — it is one-way or expensive to reverse: money, anything published, a schema or
+  API, a claim already live on the site.
+- **Turf** — you are about to do work another role owns. See [CODEOWNERS](../../.github/CODEOWNERS).
+
+All three false → decide it yourself and log it. **Difficulty is not a trigger.**
+Hard-but-reversible-and-yours is what your Oracle is for, and consulting the Oracle is not
+an escalation.
+
+Every row carries a **default action** and a **deadline**. Nobody is ever parked waiting on
+an answer; if the deadline passes, execute the default and record that it went unopposed
+rather than agreed. The record must distinguish those two.


### PR DESCRIPTION
Builds the scaffolding the org protocol already assumed existed. Before this PR there was **no `docs/decisions/` anywhere in this repository's history** and no Escalations database in Notion — so the instruction every session was given ("read `docs/decisions/INDEX.md` before opening a PR") pointed at nothing.

## What lands

| Path | What it is |
|---|---|
| `docs/decisions/INDEX.md` | The file every session reads before opening a PR. Carries the Answered-vs-Ratified distinction and the Promise/Door/Turf triggers. |
| `ADR-0001` (Accepted) | The record and the queue, and why they are two artifacts rather than one. |
| `ADR-0002` (**Proposed**) | The path ownership map. |
| `ADR-0003` (Accepted) | The `policy` gate below. |
| `ADR-TEMPLATE.md` | Template. |
| `.github/CODEOWNERS` | Roles carried in `# role:` tags. |
| `.github/policy_check.py` + `policy` job | The gate. |

The Notion half is live: [Escalations database](https://app.notion.com/p/150eb337e89349948f980d2bb06bab80).

## ADR-0002 is Proposed on purpose

A path map binds every other role, which makes it a **Promise** under the escalation rule. The COO does not get to set it unilaterally just because the COO owns the file it lives in. Boundaries are taken from what the handoff docs already assert rather than invented — notably the line runs *through* `sim/` rather than around it, because Mechanical owns where plant numbers come from and Controls owns the law tuned against them. An Escalations row to the CEO carries it, with a default action.

## The gate

Four hard checks, all green today, all able to genuinely fail:

1. **ADR index integrity** — index and record cannot drift apart.
2. **Ownership coverage** — every top-level directory needs an explicit rule; the `*` catch-all does not count, so a new top-level directory forces an ownership decision.
3. **Banned absolutes** — `production-ready`, `certified`, `safe to ride`, … in public markdown.
4. **Claims-section traceability** — a section whose heading says "claim" must cite a requirement ID. README's *"What the sim results here do and do not claim"* already satisfies this via `UR-13`; the check stops that being quietly deleted.

Plus one **advisory** report that does not fail the build: capability language with no requirement ID in scope. It fires 4 times today, including on `README.md:1` — "DIY self-balancing onewheel" in a section with no requirement ID. That is a description of intent, not a capability claim, and making it hard would force either a wrong edit to a CEO-owned file or an ever-growing allowlist. That is how a gate gets switched off. It is reported instead, as the input to a later ADR that tightens it.

`docs/decisions/` is excluded from the claim scans — ADR-0003 has to be able to quote the banned words in order to ban them.

## Not a required check yet

Per instruction, `policy` stays advisory until it has been green on master at least once. Required checks remain `rust` and `sim`. It is deliberately not a `needs:` of `publish-sim-artifact` either — a policy failure should not suppress an artifact whose physics passed.

Verified locally: `python3 .github/policy_check.py` → exit 0, and the workflow YAML parses with the new job present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)