### PR TITLE
Fix the sim IMU→ICD frame map: it is a reflection (det = −1), not a rotation

### DIFF
--- a/sim/scenarios/plant.py
+++ b/sim/scenarios/plant.py
@@ -7,9 +7,39 @@ model out of `scripts/` would have the dependency backwards.
 
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 
 MODEL_PATH = Path(__file__).resolve().parents[2] / "sim" / "models" / "overboard_onewheel.xml"
+
+
+@functools.lru_cache(maxsize=1)
+def R_MODEL_TO_ICD():
+    """Rotation from the MuJoCo model frame to the ICD body frame (§10.1).
+
+    Model: z-up, **forward = −X** (overboard_onewheel.xml). ICD: FRD,
+    right-handed — x forward, y right, z down. Forward flips and up flips;
+    right is shared. That is a 180° rotation about +Y.
+
+    A frame change is a PROPER rotation. The determinant assertion is the whole
+    reason this is a matrix and not a per-axis sign triple: `det = −1` is a
+    reflection, it turns a right-handed frame into a left-handed one, and it is
+    exactly the defect this replaced. A sign triple gives you nowhere to check.
+
+    Built lazily and cached because this module imports numpy per-function on
+    purpose (see the module docstring's note on dependency direction).
+    """
+    import numpy as np
+
+    R = np.diag([-1.0, 1.0, -1.0])
+    det = float(np.linalg.det(R))
+    if abs(det - 1.0) > 1e-12:
+        raise ValueError(
+            f"model→ICD frame map must be a proper rotation (det = +1), got {det:+.6f}. "
+            "A det = −1 map is a reflection and produces a left-handed frame, which "
+            "ICD §10.1 forbids."
+        )
+    return R
 
 #: Motor torque constant, N*m per amp. **UNFITTED PLACEHOLDER.**
 #:
@@ -248,22 +278,37 @@ def imu_readings(model, data) -> tuple:
     the sensor block has been reordered once already, and an index quietly
     pointing at the wrong sensor would hand the estimator plausible garbage.
 
-    THE MODEL'S BODY FRAME IS NOT THE ICD'S. MuJoCo's frame here is **z-up**;
-    ICD §10.1 specifies FRD, **z-down**. Feeding the raw sensor to an estimator
-    that assumes FRD gives an attitude offset by 180°, which is about as bad as
-    a sign error gets on a balancer.
+    THE MODEL'S BODY FRAME IS NOT THE ICD'S. The model is **z-up with forward
+    = −X** (see the FORWARD note in overboard_onewheel.xml); ICD §10.1 mandates
+    **FRD, right-handed**: x forward, y right, z down. Feeding a raw sensor to
+    an estimator that assumes FRD is about as bad as a sign error gets on a
+    balancer.
 
-    The conversion is **z-negation on both vectors**, and it was determined
-    EMPIRICALLY against `framequat` truth rather than derived — §10.3 makes the
-    sim the arbiter for exactly this class of question, and a derivation that
-    looked right had the accelerometer's x sign backwards. On quiet samples
-    (specific force within 0.15 of 1 g, so gravity dominates) the converted
-    reading recovers truth to about 2° RMS, the residual being real
-    acceleration rather than a frame error. `test_imu_frame_matches_truth`
-    pins it.
+    The map is therefore a **180° rotation about +Y**, `diag(−1, +1, −1)` —
+    derived from the two frame definitions, not fitted. It is written as a
+    matrix rather than a per-axis sign triple so that its determinant can be
+    asserted: a frame change is a PROPER rotation, `det = +1`. A sign triple
+    has nowhere to check handedness, which is how the previous value got in.
 
