### PR TITLE
Fix the bench kt fit: 50% low on the default profile, and the index mark survived the flywheel strip

### DIFF
--- a/sim/scenarios/bench_spinup.py
+++ b/sim/scenarios/bench_spinup.py
@@ -47,6 +47,60 @@ not exist. `J_bare`, by contrast, comes out UNBIASED by this same algebra --
 the friction term cancels between the two runs exactly, which is a genuine
 property of the method and not a coincidence of these particular numbers.
 
+kt WAS ALSO BIASED BY A MUCH LARGER AMOUNT, AND THAT ONE IS FIXED HERE
+-----------------------------------------------------------------------
+The Coulomb bias above is ~0.5%. There was a second bias roughly a HUNDRED
+times larger, and the asymmetry between what it does to kt and what it does to
+`J_bare` is worth understanding because it is the same asymmetry as above
+running the other way.
+
+The current does not arrive when commanded. Under `STAGE0_PLACEHOLDER` there
+is 1 ms of actuation delay and a 1 ms current-loop time constant, against what
+used to be a 5 ms fit window. So for the first fifth of that window there was
+little or no torque at the shaft, and the 500 Hz feedback update laid a 2 ms
+staircase on top. Both ramps were suppressed by roughly the same factor
+k ~ 0.5, and:
+
+  * `J_bare = kt*i/alpha_1` -- k appears in numerator and denominator, so it
+    CANCELS. J_bare was accurate to 0.1% the whole time.
+  * `kt = J_disc / (i*(1/alpha_2 - 1/alpha_1))` -- scales LINEARLY with k. It
+    came out at 0.02493 against a 0.05026 nameplate: 50.4% low, a factor of
+    two, on the default profile.
+
+The slope RATIO survived (7.70 with imperfections, 7.68 without), which is why
+the two-run structure still worked and only the absolute scale was lost. That
+is also why this hid so well: everything self-consistent stayed self-consistent
+and only the one number with an external reference was wrong.
+
+THE FIX HAS TWO PARTS, AND BOTH ARE ABOUT NOT ASSUMING THE COMMAND WAS OBEYED.
+
+1. FIT WHERE THE RAMP IS ACTUALLY A RAMP. The window now starts when the
+   measured current has settled to within `settle_fraction` of the command,
+   detected FROM THE CURRENT TRACE rather than computed from the profile --
+   see `settle_time_s`. That distinction matters: on hardware there is no
+   profile object to consult, only a current sensor, so a data-driven rule is
+   the only one that transfers. The rig's whole job is to characterise this
+   signal path, so it must not require the answer as an input.
+
+2. FIT AGAINST THE MEASURED CURRENT, NOT THE COMMANDED ONE. `kt*i = J*alpha`
+   is a statement about the current that actually flowed. Using the command
+   assumes a perfect current loop, which is precisely the assumption the bench
+   exists to test. The mean measured current over the fit window is the
+   consistent estimator here, and it makes the fit robust to any current-path
+   imperfection rather than only to the two currently modelled.
+
+Result: kt error on the default profile goes 50.4% -> 0.13%, and both
+profiles now land on the same ~0.1-0.5% floor, which IS the Coulomb bias above
+-- i.e. the only bias left is the one the algebra predicts. `test_identify_
+recovers_kt_under_the_stage0_profile` pins this so it cannot regress; its
+absence is why a factor-of-two error shipped green.
+
+RAISED BY Digital Content Production, who found it while building the render
+and correctly declined to quote a fitted kt in published material until it was
+resolved. The diagnostic that should have caught it did fire -- R^2 fell from
+1.0000 to 0.6927 -- but nothing asserted it, so the suite stayed green. Both
+R^2 values are now floored in the tests.
+
 SPIN-DOWN: b AND tau_c ARE FIT SEPARATELY, NOT LUMPED
 ------------------------------------------------------
 A single lumped friction coefficient fits a decelerating flywheel badly:
@@ -131,6 +185,21 @@ CURRENT_TRACKING_TOLERANCE_A = 0.5
 
 _FLYWHEEL_GEOM_RE = re.compile(r'<geom name="flywheel"[^>]*/>')
 