-    The y axis is untouched, which is the component that matters: `gyro[1]` is
-    the nose-up pitch rate in both frames.
+    HISTORY, because this cost a real result. This used to be
+    `diag(+1, +1, −1)`, `det = −1` — a reflection, mapping a right-handed frame
+    to a left-handed one, which ICD §10.1 forbids in as many words. It was
+    "determined EMPIRICALLY against framequat truth" on quiet samples and
+    reported ~2° RMS. That residual was not real acceleration; it was the frame
+    error itself. The error vanishes at θ = 0 and grows as 2θ, so validating
+    near upright is validating in the one regime where the bug is invisible —
+    undisturbed estimator error is bit-identical under both maps. A test named
+    `test_imu_frame_matches_truth` was cited as pinning this and was never
+    written. See tests/test_frame_conformance.py, which does.
+
+    Two channels were wrong, one root cause. Accel-derived pitch came out at
+    exactly −θ, so the estimator fused a nose-up-positive gyro against a
+    nose-down-positive accelerometer. `gyro[0]` — roll rate — was also
+    inverted, and silently, because nothing consumes roll yet; it would have
+    surfaced as a control inversion the day lean-to-steer was wired up.
+
+    `gyro[1]` is the nose-up pitch rate and is the one component both maps
+    agree on, which is why the pitch RATE path was always correct.
     """
     import mujoco
     import numpy as np
@@ -276,5 +321,5 @@ def imu_readings(model, data) -> tuple:
         adr, dim = int(model.sensor_adr[sid]), int(model.sensor_dim[sid])
         out.append(np.array(data.sensordata[adr : adr + dim], dtype=float))
     gyro, accel = out
-    to_icd = np.array([1.0, 1.0, -1.0])
-    return gyro * to_icd, accel * to_icd
+    R = R_MODEL_TO_ICD()
+    return R @ gyro, R @ accel

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -28,6 +28,32 @@ def ridden():
 
 OFF, ACTIVE, SHADOW = 0, 1, 2
 
+#: Shared reason for the results this branch re-opens rather than re-tunes.
+#:
+#: `plant.imu_readings` used to convert MuJoCo axes to the ICD body frame with
+#: `diag(+1,+1,−1)` — determinant −1, a reflection, not a rotation. It inverted
+#: the accelerometer's x channel, so the complementary filter fused a
+#: nose-up-positive gyro against a nose-down-positive accelerometer. Every
+#: result below was measured through that. The corrected `diag(−1,+1,−1)`
+#: changes them materially, and in one case reverses the comparison the
+#: workstream's conclusion rests on.
+#:
+#: These are marked xfail(strict) rather than re-tuned, deleted, or left red on
+#: purpose. Re-tuning them to the new numbers would silently re-author Senior
+#: Controls' conclusions inside a frame-map fix; deleting them would destroy the
+#: evidence; leaving them red would block the fix indefinitely on a sim every
+#: other role is building against. strict=True means each one goes red the
+#: moment it starts passing again, so none can be forgotten.
+#:
+#: Owner: Senior Controls. Each xfail should become a re-derived assertion or a
+#: deliberate deletion. See the Escalations row "Correct the sim IMU→ICD frame
+#: map: it is a reflection (det = −1), not a rotation".
+FRAME_MAP_REBASELINE = (
+    "Recorded against the pre-fix IMU→ICD frame map (det = −1, a reflection that "
+    "inverted accelerometer x). Needs re-deriving by Senior Controls against the "
+    "corrected diag(−1,+1,−1) rotation — see the Escalations row on the frame map."
+)
+
 
 def _run(model, use_estimator, tau=TAU, secs=8.0, impulse=NOMINAL_IMPULSE_NS):
     with RustController(
@@ -97,8 +123,16 @@ def test_the_estimator_meets_the_ac_on_an_undisturbed_board(ridden):
     assert r.metrics.pitch_est_max_deg <= 1.0
 
 
+@pytest.mark.xfail(strict=True, reason=FRAME_MAP_REBASELINE)
 def test_closing_the_loop_on_the_v1_estimator_destabilises_the_board(ridden):
     """**The headline result, recorded rather than hidden.**
+
+    XFAILED PENDING RE-BASELINE (see FRAME_MAP_REBASELINE). Under the corrected
+    model→ICD rotation the board no longer strikes: peak |pitch| 18.81° → 7.71°,
+    estimator RMS 27.813° → 0.312°. The destabilisation recorded here was
+    dominated by an inverted accelerometer x channel, not by the mechanism the
+    docstring describes. That mechanism is still real and still measurable —
+    closed loop remains ~5× worse than shadow — but at a fraction of this size.
 
     In shadow the filter is accurate to ~1.1 deg RMS. Driving the loop with it
     strikes. The mechanism is feedback: estimate error produces a wrong command,
@@ -238,8 +272,14 @@ def test_the_shuttle_hands_the_controller_a_live_imu():
     )
 
 
+@pytest.mark.xfail(strict=True, reason=FRAME_MAP_REBASELINE)
 def test_command_feedforward_closes_the_loop_on_the_shuttle():
     """**The result this whole workstream was after.**
+
+    XFAILED PENDING RE-BASELINE. Still completes the run without a strike, but
+    return error goes 0.0226 m → 0.2331 m under the corrected rotation, so the
+    < 0.10 m assertion no longer holds. The qualitative result survives; the
+    number does not.
 
     Driving the real control law from a fused attitude estimate, the board
     completes the shuttle run. Measured through the real scenario and the real
@@ -256,8 +296,20 @@ def test_command_feedforward_closes_the_loop_on_the_shuttle():
     )
 
 
+@pytest.mark.xfail(strict=True, reason=FRAME_MAP_REBASELINE)
 def test_the_original_wheel_odometry_aiding_still_falls_over():
     """The other half of the measurement, so the fix is a comparison.
+
+    XFAILED PENDING RE-BASELINE — **and this is the one that matters most.**
+    Under the corrected rotation wheel-odometry aiding does NOT fall over:
+    strike True → False, return error 120.84 m → 0.2783 m, against command
+    feedforward's 0.2331 m. The comparison this test exists to make — odometry
+    fatal, feedforward the fix — collapses to a 0.05 m difference between two
+    configurations that both work.
+
+    That does not make command feedforward wrong. It removes the evidence that
+    it was *necessary*, which is a different claim and has to be re-established
+    rather than assumed.
 
     Same filter, same tau, same everything -- only the source of the forward
     acceleration correction differs. Wheel odometry differentiates a quantised,
@@ -272,8 +324,13 @@ def test_the_original_wheel_odometry_aiding_still_falls_over():
     )
 
 