+#: The index mark goes with the disc it is drawn on.
+#:
+#: `index` sits at `pos="0 0.046 0.052"` -- the same y as the flywheel, at 52 mm
+#: radius, i.e. on the disc face. Strip the disc and leave the mark and you get
+#: a white bar rotating in mid-air where the flywheel used to be.
+#:
+#: It is massless with collision off, so `J_bare` and every fitted number are
+#: unaffected either way; this is model coherence, not correctness. But a plant
+#: model that renders as a floating decal is a plant model that will eventually
+#: be believed about something else. The mark exists so rotation is legible, and
+#: a bare on-axis rotor has nothing to make legible.
+#:
+#: Raised by Digital Content Production, who hit it rendering the bare variant.
+_INDEX_GEOM_RE = re.compile(r'<geom name="index"[^>]*/>')
+
 
 def known_disc_inertia_kg_m2() -> float:
     """`J_disc` from geometry and material, NOT from the compiled model.
@@ -162,19 +231,30 @@ def _joint_inertia(model: mujoco.MjModel) -> float:
 
 
 def strip_flywheel_geom(xml: str) -> str:
-    """Remove the flywheel geom from the MJCF string.
+    """Remove the flywheel geom -- and the index mark drawn on it -- from the
+    MJCF string.
 
     A regex, not `MjSpec` surgery: `MjsGeom` has no `.delete()`, and building
     the bare variant through spec editing is not worth the fragility for one
     geom. The caller MUST verify the strip actually worked -- see
     `build_bare_model` -- because a silent no-op here would make the bare and
     loaded runs identical and turn the two-run fit into a divide-by-zero.
+
+    The index mark is removed with the disc because it is ON the disc; see
+    `_INDEX_GEOM_RE`. It is massless, so no fitted number moves.
     """
     stripped, n = _FLYWHEEL_GEOM_RE.subn("", xml)
     if n != 1:
         raise RuntimeError(
             f"expected exactly one <geom name=\"flywheel\".../> to strip, found {n}. "
             "The bench_rig.xml flywheel geom's markup may have changed; update the regex."
+        )
+    stripped, n_index = _INDEX_GEOM_RE.subn("", stripped)
+    if n_index != 1:
+        raise RuntimeError(
+            f"expected exactly one <geom name=\"index\".../> to strip, found {n_index}. "
+            "The mark is drawn on the flywheel face, so it must go with it -- "
+            "otherwise the bare model renders a decal floating where the disc was."
         )
     return stripped
 
@@ -191,20 +271,66 @@ def build_bare_model(xml_text: str | None = None) -> mujoco.MjModel:
     assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel") < 0, (
         "flywheel geom is still present after stripping -- the regex did not match"
     )
+    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "index") < 0, (
+        "index mark survived the flywheel strip -- it is drawn on the disc face, "
+        "so the bare model would render a decal floating in mid-air"
+    )
     return bare
 
 
-def _fit_line(t: np.ndarray, y: np.ndarray, window_s: float) -> tuple[float, float]:
-    """Least-squares slope of `y` vs `t` over `t <= window_s`, plus R^2.
+def settle_time_s(
+    t: np.ndarray, i_measured: np.ndarray, commanded_a: float, fraction: float,
+) -> float:
+    """First instant after which the measured current STAYS within `fraction`
+    of the command.
+
+    Data-driven on purpose. The obvious alternative -- compute
+    `actuation_delay_s + 5*current_loop_tau_s` from the profile -- gives the
+    same answer in sim and is useless on hardware, where there is no profile
+    object, only a current sensor. Since characterising this very signal path
+    is the rig's job, a rule that needs the answer as an input is circular.
+
+    "Stays within" rather than "first reaches": a staircased or noisy current
+    can clip the threshold once on the way up. The last violation is what
+    bounds the transient, so the search runs from the end.
+    """
+    ok = np.asarray(i_measured) >= fraction * commanded_a
+    if not ok.any():
+        raise ValueError(
+            f"measured current never reached {fraction:.0%} of the commanded "
+            f"{commanded_a} A. Either the drive is saturating or the run is too "
+            "short to contain a settled ramp; the fit would be of the transient."
+        )
+    violations = np.flatnonzero(~ok)
+    idx = 0 if violations.size == 0 else int(violations[-1]) + 1
+    if idx >= len(t):
+        raise ValueError(
+            "measured current settles only at the very last sample -- no ramp "
+            "left to fit. Increase IdentifyParams.sim_seconds."
+        )
+    return float(t[idx])
+
+
+def _fit_line(
+    t: np.ndarray, y: np.ndarray, window_s: float, start_s: float = 0.0,
+) -> tuple[float, float]:
+    """Least-squares slope of `y` vs `t` over `start_s <= t <= window_s`, plus R^2.
 
     A window fit, not a two-sample finite difference -- so a bad window (too
     long, catching friction or a current cutback) is visible in the R^2
     rather than silently baked into a slope from two noisy points.
+
+    `start_s` defaults to 0.0 so the pre-existing two-argument call is
+    unchanged, but `identify` always passes an explicit start: fitting from
+    t=0 through an actuation delay and a current-loop lag is what produced a
+    factor-of-two kt error (see the module docstring).
     """
-    mask = t <= window_s
+    mask = (t >= start_s) & (t <= window_s)
     tt, yy = t[mask], y[mask]
     if len(tt) < 2:
-        raise ValueError(f"fit window {window_s}s contains fewer than 2 samples")
+        raise ValueError(
+            f"fit window [{start_s}s, {window_s}s] contains fewer than 2 samples"
+        )
     design = np.vstack([tt, np.ones_like(tt)]).T
     (slope, intercept), *_ = np.linalg.lstsq(design, yy, rcond=None)
     pred = slope * tt + intercept
@@ -217,23 +343,32 @@ def _fit_line(t: np.ndarray, y: np.ndarray, window_s: float) -> tuple[float, flo
 def _run_constant_current(
     model: mujoco.MjModel, current_a: float, seconds: float, profile: ImperfectionProfile,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Drive `model` with a held commanded current; log time and SENSED shaft
-    rate (i.e. run through the same quantisation/update-rate a real bench
-    identification would see, not MuJoCo truth)."""
+    """Drive `model` with a held commanded current; log time, SENSED shaft rate,
+    and the current ACTUALLY delivered.
+
+    The sensed rate runs through the same quantisation and update-rate a real
+    bench identification would see, not MuJoCo truth.
+
+    The delivered current is returned because `kt*i = J*alpha` is a statement
+    about the current that flowed, not the one that was asked for. Returning
+    only the command would force every caller to assume a perfect current loop
+    -- the assumption this rig exists to test.
+    """
     data = mujoco.MjData(model)
     dt = float(model.opt.timestep)
     n_steps = int(round(seconds / dt))
     imp = ImperfectionState(profile=profile, dt_s=dt)
     mujoco.mj_forward(model, data)
 
-    ts, ws = [], []
+    ts, ws, i_meas = [], [], []
     for _ in range(n_steps):
         current = imp.apply_current(current_a)
         data.ctrl[0] = current * NAMEPLATE_KT_NM_PER_A
         mujoco.mj_step(model, data)
         ts.append(float(data.time))
         ws.append(imp.wheel_rate(float(data.qvel[0]), float(data.time)))
-    return np.asarray(ts), np.asarray(ws)
+        i_meas.append(current)
+    return np.asarray(ts), np.asarray(ws), np.asarray(i_meas)
 
 
 # ---------------------------------------------------------------------------
@@ -250,14 +385,37 @@ class IdentifyParams:
     the kt fit (tau_c/i, see the module docstring) stays under ~0.5% of kt
     while remaining well inside the rig's 40 A / 2.0 N*m envelope."""
 
-    fit_window_s: float = 0.005
-    """Early window for the alpha fit. Short enough that viscous drag (which
-    grows with w, unlike Coulomb) has not yet bent the ramp measurably."""
+    fit_span_s: float = 0.014
+    """Length of the alpha fit window, measured FROM the settle instant rather
+    than from t=0 -- see `settle_time_s` and the module docstring.
 
-    sim_seconds: float = 0.02
-    """Just past the fit window, so nothing here depends on a current cutback
-    or on friction dominating -- both would show up as a fit window that
-    silently ran past the data available."""
+    Replaces the old `fit_window_s = 0.005`, which started at zero and so spent
+    its first fifth inside the actuation delay and current-loop lag. That is
+    the factor-of-two kt error. The name changed deliberately: the semantics
+    are different, and a silently redefined `fit_window_s` would be worse than
+    a loud `AttributeError` for any caller that reaches for it.
+
+    14 ms is chosen against measurement, not taste. Too short and the 500 Hz
+    sensed-rate staircase leaves too few distinct updates to fit a slope
+    through (10 ms gives five); too long and viscous drag, which grows with w
+    unlike Coulomb, starts bending the ramp -- visible as J_bare error creeping
+    up with span. Measured kt error by span on the default profile: 0.23% at
+    10 ms, 0.13% at 14 ms, 0.31% at 20 ms, 0.95% at 30 ms."""
+
+    settle_fraction: float = 0.99
+    """Fraction of the commanded current the measured current must reach, and
+    stay at, before the fit window opens.
+
+    0.99 is ~5 time constants of the current loop. 0.95 would open the window
+    ~3 tau in, while the ramp is still visibly curved; 0.999 buys nothing and
+    costs samples off the front of a finite run."""
+
+    sim_seconds: float = 0.04
+    """Long enough to contain the settle transient AND the full fit span with
+    margin (7 ms + 14 ms on the default profile). Was 0.02, which only just
+    cleared the old 5 ms window; the fit now starts later, so the run has to
+    end later. `identify` asserts the window actually fits inside the data
+    rather than letting a short run silently truncate it."""
 
 
 @dataclass