+@pytest.mark.xfail(strict=True, reason=FRAME_MAP_REBASELINE)
 def test_a_long_crossover_is_the_other_way_to_survive_and_costs_accuracy():
     """Both knobs work, and the trade between them is the interesting part.
+
+    XFAILED PENDING RE-BASELINE. The trade is still visible but no longer clears
+    the 5× bar: 0.9567 m vs 0.2331 m is 4.10×. A threshold set against a
+    confounded baseline, not a result that vanished.
 
     tau >= 10 s stabilises the loop with the ORIGINAL aiding, by leaning on the
     accelerometer less. It costs position accuracy, because a gyro bias b leaves

--- a/tests/test_frame_conformance.py
+++ b/tests/test_frame_conformance.py
@@ -1,0 +1,140 @@
+"""The model→ICD frame map, tested as a CONTRACT rather than as a behaviour.
+
+This is the test whose absence let a reflection ship. `plant.imu_readings`'
+docstring used to cite `test_imu_frame_matches_truth` as pinning the
+conversion; that test was never written, and the map it was supposed to protect
+had `det = −1`.
+
+WHY THIS FILE IS DYNAMICS-FREE, AND WHY THAT IS THE POINT
+---------------------------------------------------------
+The previous map was "determined EMPIRICALLY against framequat truth". That
+method is what failed. Deriving a sign convention from a simulation run makes
+the answer depend on the regime you sampled — and the regime sampled (quiet,
+near-upright) is precisely where this class of error is invisible, because the
+error vanishes at θ = 0 and grows as 2θ.
+
+So nothing here integrates, contacts the ground, or reads a sensor. A frame
+conversion is a *definition*: two frames are declared, the map between them
+follows, and it is checkable with linear algebra. ICD §10.3 names the sim as
+the arbiter of the *polarity gate* — a dynamical question about which way the
+plant moves. It does not make the sim the arbiter of handedness, and reading it
+that way is what licensed the defect.
+
+SCOPE. This asserts the frame contract only. It deliberately says nothing about
+estimator accuracy: that is Senior Controls' acceptance criterion, measured in
+tests/test_estimator.py. Keeping this file purely contractual is what keeps the
+seam clean — a contract test that also encodes someone else's AC becomes a
+tripwire on their tuning.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from sim.scenarios.plant import R_MODEL_TO_ICD
+
+# ICD §10.1: FRD, right-handed — x forward (nose), y right, z down.
+# Model (overboard_onewheel.xml): z-up, forward = −X, therefore right = +Y.
+MODEL_FORWARD = np.array([-1.0, 0.0, 0.0])
+MODEL_RIGHT = np.array([0.0, 1.0, 0.0])
+MODEL_UP = np.array([0.0, 0.0, 1.0])
+
+ICD_FORWARD = np.array([1.0, 0.0, 0.0])
+ICD_RIGHT = np.array([0.0, 1.0, 0.0])
+ICD_DOWN = np.array([0.0, 0.0, 1.0])
+
+G = 9.81
+
+
+def test_the_map_is_a_proper_rotation():
+    """`det = +1`. The one assertion that would have caught the original bug.
+
+    A reflection maps a right-handed frame to a left-handed one. ICD §10.1 says
+    "right-handed" in as many words, so `det = −1` is not a near miss — it is a
+    direct contradiction of the spec, checkable without knowing any physics.
+    """
+    det = float(np.linalg.det(R_MODEL_TO_ICD()))
+    assert det == pytest.approx(1.0, abs=1e-12), (
+        f"det = {det:+.6f}. A frame change is a proper rotation; det = −1 is a "
+        "reflection and yields a left-handed frame (ICD §10.1 requires right-handed)."
+    )
+
+
+def test_the_map_is_orthonormal():
+    """R·Rᵀ = I. Together with det = +1 this is the definition of a rotation,
+    and it also forbids a map that quietly rescales an axis."""
+    R = R_MODEL_TO_ICD()
+    assert np.allclose(R @ R.T, np.eye(3), atol=1e-12)
+
+
+def test_the_three_body_axes_land_where_the_icd_says():
+    """The map is fixed by the two frame definitions, so check it against them
+    directly rather than against a number someone recorded."""
+    R = R_MODEL_TO_ICD()
+    assert np.allclose(R @ MODEL_FORWARD, ICD_FORWARD), "model forward (−X) must map to ICD +x"
+    assert np.allclose(R @ MODEL_RIGHT, ICD_RIGHT), "model right (+Y) must map to ICD +y"
+    assert np.allclose(R @ MODEL_UP, -ICD_DOWN), "model up (+Z) must map to ICD −z (z is DOWN)"
+
+
+@pytest.mark.parametrize("deg", [-40, -25, -15, -8, -4, -1, 0, 1, 4, 8, 15, 25, 40])
+def test_accel_derived_pitch_recovers_the_true_angle(deg):
+    """The consequence that actually bit: a supported accelerometer at pitch θ
+    must yield +θ through `control-core`'s estimator formula, not −θ.
+
+    Specific force on a supported board is `+g·ẑ_world`, rotated into the body
+    frame. No contact solver, no integration — just the tilt.
+
+    The formula is `control-core`'s `ComplementaryFilter::accel_pitch`:
+    `θ = atan2(f_x − a, −f_z)`, with the linear-acceleration term zero here.
+    That formula is correct for FRD and is NOT the thing under test; the frame
+    map is. If this fails, the map is wrong, not the estimator.
+    """
+    phi = math.radians(deg)
+    # Rotation of the body by +phi about +Y in the model frame (nose-up).
+    c, s = math.cos(phi), math.sin(phi)
+    R_body = np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+
+    f_model = R_body.T @ np.array([0.0, 0.0, G])   # what the sensor reads, supported
+    f_icd = R_MODEL_TO_ICD() @ f_model
+
+    theta = math.degrees(math.atan2(f_icd[0], -f_icd[2]))
+    assert theta == pytest.approx(deg, abs=1e-9), (
+        f"accel-derived pitch {theta:+.4f}° for a true {deg:+d}°. "
+        f"A result of {-deg:+d}° means the map inverted the x channel."
+    )
+
+
+@pytest.mark.parametrize(
+    "model_rate, axis, expected_icd",
+    [
+        ((0.0, 0.7, 0.0), "pitch (nose-up, +y)", (0.0, 0.7, 0.0)),
+        ((0.7, 0.0, 0.0), "roll (+x, right-wing-down)", (-0.7, 0.0, 0.0)),
+        ((0.0, 0.0, 0.7), "yaw (+z, down)", (0.0, 0.0, -0.7)),
+    ],
+)
+def test_every_gyro_axis_converts(model_rate, axis, expected_icd):
+    """All three axes, not just pitch.
+
+    Pitch was always correct because +y is the one component the old reflection
+    and the true rotation agree on — which is exactly why the defect survived:
+    the only axis anyone consumed was the only axis that was right.
+
+    ROLL IS THE LATENT ONE. Nothing reads `gyro[0]` today, so an inverted roll
+    rate is silent until lean-to-steer is wired up, at which point it presents
+    as a steering control inversion on a rideable vehicle. Pinned here so it
+    cannot be reintroduced by a future "simplification" back to a sign triple.
+    """
+    got = R_MODEL_TO_ICD() @ np.array(model_rate)
+    assert np.allclose(got, expected_icd, atol=1e-12), (
+        f"{axis}: model {model_rate} -> ICD {tuple(got)}, expected {expected_icd}"
+    )
+
+
+def test_the_map_survives_a_round_trip():
+    """Rᵀ·R = I on arbitrary vectors — the conversion loses nothing, so a
+    consumer that needs to go back to model axes can."""
+    R = R_MODEL_TO_ICD()
+    rng = np.random.default_rng(0)
+    v = rng.normal(size=(64, 3))
+    assert np.allclose((R.T @ (R @ v.T)).T, v, atol=1e-12)