@@ -269,6 +427,20 @@ class IdentifyMetrics:
     alpha_loaded_rad_s2: float = 0.0
     r2_bare: float = 0.0
     r2_loaded: float = 0.0
+
+    #: The fit window actually used, in seconds. DERIVED FROM THE DATA, not a
+    #: parameter, so it has to be reported or the fit is not reproducible: the
+    #: start comes from where the measured current settled (`settle_time_s`).
+    #: Anything cross-checking these slopes must fit over the same interval --
+    #: comparing a post-settle slope against a from-zero one is a ~40%
+    #: "divergence" that is really two different signals.
+    fit_start_s: float = 0.0
+    fit_end_s: float = 0.0
+
+    #: Mean current that actually flowed over the fit window. This, not
+    #: `commanded_current_a`, is the `i` in `kt*i = J*alpha` -- see the module
+    #: docstring on why using the command cost a factor of two.
+    i_measured_mean_a: float = 0.0
 
     #: Against the nameplate/geometry references -- informational, NOT the
     #: acceptance criterion for a bare-motor J (there is no independent
@@ -310,20 +482,45 @@ def identify(
         "did not actually remove any mass"
     )
 
-    t_bare, w_bare = _run_constant_current(
+    t_bare, w_bare, i_bare = _run_constant_current(
         bare_model, params.commanded_current_a, params.sim_seconds, profile
     )
-    t_loaded, w_loaded = _run_constant_current(
+    t_loaded, w_loaded, i_loaded = _run_constant_current(
         loaded_model, params.commanded_current_a, params.sim_seconds, profile
     )
 
-    alpha1, r2_1 = _fit_line(t_bare, w_bare, params.fit_window_s)
-    alpha2, r2_2 = _fit_line(t_loaded, w_loaded, params.fit_window_s)
+    # Open the window only once the current has settled in BOTH runs. Taking the
+    # later of the two keeps the two fits over the same interval, which is what
+    # makes the slope ratio -- the quantity the whole two-run method rests on --
+    # a comparison of like with like.
+    i_cmd = params.commanded_current_a
+    t_start = max(
+        settle_time_s(t_bare, i_bare, i_cmd, params.settle_fraction),
+        settle_time_s(t_loaded, i_loaded, i_cmd, params.settle_fraction),
+    )
+    t_end = t_start + params.fit_span_s
+    if t_end > float(t_bare[-1]):
+        raise ValueError(
+            f"fit window [{t_start*1e3:.1f}, {t_end*1e3:.1f}] ms runs past the "
+            f"{float(t_bare[-1])*1e3:.1f} ms run. Increase sim_seconds; a truncated "
+            "window would silently fit fewer samples than asked for."
+        )
+
+    alpha1, r2_1 = _fit_line(t_bare, w_bare, t_end, start_s=t_start)
+    alpha2, r2_2 = _fit_line(t_loaded, w_loaded, t_end, start_s=t_start)
+
+    # The current that actually flowed over the fit window, not the command.
+    # Averaged across both runs: they share a profile and a held command, so the
+    # traces are the same to within the loop's own settling, and one number keeps
+    # the two-equation algebra below in the form the docstring derives.
+    def _mean_i(t, i_meas):
+        return float(np.asarray(i_meas)[(t >= t_start) & (t <= t_end)].mean())
+
+    i_eff = 0.5 * (_mean_i(t_bare, i_bare) + _mean_i(t_loaded, i_loaded))
 
     j_disc = known_disc_inertia_kg_m2()
-    i = params.commanded_current_a
-    kt_fit = j_disc / (i * (1.0 / alpha2 - 1.0 / alpha1))
-    j_bare_fit = kt_fit * i / alpha1
+    kt_fit = j_disc / (i_eff * (1.0 / alpha2 - 1.0 / alpha1))
+    j_bare_fit = kt_fit * i_eff / alpha1
 
     m = IdentifyMetrics(
         kt_fit_nm_per_a=kt_fit,
@@ -334,8 +531,11 @@ def identify(
         r2_bare=r2_1,
         r2_loaded=r2_2,
         kt_error_vs_nameplate_pct=abs(kt_fit - NAMEPLATE_KT_NM_PER_A) / NAMEPLATE_KT_NM_PER_A * 100.0,
+        fit_start_s=t_start,
+        fit_end_s=t_end,
+        i_measured_mean_a=i_eff,
         imperfection_profile_id=profile.profile_id,
-        commanded_current_a=i,
+        commanded_current_a=i_cmd,
         model_sha256=hashlib.sha256(MODEL_PATH.read_bytes()).hexdigest()[:16],
         mujoco_version=mujoco.__version__,
         timestep_s=float(loaded_model.opt.timestep),

--- a/tests/test_bench_spinup.py
+++ b/tests/test_bench_spinup.py
@@ -3,10 +3,27 @@
 Wave-0 job: prove the identification METHOD (two-run kt/J fit, spin-down
 friction split, hardware-residual replay) on a rig small enough to sit on a
 desk, against a model whose joint-space inertias are known from geometry (see
-bench_rig.xml's header). Everything here runs on the noise-free `IDEAL`
-profile so the method itself, not the signal path, is what is being checked;
-`STAGE0_PLACEHOLDER` is exercised in `sim.scenarios.imperfections`'s own
-suite.
+bench_rig.xml's header).
+
+MOST OF THIS RUNS ON `IDEAL`, AND THAT USED TO BE THE WHOLE STORY. It is not
+enough, and the gap cost a factor of two.
+
+This file previously said that `STAGE0_PLACEHOLDER` "is exercised in
+`sim.scenarios.imperfections`'s own suite" and left it there. True, and
+irrelevant: that suite checks the imperfections, not what the identification
+does *under* them. So a `kt` fit that was 50% low on the default profile sat
+green, because the only kt assertion was on the ideal run and its name said so.
+
+The fix is a method-versus-signal-path split that actually holds:
+
+  * `IDEAL` tests pin the ALGEBRA. If they fail, the two-run derivation or the
+    geometry is wrong.
+  * `STAGE0_PLACEHOLDER` tests pin the WINDOWING. If they fail, the fit is
+    reading the current-loop transient instead of the ramp -- which is exactly
+    the failure that shipped.
+
+Any new fitted quantity needs both. A number that is only ever asserted on a
+noise-free profile is a number nobody has checked.
 """
 
 import csv
@@ -16,6 +33,7 @@ import numpy as np
 import pytest
 
 from sim.scenarios.bench_spinup import (
+    MODEL_PATH,
     NAMEPLATE_KT_NM_PER_A,
     IdentifyParams,
     SpindownParams,
@@ -24,10 +42,16 @@ from sim.scenarios.bench_spinup import (
     load_model,
     replay,
     spindown,
+    _FLYWHEEL_GEOM_RE,
     _joint_inertia,
     identify,
 )
-from sim.scenarios.imperfections import IDEAL
+from sim.scenarios.imperfections import IDEAL, STAGE0_PLACEHOLDER
+
+
+def load_model_xml() -> str:
+    """The raw MJCF text, for tests that build variants by stripping geoms."""
+    return MODEL_PATH.read_text()
 
 #: The committed model's joint-space inertias, from bench_rig.xml's header --
 #: geometry-derived, not tuned. A change to the flywheel or rotor geometry
@@ -83,6 +107,143 @@ def test_identify_recovers_nameplate_kt_and_bare_inertia_on_ideal_run(loaded_mod
     # are meaningless -- a bad window would still average to *something*.
     assert m.r2_bare > 0.999
     assert m.r2_loaded > 0.999
+
+
+def test_identify_recovers_kt_under_the_stage0_profile(loaded_model):
+    """**The assertion whose absence let a factor-of-two error ship green.**
+
+    kt used to come out at 0.02493 against a 0.05026 nameplate -- 50.4% low --
+    on the DEFAULT profile, while every test here passed because every kt
+    assertion was on the ideal run.
+
+    The tolerance is 1%, the same as the ideal run, because after the fix there
+    is no reason for the realistic profile to be worse: the only bias left is
+    Coulomb (`tau_c/i`, ~0.5%), which both profiles share. A regression to the
+    old windowing fails this by a factor of fifty, not by a hair.
+    """
+    m = identify(IdentifyParams(), loaded_model=loaded_model,
+                 profile=STAGE0_PLACEHOLDER).metrics
+    assert m.kt_fit_nm_per_a == pytest.approx(NAMEPLATE_KT_NM_PER_A, rel=0.01), (
+        f"kt {m.kt_fit_nm_per_a:.5f} vs nameplate {NAMEPLATE_KT_NM_PER_A:.5f} "
+        f"({m.kt_error_vs_nameplate_pct:.1f}% off) -- if this is ~50% low the fit "
+        "window is back inside the actuation delay and current-loop lag"
+    )
+    # J_bare was ALWAYS right, even with the bug, because the suppression factor
+    # cancels between numerator and denominator. Asserting it here documents that
+    # it is not what regressed and not what proves the fix.
+    assert m.j_bare_fit_kg_m2 == pytest.approx(KNOWN_GOOD_J_BARE, rel=0.02)
+
+
+def test_the_r2_diagnostic_is_asserted_and_not_merely_reported(loaded_model):
+    """R^2 fell 1.0000 -> 0.6927 while the bug was live, and nothing checked it.
+
+    `_fit_line`'s docstring claims a bad window is "visible in the R^2 rather
+    than silently baked into a slope". It was visible. It was just not looked at.
+
+    Floored below the ideal run's 0.999 on purpose: the 500 Hz sensed-rate
+    staircase is real and caps R^2 near 0.98. The point is that 0.69 -- a
+    curve, not a line -- can no longer pass.
+    """
+    m = identify(IdentifyParams(), loaded_model=loaded_model,
+                 profile=STAGE0_PLACEHOLDER).metrics
+    assert m.r2_bare > 0.95, f"bare ramp is not a line: R^2={m.r2_bare:.4f}"
+    assert m.r2_loaded > 0.95, f"loaded ramp is not a line: R^2={m.r2_loaded:.4f}"
+
+
+def test_the_fit_window_opens_after_the_current_has_settled(loaded_model):
+    """The mechanism, pinned so it cannot be "simplified" back to fitting from zero.
+
+    Under Stage-0 there is 1 ms of actuation delay and a 1 ms current-loop time
+    constant, so a settled window cannot start at t=0 -- and on IDEAL there is
+    nothing to wait for, so it must start immediately. Both directions are
+    asserted; checking only one would pass on a hard-coded offset.
+    """
+    stage0 = identify(IdentifyParams(), loaded_model=loaded_model,
+                      profile=STAGE0_PLACEHOLDER).metrics
+    ideal = identify(IdentifyParams(), loaded_model=loaded_model, profile=IDEAL).metrics
+
+    assert stage0.fit_start_s > 0.005, (
+        f"window opened at {stage0.fit_start_s*1e3:.1f} ms -- too early to have "
+        "cleared a 1 ms delay plus ~5 time constants of a 1 ms current loop"
+    )
+    assert ideal.fit_start_s < 0.002, (
+        f"window opened at {ideal.fit_start_s*1e3:.1f} ms on a profile with no "
+        "delay and no lag -- the settle detector is not data-driven"
+    )
+    # The span is what was asked for, in both cases.
+    for m in (stage0, ideal):
+        assert m.fit_end_s - m.fit_start_s == pytest.approx(IdentifyParams().fit_span_s)
+
+    # And the current the fit believes is the one that flowed, not the command.
+    assert stage0.i_measured_mean_a == pytest.approx(stage0.commanded_current_a, rel=0.02), (
+        "after settling, measured and commanded current should agree closely; a "
+        "large gap means the window still straddles the transient"
+    )
+
+
+def test_fitting_from_zero_reproduces_the_original_50_percent_error(loaded_model):
+    """The counterfactual, so the reason for the window is measured and not just
+    asserted in a docstring.
+
+    Deliberately reconstructs the OLD behaviour -- fit from t=0 over 5 ms
+    against the COMMANDED current -- and shows it really does halve kt. If this
+    ever stops being true, the delay/lag model changed and the windowing
+    rationale needs revisiting rather than being trusted.
+    """
+    from sim.scenarios.bench_spinup import _fit_line, _run_constant_current
+
+    p = IdentifyParams()
+    bare = build_bare_model()
+    t_b, w_b, _ = _run_constant_current(bare, p.commanded_current_a, p.sim_seconds,
+                                        STAGE0_PLACEHOLDER)
+    t_l, w_l, _ = _run_constant_current(loaded_model, p.commanded_current_a,
+                                        p.sim_seconds, STAGE0_PLACEHOLDER)
+    a1, r2_bare = _fit_line(t_b, w_b, 0.005)          # from zero, as it used to be
+    a2, _ = _fit_line(t_l, w_l, 0.005)
+    kt_old = known_disc_inertia_kg_m2() / (p.commanded_current_a * (1.0 / a2 - 1.0 / a1))
+
+    assert kt_old < 0.6 * NAMEPLATE_KT_NM_PER_A, (
+        f"the old from-zero window gave kt={kt_old:.5f}, not the ~50%-low result "
+        "it is documented to give -- the delay/lag model has changed"
+    )
+    assert r2_bare < 0.8, (
+        f"R^2={r2_bare:.4f} for the from-zero fit; the transient is supposed to be "
+        "visibly curved, which is what makes R^2 a usable diagnostic"
+    )
+
+
+# --------------------------------------------------------------------------
+# The bare variant: what the strip removes
+# --------------------------------------------------------------------------
+
+def test_the_bare_model_carries_no_floating_index_mark(loaded_model):
+    """The index mark is drawn on the flywheel face, so it goes with the disc.
+
+    Left behind, it renders as a white bar rotating in mid-air 52 mm off the
+    shaft, where the disc used to be. Raised by Digital Content Production after
+    it reached a render.
+    """
+    bare = build_bare_model()
+    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "index") < 0
+    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel") < 0
+    # Still present on the loaded rig -- the strip must be the only thing that
+    # removes it, or the mark has simply been deleted from the model.
+    assert mujoco.mj_name2id(loaded_model, mujoco.mjtObj.mjOBJ_GEOM, "index") >= 0
+
+
+def test_removing_the_index_mark_changes_no_fitted_quantity(loaded_model):
+    """It is massless with collision off, so this is model coherence, not
+    correctness -- and that claim is worth checking rather than repeating.
+
+    Compares joint inertia of a bare model against one built by stripping only
+    the flywheel. Identical means the mark never contributed, so no previously
+    published J_bare or kt moves because of this change.
+    """
+    xml = load_model_xml()
+    flywheel_only = mujoco.MjModel.from_xml_string(_FLYWHEEL_GEOM_RE.sub("", xml))
+    assert _joint_inertia(build_bare_model()) == pytest.approx(
+        _joint_inertia(flywheel_only), rel=1e-12
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes both open rows from **Digital Content Production**: the [kt fit window](https://app.notion.com/p/3aa472a5fb6981ee879fee40f4d044c5) and the [index mark](https://app.notion.com/p/3a9472a5fb6981f29786ff584261136f). Both files are mine under ADR-0002, so these are decisions I own rather than escalations — logged in the rows.

**Reproduced before acting.** kt = 0.02493 against a 0.05026 nameplate — **50.4% low** on `STAGE0_PLACEHOLDER`, R² 0.6927. Their diagnosis is right in every particular, including the algebra.

## Why kt broke and J_bare did not

1 ms actuation delay + 1 ms current-loop τ against a 5 ms window: the first fifth had little torque at the shaft, and the 500 Hz update laid a staircase on top. Both ramps suppressed by the same factor k ≈ 0.5, and then:

| Quantity | Form | Effect of k |
|---|---|---|
| `J_bare` | `kt·i/α₁` | numerator and denominator both scale → **cancels**, accurate to 0.1% throughout |
| `kt` | `J_disc/(i·(1/α₂ − 1/α₁))` | scales **linearly** → factor of two |

The slope *ratio* survived (7.70 vs 7.68 ideal), so the two-run structure kept working and only the one number with an external reference was wrong. **That is why it hid: everything self-consistent stayed self-consistent.**

## The fix — two parts, both "do not assume the command was obeyed"

**1. Fit where the ramp is actually a ramp.** The window opens once the measured current has settled to within `settle_fraction` (0.99, ≈5τ) of the command — detected **from the current trace**, not computed from the profile.

That distinction is the whole point. Computing `actuation_delay_s + 5·current_loop_tau_s` gives the same answer in sim and is useless on hardware, where there is no profile object, only a current sensor. Since characterising this signal path *is* the rig's job, a rule that needs the answer as an input is circular.

**2. Fit against the measured current.** `kt·i = J·α` is a statement about the current that *flowed*. Using the command assumes a perfect current loop — the assumption the bench exists to test. This also makes the fit robust to any current-path imperfection, not only the two currently modelled.

| profile | kt | err | J_bare | R² | window | mean measured i |
|---|---|---|---|---|---|---|
| IDEAL | 0.05001 | **0.50%** | 2.414e−04 | 1.0000 | [0.5, 14.5] ms | 20.000 A |
| STAGE0 | 0.05019 | **0.13%** | 2.417e−04 | 0.9814 | [7.0, 21.0] ms | 19.983 A |

**50.4% → 0.13%**, and both profiles now sit on the same ~0.1–0.5% floor — which *is* the Coulomb `τ_c/i` bias the module already documented. The only bias left is the one the algebra predicts.

## The other options, and why not

- **Widen the window alone** — measured: viscous drag then bends the ramp. J_bare error climbs with span (0.23% → 0.64% from 10 to 30 ms) and kt degrades again past ~20 ms (0.13% at 14 ms, 0.31% at 20, 0.95% at 30). Span is now 14 ms, chosen against that sweep rather than taste.
- **Fit the delay as a third parameter** — solves a harder problem than needed, and adds a parameter hardware cannot independently check.
- **Assert the bias instead of removing it** — documents a number nobody should quote. Taken *as well*, not instead: the bias is now pinned by tests.

## The real defect was the missing assertion

The suite tested kt only on the ideal run, said so in the test name, and stayed green through a factor of two. The file's docstring claimed Stage-0 was covered "in `imperfections`' own suite" — true, and irrelevant: that suite checks the imperfections, not what the identification does *under* them. Now split so it holds — **IDEAL pins the algebra, STAGE0 pins the windowing.**

- `test_identify_recovers_kt_under_the_stage0_profile` — the missing assertion, 1% tolerance
- `test_the_r2_diagnostic_is_asserted_and_not_merely_reported` — R² fell to 0.6927 while the bug was live, and `_fit_line`'s docstring already claimed this was the diagnostic. It was visible. Nobody looked at it.
- `test_the_fit_window_opens_after_the_current_has_settled` — asserts *both* directions (late on Stage-0, immediate on IDEAL) so a hard-coded offset cannot pass
- `test_fitting_from_zero_reproduces_the_original_50_percent_error` — the counterfactual, so the rationale is measured rather than trusted to a docstring

## Second row: the index mark

`strip_flywheel_geom` now takes the mark with the disc. `index` sits at `pos="0 0.046 0.052"` — on the flywheel face — so stripping only the disc left a white bar rotating in mid-air 52 mm off the shaft.

DCP's claim that this is coherence-only is correct, and now checked rather than repeated: `test_removing_the_index_mark_changes_no_fitted_quantity` compares joint inertia against a flywheel-only strip. **No previously published J_bare or kt moves because of this.**

## Interface change — Digital Content Production

`fit_window_s` → `fit_span_s` is a **deliberate rename**. The semantics changed from "window from t=0" to "span from settle", and a silently redefined `fit_window_s` would be far worse than a loud `AttributeError`.

`overboard-viz/viz/src/export_track.py:399` reads `ip.fit_window_s` and calls `bench._fit_line` to cross-check its re-run against these slopes. **That cross-check will now fail loudly — which is exactly what you built it to do.** Migration: fit over the reported window, which is now in the metrics because a data-derived window has to be recorded to be reproducible:

```python
slope, r2 = bench._fit_line(
    t, w_sensed, ident.metrics.fit_end_s, start_s=ident.metrics.fit_start_s
)
```

`_fit_line` keeps its two-argument form working, so nothing crashes on the signature — the failure you get is the numeric one, comparing a post-settle slope against a from-zero one.

**And the practical consequence for you: kt is now safe to quote.** It is within 0.13% on the default profile. The V1.4 review page chart no longer needs the number pulled.

## Verification

- `94 passed, 1 xfailed` (baseline `88 passed, 1 xfailed`; +6 new tests)
- `python3 .github/policy_check.py` — all hard checks pass
- No Rust touched

Filed by Sr. Mechanical & Systems, who owns the bench rig and the identification method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPqmiktJQkmGc14UaUAPFS