### PR DESCRIPTION
**Proposal, not a merge.** `sim/scenarios/plant.py` and `tests/` are Senior Controls' paths under ADR-0002. Filed as an [Escalations row](https://app.notion.com/p/3a9472a5fb69817eb49ae206cbc9f877) before this branch was opened. I have not self-merged and will not.

## The defect — arithmetic, not opinion

`plant.imu_readings` converted MuJoCo axes to the ICD body frame with `diag(+1, +1, −1)`.

**That determinant is −1.** It is a reflection — it maps a right-handed frame to a left-handed one. ICD §10.1 mandates *"Body frame = FRD, **right-handed**"* in as many words, so this is not a near miss; it is a direct contradiction of the spec, checkable without knowing any physics.

The model is z-up with **forward = −X** (`overboard_onewheel.xml:25`). Model→FRD is therefore a 180° rotation about +Y — `diag(−1, +1, −1)`, det +1. Forward flips, up flips, right is shared.

## Two channels wrong, one root cause

| Channel | Shipped | Correct | Consumed today? |
|---|---|---|---|
| `accel[0]` | inverted | — | **yes** — accel-derived pitch came out at exactly −θ |
| `gyro[0]` (roll rate) | inverted | — | **no** — latent |
| `gyro[1]` (pitch rate) | correct | correct | yes |
| `gyro[2]`, `accel[2]` | correct | correct | — |

The estimator was fusing a **nose-up-positive gyro against a nose-down-positive accelerometer**.

Roll rate is the one that worries me more. Nothing reads `gyro[0]` today, so the inversion is silent — until lean-to-steer is wired up, at which point it presents as a steering control inversion on a rideable vehicle. `gyro[1]` being the single component both maps agree on is exactly why this survived: the only axis anyone consumed was the only axis that was right.

## Why it survived validation

The old docstring recorded the map as *"determined **EMPIRICALLY** against framequat truth"*, validated on quiet samples to *"about 2° RMS, the residual being real acceleration rather than a frame error."*

It was the frame error. The error vanishes at θ = 0 and grows as 2θ, so validating near upright is validating in the one regime where the bug is invisible — **undisturbed estimator error is identical under both maps, 0.105° RMS either way.**

`test_imu_frame_matches_truth`, cited in that docstring as pinning the conversion, **does not exist anywhere in the repo** and never did.

## The new test, and why it is dynamics-free

`tests/test_frame_conformance.py` is that missing test. It deliberately does not integrate, contact the ground, or read a sensor, because **deriving a sign convention from a simulation run is the method that failed here.**

A frame conversion is a *definition*: two frames are declared and the map follows. So it is checked with linear algebra — determinant, orthonormality, axis images, round-trip, and angle recovery through `control-core`'s own `accel_pitch` formula swept −40°…+40°.

ICD §10.3 names the sim as arbiter of the **polarity gate** — a dynamical question about which way the plant moves. It does not make the sim the arbiter of **handedness**, and reading it that way is what licensed this. I am amending §10.1/§10.3 on the ICD side to close that off; that part is mine and is not in this PR.

The test asserts the frame contract **only**. It says nothing about estimator accuracy — that is your AC, and a contract test that also encodes it becomes a tripwire on your tuning.

## Four recorded results change

| Recorded result | Shipped | Corrected |
|---|---|---|
| closing the loop destabilises the board | strike, peak 18.81°, RMS 27.813° | **no strike**, peak 7.71°, RMS 0.312° |
| command feedforward closes the shuttle | 0.0226 m | **0.2331 m** (still no strike; `<0.10 m` no longer holds) |
| wheel-odometry aiding still falls over | **strike**, 120.84 m | **no strike, 0.2783 m** |
| long-crossover trade > 5× | ~5×+ | **4.10×** |

**The third is the consequential one.** The comparison that motivated command feedforward over wheel odometry — one fatal, one the fix — collapses to a **0.05 m difference between two configurations that both work** (0.2783 vs 0.2331 m).

To be precise about what I am and am not claiming: this does **not** make command feedforward wrong, and it does not mean you chased a phantom. Accel contamination by the board's own acceleration is real physics and it is *still present after this fix* — the AC is still missed, and closed loop is still ~5× worse than shadow. What changes is that the evidence feedforward was **necessary** is gone. That is a different claim from "feedforward is better", and it has to be re-established rather than assumed.

## How I handled your failing tests

`xfail(strict=True)` with a shared `FRAME_MAP_REBASELINE` reason — not re-tuned, not deleted, not left red.

- **Re-tuning** them to the new numbers would silently re-author your conclusions inside a frame-map fix. Not mine to do.
- **Deleting** destroys the evidence. `test_closing_the_loop_...` authorises its own deletion "when accel compensation lands" — that is not what happened here, so I did not take it.
- **Leaving red** blocks the fix indefinitely on a sim every other role is building against.

`strict=True` means each goes red the moment it starts passing, so none can be quietly forgotten. **Each xfail is yours to convert into a re-derived assertion or a deliberate deletion.** Reshape freely — including the shape of my `plant.py` change, though the determinant assertion is the part I would ask you to keep.

## Verification

- `104 passed, 5 xfailed` (was `88 passed, 1 xfailed`; +20 new frame-conformance tests, +4 xfails)
- `python3 .github/policy_check.py` — all hard checks pass
- No Rust touched

## Requirements

Moves `DR-SIM-1` / `SR-SIM-3` fidelity: the sim-to-hardware contract now has its frame seam pinned by a derivation-based test rather than by a docstring citing a test that was never written. Filed by Sr. Mechanical & Systems as V&V and ICD authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPqmiktJQkmGc14UaUAPFS