### PR TITLE
feat(ops): role registry, three-lane routing, and turf enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,32 +1,37 @@
 # CODEOWNERS — path ownership map for the Overboard org
 #
-# STATUS: PROPOSED. See docs/decisions/ADR-0002-path-ownership-map.md and the
-# Escalations row it names. This file is the current working assumption; a role
-# that disagrees with a boundary files a row rather than editing around it.
+# Roles are defined in docs/decisions/ROLES.md, which is the single home for the
+# role list. The `# role:` tag above each rule is the authoritative assignment;
+# `policy_check.py` validates every tag against that registry.
 #
-# GitHub CODEOWNERS can only name real accounts, and this org has exactly one
-# human. So @MikePaNtZ is the reviewer on every rule, and the ROLE is carried in
-# the `# role:` tag above each block. Those tags are the authoritative map that
-# the `policy` CI job parses and that the "do not edit paths another role owns"
-# rule refers to. Do not remove them.
+# GitHub CODEOWNERS can only name real accounts and this org has one human, so
+# @MikePaNtZ is the reviewer on every rule. That means CODEOWNERS provides no
+# review routing here -- all enforcement lives in the policy check. Do not
+# remove the tags.
 #
-# Known roles (the policy check rejects any other value):
-#   CEO, COO, CMO, Sr. Mechanical & Systems, Senior Controls,
-#   Digital Content Production
+# OWNERSHIP GOVERNS WRITE, NOT READ. Importing, reading or depending on another
+# role's module needs no permission and no row. Only editing does. A session
+# that files a row before importing a module has over-escalated, which is the
+# same failure as trespassing, just pointed the other way.
+#
+# "Am I trespassing?"  ->  python3 .github/policy_check.py --who <path>
 #
 # Last matching pattern wins, so specific rules go BELOW general ones.
+# See docs/decisions/ADR-0002-path-ownership-map.md.
 
 # --------------------------------------------------------------------------
-# Default. Anything not explicitly claimed belongs to the CEO, which is the
-# right default because unclaimed territory is a scoping question, not a
-# technical one.
+# Default. Unclaimed territory is a scoping question, not a technical one.
+#
+# Root-level SOURCE files are not a valid resting place -- they get a directory
+# and an owner before they are committed. This default exists for metadata, not
+# as a dumping ground. (A verbatim GPLv3 comm_can.c once sat untracked at this
+# root, one `git add .` from a public MIT repo.)
 # --------------------------------------------------------------------------
 # role: CEO
 *                               @MikePaNtZ
 
 # --------------------------------------------------------------------------
-# Project rules, public front door, and the licence. Public claims and the
-# licence are one-way doors; both stay with the CEO.
+# Project rules, public front door, and the licence -- one-way doors all.
 # --------------------------------------------------------------------------
 # role: CEO
 /README.md                      @MikePaNtZ
@@ -34,9 +39,12 @@
 /CLAUDE.md                      @MikePaNtZ
 # role: CEO
 /LICENSE                        @MikePaNtZ
+# role: CEO
+/.claude/                       @MikePaNtZ
 
 # --------------------------------------------------------------------------
-# Cross-role operations: the decision record, the escalation machinery, and CI.
+# Cross-role operations: the decision record, the role registry, the
+# escalation machinery, and the governance checks. NOT the build -- see below.
 # --------------------------------------------------------------------------
 # role: COO
 /.github/                       @MikePaNtZ
@@ -46,7 +54,11 @@
 /docs/decisions/                @MikePaNtZ
 
 # --------------------------------------------------------------------------
-# The control law and the Rust workspace it lives in.
+# The control law and its harness.
+#
+# .github/workflows/ci.yml is Controls, not COO: it runs the Rust and sim test
+# matrix and Controls edits it constantly. COO owning .github/ means owning
+# governance -- CODEOWNERS, policy_check.py -- not the build.
 # --------------------------------------------------------------------------
 # role: Senior Controls
 /crates/                        @MikePaNtZ
@@ -57,6 +69,8 @@
 # role: Senior Controls
 /rust-toolchain.toml            @MikePaNtZ
 # role: Senior Controls
+/requirements-sim.txt           @MikePaNtZ
+# role: Senior Controls
 /notebooks/                     @MikePaNtZ
 # role: Senior Controls
 /tests/                         @MikePaNtZ
@@ -65,27 +79,52 @@
 # role: Senior Controls
 /scripts/                       @MikePaNtZ
 # role: Senior Controls
-/requirements-sim.txt           @MikePaNtZ
-# role: Senior Controls
 /docs/sim-impulse-response.md   @MikePaNtZ
+# role: Senior Controls
+/.github/workflows/ci.yml       @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# sim/out/ is harness output and belongs to Controls. Media PROMOTED for
+# publication moves to a Content-owned path and is Content's from that point --
+# it does not become Content's by being written into this directory.
+# --------------------------------------------------------------------------
+# role: Senior Controls
+/sim/out/                       @MikePaNtZ
 
 # --------------------------------------------------------------------------
 # Plant models, the bench rig, and the sim-to-hardware fidelity contract.
-# Per the Sr. Mechanical & Systems handoff: this role owns where model numbers
-# come from and which are measured versus asserted. The control law is NOT
-# owned here, which is why the split runs through sim/ rather than around it.
+#
+# The boundary runs THROUGH sim/ rather than around it: Mechanical owns where
+# plant numbers come from, Controls owns the law tuned against them. Giving
+# either role the whole directory hands it the other's work.
+#
+# plant.py and imperfections.py are named explicitly because the earlier
+# bench_* prefix seam misassigned them -- they are the fidelity contract, which
+# is verbatim Mechanical's per its handoff. A prefix convention is discoverable
+# only from this file; a directory is discoverable from `ls`. If these keep
+# accumulating, split into sim/scenarios/plant/ and sim/scenarios/control/.
+#
+# WITHIN sim/models/: mass, inertia, geometry, contact and friction are
+# Mechanical's and need a row. <sensor> and <actuator> elements are Controls'
+# and do not -- adding observability is a routine controls act and routing it
+# through an escalation weekly would just get the protocol ignored.
 # --------------------------------------------------------------------------
 # role: Sr. Mechanical & Systems
 /sim/models/                    @MikePaNtZ
 # role: Sr. Mechanical & Systems
+/sim/scenarios/plant.py         @MikePaNtZ
+# role: Sr. Mechanical & Systems
+/sim/scenarios/imperfections.py @MikePaNtZ
+# role: Sr. Mechanical & Systems
 /sim/scenarios/bench_*.py       @MikePaNtZ
 # role: Sr. Mechanical & Systems
 /tests/test_bench_*.py          @MikePaNtZ
+# role: Sr. Mechanical & Systems
+/tests/test_imperfections.py    @MikePaNtZ
 
 # --------------------------------------------------------------------------
-# Renders and published media. Per the Digital Content Production handoff this
-# role does NOT own the landing page's markup or CSS — that lives in the
-# overboard-web repo under a separate session.
+# Renders and published media. This role does NOT own the landing page's
+# markup or CSS -- that is the Senior Digital Marketer's, in overboard-web.
 # --------------------------------------------------------------------------
 # role: Digital Content Production
 /scripts/render_scenario.py     @MikePaNtZ
@@ -93,10 +132,15 @@
 /docs/web-artifact-pipeline.md  @MikePaNtZ
 
 # --------------------------------------------------------------------------
-# UNRESOLVED — flagged, not assigned.
+# ROLES THAT OWN NOTHING IN THIS REPO -- stated on purpose, so their absence
+# reads as a decision rather than an oversight.
 #
-# /overboard-logo.html is a brand asset sitting in a controls-only repo, which
-# the project rules say should not happen (brand lives in overboard-web). It
-# falls to the CEO default above until the CMO and CEO settle where it goes.
-# Raised in ADR-0002; not moved here, because moving it is CMO turf.
+#   CMO                     -- brand and the marketing line live in
+#                              overboard-web; nothing here.
+#   Senior Digital Marketer -- landing page, brand identity, page copy and
+#                              analytics, all in overboard-web. Provisional.
+#   Archivist               -- surface not yet declared. Provisional.
+#
+# Neither sibling repo has a CODEOWNERS yet, so turf is still unfalsifiable in
+# two thirds of the estate. Open item in ADR-0002.
 # --------------------------------------------------------------------------

--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 """Policy gate for the Overboard repo.
 
-Four hard checks that fail the build, plus one advisory report that does not.
-See docs/decisions/ADR-0003-policy-ci-gate.md for why each one exists and why
-the advisory one is deliberately not hard yet.
+Hard checks fail the build; advisory findings are reported and do not.
+See docs/decisions/ADR-0003 (the gate) and ADR-0005 (the role registry).
 
-Run it locally before opening a PR:
-
-    python3 .github/policy_check.py
+    python3 .github/policy_check.py              # run every check
+    python3 .github/policy_check.py --who PATH   # who owns PATH?
 
 Stdlib only, on purpose: the policy gate must not be able to fail because a
-dependency moved.
+dependency moved. It also never queries Notion -- a network- or token-dependent
+required check produces red builds the PR author cannot fix, which would poison
+the one interrupt this org has that reliably works.
 """
 
 from __future__ import annotations
 
+import fnmatch
+import os
 import re
 import subprocess
 import sys
@@ -23,26 +25,14 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 DECISIONS = REPO / "docs" / "decisions"
 CODEOWNERS = REPO / ".github" / "CODEOWNERS"
-
-KNOWN_ROLES = {
-    "CEO",
-    "COO",
-    "CMO",
-    "Sr. Mechanical & Systems",
-    "Senior Controls",
-    "Digital Content Production",
-}
+ROLES_MD = DECISIONS / "ROLES.md"
 
 VALID_ADR_STATUS = re.compile(
     r"^\s*-\s*\*\*Status:\*\*\s*(Proposed|Accepted|Rejected|Superseded by ADR-\d{4})\s*$",
     re.MULTILINE,
 )
-
-# A requirement ID: UR-13, SR-WEB-4, DR-SIM-1.
 REQ_ID = re.compile(r"\b(?:UR|SR|DR)-[A-Z0-9]*-?\d+\b")
 
-# Absolutes the program committed to never saying in public. Deliberately tight:
-# a broad list produces false positives, and a gate that cries wolf gets removed.
 BANNED = [
     (re.compile(r"production[- ]ready", re.I), "the project is explicitly not production-ready"),
     (re.compile(r"\bcertified\b", re.I), "nothing here is certified by anyone"),
@@ -54,12 +44,13 @@ BANNED = [
     (re.compile(r"medical[- ]grade|\bFDA\b"), "not a regulated device; do not borrow the language"),
 ]
 
-# Capability language that SHOULD trace to a requirement. Advisory for now.
 CAPABILITY = re.compile(
     r"self[- ]balanc\w*|balances?\s+itself|rides?\s+itself|riderless|driverless"
     r"|autonomous|\bproven\b",
     re.I,
 )
+
+TURF_OVERRIDE = re.compile(r"TURF-OVERRIDE:\s*(\S.*)")
 
 failures: list[str] = []
 advisories: list[str] = []
@@ -69,13 +60,206 @@ def fail(check: str, msg: str) -> None:
     failures.append(f"{check}: {msg}")
 
 
-def public_markdown() -> list[Path]:
-    """Markdown that forms the repo's public face.
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=REPO, capture_output=True, text=True
+    ).stdout.strip()
 
-    docs/decisions/ is excluded on purpose. ADRs are internal engineering
-    records and must be able to QUOTE the banned words in order to ban them --
-    ADR-0003 lists every one of them. Scanning them would make the gate
-    self-defeating on its own charter.
+
+# ---------------------------------------------------------------------------
+# The role registry -- docs/decisions/ROLES.md is the single home.
+# ---------------------------------------------------------------------------
+def load_roles() -> dict[str, dict[str, str]]:
+    """Parse the registry table. Returns {role: {status, prefix}}."""
+    if not ROLES_MD.is_file():
+        fail("roles", "docs/decisions/ROLES.md is missing -- the role registry has no home")
+        return {}
+
+    roles: dict[str, dict[str, str]] = {}
+    for line in ROLES_MD.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 4:
+            continue
+        m = re.fullmatch(r"`([^`]+)`", cells[0])
+        if not m:
+            continue  # header or a non-role table
+        status = cells[1]
+        if status not in {"Provisional", "Ratified"}:
+            continue  # a different table that happens to have a backticked col 0
+        prefix = ""
+        pm = re.fullmatch(r"`([^`]+)`", cells[3])
+        if pm:
+            prefix = pm.group(1)
+        roles[m.group(1)] = {"status": status, "prefix": prefix}
+
+    if not roles:
+        fail("roles", "ROLES.md parsed to zero roles -- the registry table shape changed")
+    return roles
+
+
+# ---------------------------------------------------------------------------
+# CODEOWNERS
+# ---------------------------------------------------------------------------
+def load_codeowners() -> list[tuple[str, str, int]]:
+    """Returns [(pattern, role, lineno)] in file order. Last match wins."""
+    if not CODEOWNERS.is_file():
+        fail("ownership", ".github/CODEOWNERS is missing")
+        return []
+
+    rules: list[tuple[str, str, int]] = []
+    pending: str | None = None
+    for lineno, raw in enumerate(CODEOWNERS.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            m = re.match(r"#\s*role:\s*(.+?)\s*$", line)
+            if m:
+                pending = m.group(1)
+            continue
+        if pending is None:
+            fail("ownership", f"CODEOWNERS:{lineno} rule {line.split()[0]!r} has no '# role:' tag above it")
+            continue
+        rules.append((line.split()[0], pending, lineno))
+        pending = None
+    return rules
+
+
+def matches(pattern: str, path: str) -> bool:
+    if pattern == "*":
+        return True
+    p = pattern.lstrip("/")
+    if p.endswith("/"):
+        return path.startswith(p)
+    if "*" in p:
+        return fnmatch.fnmatch(path, p)
+    return path == p or path.startswith(p + "/")
+
+
+def owner_of(path: str, rules: list[tuple[str, str, int]]) -> tuple[str, str, int] | None:
+    hit = None
+    for pattern, role, lineno in rules:
+        if matches(pattern, path):
+            hit = (role, pattern, lineno)
+    return hit
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+def check_adr_index() -> None:
+    index = DECISIONS / "INDEX.md"
+    if not index.is_file():
+        fail("adr-index", "docs/decisions/INDEX.md is missing")
+        return
+    index_text = index.read_text(encoding="utf-8")
+    on_disk = {p.name for p in DECISIONS.glob("ADR-*.md") if p.name != "ADR-TEMPLATE.md"}
+
+    for name in sorted(on_disk):
+        if name not in index_text:
+            fail("adr-index", f"{name} exists but is not listed in INDEX.md")
+    for ref in sorted(set(re.findall(r"ADR-\d{4}-[a-z0-9-]+\.md", index_text))):
+        if not (DECISIONS / ref).is_file():
+            fail("adr-index", f"INDEX.md references {ref}, which does not exist")
+    for name in sorted(on_disk):
+        body = (DECISIONS / name).read_text(encoding="utf-8")
+        if not VALID_ADR_STATUS.search(body):
+            fail("adr-index", f"{name} has no recognised '- **Status:**' line")
+        if not re.search(r"^\s*-\s*\*\*Closes:\*\*", body, re.MULTILINE):
+            fail("adr-index", f"{name} has no '- **Closes:**' line naming the row it closes")
+
+    numbers = [re.match(r"ADR-(\d{4})", n).group(1) for n in on_disk]
+    if len(numbers) != len(set(numbers)):
+        fail("adr-index", "duplicate ADR numbers on disk; numbers are never reused")
+
+
+def check_ownership(roles: dict, rules: list) -> None:
+    for _pattern, role, lineno in rules:
+        if role not in roles:
+            fail(
+                "ownership",
+                f"CODEOWNERS:{lineno} role {role!r} is not in docs/decisions/ROLES.md. "
+                f"Add a Provisional registry entry first -- see ADR-0005",
+            )
+
+    explicit = {p.strip("/") for p, _r, _l in rules if p != "*"}
+    tracked = git("ls-files").split()
+    for d in sorted({p.split("/")[0] for p in tracked if "/" in p}):
+        if d not in explicit:
+            fail(
+                "ownership",
+                f"top-level directory {d!r} has no explicit CODEOWNERS rule "
+                f"(the '*' catch-all does not count -- assign it deliberately)",
+            )
+
+    if CODEOWNERS.is_file():
+        text = CODEOWNERS.read_text(encoding="utf-8")
+        for role, meta in roles.items():
+            if meta["status"] == "Ratified" and role not in text:
+                fail(
+                    "ownership",
+                    f"ratified role {role!r} appears nowhere in CODEOWNERS -- give it a rule, "
+                    f"or declare that it owns nothing in this repo",
+                )
+
+
+def check_turf(roles: dict, rules: list) -> None:
+    """Turf, checked at the moment of offence.
+
+    Only enforced when the branch prefix resolves to a registered role. Roles
+    that have not declared a prefix are skipped entirely -- failing open keeps
+    the blast radius to roles that opted in, and the check tightens by itself as
+    the registry fills in.
+    """
+    branch = os.environ.get("POLICY_BRANCH") or git("rev-parse", "--abbrev-ref", "HEAD")
+    base = os.environ.get("POLICY_BASE_REF", "origin/master")
+
+    prefixes = {m["prefix"]: r for r, m in roles.items() if m["prefix"]}
+    role = next((r for p, r in prefixes.items() if branch.startswith(p)), None)
+    if role is None:
+        print(f"turf: branch {branch!r} matches no registered branch prefix -- skipping")
+        return
+
+    merge_base = git("merge-base", base, "HEAD")
+    if not merge_base:
+        print(f"turf: cannot resolve {base} -- skipping")
+        return
+    changed = [p for p in git("diff", "--name-only", f"{merge_base}...HEAD").split() if p]
+    if not changed:
+        return
+
+    override = os.environ.get("POLICY_PR_BODY", "") + "\n" + git("log", f"{merge_base}..HEAD", "--format=%B")
+    om = TURF_OVERRIDE.search(override)
+
+    trespass = []
+    for path in changed:
+        hit = owner_of(path, rules)
+        if hit and hit[0] != role:
+            trespass.append(f"{path} (owned by {hit[0]}, CODEOWNERS:{hit[2]})")
+
+    if not trespass:
+        return
+    if om:
+        print(f"turf: {len(trespass)} cross-boundary edit(s) as {role}, overridden -- {om.group(1).strip()}")
+        for t in trespass:
+            print(f"    ! {t}")
+        return
+    for t in trespass:
+        fail(
+            "turf",
+            f"branch is {role}'s ({branch}) but edits {t}. File a row, or put "
+            f"'TURF-OVERRIDE: <reason or row url>' in the PR body if this is authorised",
+        )
+
+
+def public_markdown() -> list[Path]:
+    """README plus docs/, excluding docs/decisions/.
+
+    ADRs are internal records and have to be able to QUOTE the banned words in
+    order to ban them -- ADR-0003 lists every one. Scanning them would make the
+    gate fail on its own charter.
     """
     out = [REPO / "README.md"]
     out += [p for p in sorted((REPO / "docs").rglob("*.md")) if DECISIONS not in p.parents]
@@ -83,7 +267,6 @@ def public_markdown() -> list[Path]:
 
 
 def sections(text: str) -> list[tuple[str, str, int]]:
-    """Split markdown into (heading, body, heading_line_number)."""
     lines = text.splitlines()
     out: list[tuple[str, str, int]] = []
     heading, buf, start = "(preamble)", [], 1
@@ -97,94 +280,14 @@ def sections(text: str) -> list[tuple[str, str, int]]:
     return out
 
 
-# ---------------------------------------------------------------------------
-# 1. ADR index integrity
-# ---------------------------------------------------------------------------
-def check_adr_index() -> None:
-    index = DECISIONS / "INDEX.md"
-    if not index.is_file():
-        fail("adr-index", "docs/decisions/INDEX.md is missing")
-        return
-
-    index_text = index.read_text(encoding="utf-8")
-    on_disk = {p.name for p in DECISIONS.glob("ADR-*.md") if p.name != "ADR-TEMPLATE.md"}
-
-    for name in sorted(on_disk):
-        if name not in index_text:
-            fail("adr-index", f"{name} exists but is not listed in INDEX.md")
-
-    for ref in sorted(set(re.findall(r"ADR-\d{4}-[a-z0-9-]+\.md", index_text))):
-        if not (DECISIONS / ref).is_file():
-            fail("adr-index", f"INDEX.md references {ref}, which does not exist")
-
-    for name in sorted(on_disk):
-        body = (DECISIONS / name).read_text(encoding="utf-8")
-        if not VALID_ADR_STATUS.search(body):
-            fail("adr-index", f"{name} has no recognised '- **Status:**' line")
-
-    numbers = sorted(re.match(r"ADR-(\d{4})", n).group(1) for n in on_disk)
-    if len(numbers) != len(set(numbers)):
-        fail("adr-index", "duplicate ADR numbers on disk; numbers are never reused")
-
-
-# ---------------------------------------------------------------------------
-# 2. Ownership coverage and role tags
-# ---------------------------------------------------------------------------
-def check_codeowners() -> None:
-    if not CODEOWNERS.is_file():
-        fail("ownership", ".github/CODEOWNERS is missing")
-        return
-
-    patterns: list[str] = []
-    pending_role: str | None = None
-
-    for lineno, raw in enumerate(CODEOWNERS.read_text(encoding="utf-8").splitlines(), 1):
-        line = raw.strip()
-        if not line:
-            continue
-        if line.startswith("#"):
-            m = re.match(r"#\s*role:\s*(.+?)\s*$", line)
-            if m:
-                if m.group(1) not in KNOWN_ROLES:
-                    fail("ownership", f"CODEOWNERS:{lineno} unknown role {m.group(1)!r}")
-                pending_role = m.group(1)
-            continue
-
-        # A rule line.
-        if pending_role is None:
-            fail("ownership", f"CODEOWNERS:{lineno} rule {line.split()[0]!r} has no '# role:' tag above it")
-        pending_role = None
-        patterns.append(line.split()[0])
-
-    explicit = {p.strip("/") for p in patterns if p != "*"}
-
-    tracked = subprocess.run(
-        ["git", "ls-files"], cwd=REPO, capture_output=True, text=True, check=True
-    ).stdout.split()
-    top_dirs = sorted({p.split("/")[0] for p in tracked if "/" in p})
-
-    for d in top_dirs:
-        if d not in explicit:
-            fail(
-                "ownership",
-                f"top-level directory {d!r} has no explicit CODEOWNERS rule "
-                f"(the '*' catch-all does not count -- assign it deliberately)",
-            )
-
-
-# ---------------------------------------------------------------------------
-# 3 + 4 + 5. Public claim checks
-# ---------------------------------------------------------------------------
 def check_claims() -> None:
     for path in public_markdown():
         rel = path.relative_to(REPO)
         text = path.read_text(encoding="utf-8")
-
         for lineno, line in enumerate(text.splitlines(), 1):
             for pattern, why in BANNED:
                 if pattern.search(line):
                     fail("banned-absolute", f"{rel}:{lineno} {pattern.pattern!r} -- {why}")
-
         for heading, body, lineno in sections(text):
             if "claim" in heading.lower():
                 if not REQ_ID.search(body) and not REQ_ID.search(heading):
@@ -201,9 +304,32 @@ def check_claims() -> None:
                 )
 
 
-def main() -> int:
+def who(path: str) -> int:
+    roles, rules = load_roles(), load_codeowners()
+    hit = owner_of(path.lstrip("./"), rules)
+    if hit is None:
+        print(f"{path}: no rule matches (this should be impossible -- '*' is a catch-all)")
+        return 1
+    role, pattern, lineno = hit
+    status = roles.get(role, {}).get("status", "UNREGISTERED")
+    print(f"{path}\n  owner : {role}  [{status}]\n  rule  : {pattern}  (CODEOWNERS:{lineno})")
+    print("\n  Ownership governs WRITE, not read or import. Reading needs no row.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--who" in argv:
+        i = argv.index("--who")
+        if i + 1 >= len(argv):
+            print("usage: policy_check.py --who <path>")
+            return 2
+        return who(argv[i + 1])
+
+    roles = load_roles()
+    rules = load_codeowners()
     check_adr_index()
-    check_codeowners()
+    check_ownership(roles, rules)
+    check_turf(roles, rules)
     check_claims()
 
     if advisories:
@@ -217,12 +343,12 @@ def main() -> int:
         print(f"POLICY FAILED -- {len(failures)} problem(s):\n")
         for f in failures:
             print(f"  x {f}")
-        print("\nSee docs/decisions/ADR-0003-policy-ci-gate.md")
+        print("\nSee docs/decisions/ADR-0003 and ADR-0005")
         return 1
 
-    print("policy: all hard checks pass")
+    print(f"policy: all hard checks pass ({len(roles)} roles, {len(rules)} ownership rules)")
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 Extends the global `~/.claude/CLAUDE.md`. Project: a DIY **lean-to-steer self-balancing board** (rideable inverted pendulum) — Rust real-time control on PREEMPT_RT Linux, off-the-shelf smart drive (torque mode) + hoverboard hub motors, sim-first. A deferred companion **PX4 drone** lives in its own Notion doc. Full context: memory `[[balance-board-project]]`.
 
+## Org protocol — you hold a role in a multi-session org. Read `docs/decisions/INDEX.md` before any PR.
+- **Three lanes.** A **decision** (choose between options) → the Notion Escalations queue. A
+  **handoff** (finished work crossing a boundary) → a **pull request**, review requested from the
+  receiving role. A **work request** (something that does not exist yet) → a **GitHub issue**.
+- **The test:** if you cannot name a default action you could execute alone, it is **not** an
+  escalation. Filing one anyway is how four days were lost on content that was already finished.
+- **Go and look before you ask.** Repo state, open PRs and merged branches are observable without a
+  conversation. **Prefer what you can observe over what you must wait for.**
+- **Stay in your own git worktree and branch prefix.** Two sessions in one working directory
+  corrupt each other — this has already happened. `python3 .github/policy_check.py --who <path>`
+  answers "am I trespassing?"; roles are in `docs/decisions/ROLES.md`.
+- Escalate on **Promise, Door, or Turf**; difficulty is not a trigger. Every row needs a default
+  action and a deadline, so nobody is ever parked.
+
 ## Repo boundary
 - **This repo is controls only** — Rust, sim, hardware, design docs. The public landing page and all
   brand/marketing assets live in the sibling repo **`overboard-web`** (`~/projects/overboard-web`).

--- a/docs/decisions/ADR-0002-path-ownership-map.md
+++ b/docs/decisions/ADR-0002-path-ownership-map.md
@@ -1,6 +1,7 @@
 # ADR-0002 — Map repository paths to roles
 
-- **Status:** Accepted — ⚠️ **unopposed, not agreed** (see §Ratification)
+- **Status:** Accepted
+- **Consent:** ⚠️ **unopposed, not agreed** — see §Ratification
 - **Date:** 2026-07-26 (Proposed) · 2026-07-26 (Accepted with corrections)
 - **Ratified by:** COO
 - **Closes:** [Escalations — "Confirm the path ownership map before ADR-0002 is ratified"](https://app.notion.com/p/3a9472a5fb698123862ee0c30bbc4b70)

--- a/docs/decisions/ADR-0002-path-ownership-map.md
+++ b/docs/decisions/ADR-0002-path-ownership-map.md
@@ -1,9 +1,9 @@
 # ADR-0002 — Map repository paths to roles
 
-- **Status:** Proposed
-- **Date:** 2026-07-26
-- **Ratified by:** *(not yet — awaiting CEO, see Escalations row)*
-- **Closes:** [Escalations — "Confirm the path ownership map"](https://app.notion.com/p/150eb337e89349948f980d2bb06bab80)
+- **Status:** Accepted — ⚠️ **unopposed, not agreed** (see §Ratification)
+- **Date:** 2026-07-26 (Proposed) · 2026-07-26 (Accepted with corrections)
+- **Ratified by:** COO
+- **Closes:** [Escalations — "Confirm the path ownership map before ADR-0002 is ratified"](https://app.notion.com/p/3a9472a5fb698123862ee0c30bbc4b70)
 - **Constrains:** every role's "do not edit paths another role owns" rule
 - **Enforced by:** `policy` CI job (coverage and role-tag validity only — it cannot check that a boundary is *correct*)
 
@@ -37,6 +37,53 @@ Boundaries are taken **from what the handoff documents already assert**, not inv
 The boundary deliberately runs **through** `sim/` rather than around it. Mechanical owns
 where plant numbers come from; Controls owns the law tuned against them. Drawing the line at
 the directory would have handed one role the other's work.
+
+## Corrections applied before acceptance
+
+Adversarial review found the `Proposed` version **wrong in the tree as it stood**, not merely
+incomplete. All of these are now in `CODEOWNERS`:
+
+1. **`sim/scenarios/plant.py` and `imperfections.py` → Sr. Mechanical & Systems.** The
+   original `bench_*` prefix seam left them with Controls, and they are the fidelity contract
+   — verbatim Mechanical's per its handoff. The map assigned Mechanical's two most
+   characteristic files to the wrong role. `sim/models/bench_rig.xml` landing correctly was
+   luck of naming, not the seam working.
+2. **Intra-`sim/models/` clause.** Mass, inertia, geometry, contact and friction are
+   Mechanical's and need a row. `<sensor>` and `<actuator>` elements are Controls' and do
+   not — adding observability is a routine controls act, and routing it through an escalation
+   weekly would just get the protocol ignored.
+3. **`.github/workflows/ci.yml` → Senior Controls.** COO owning `.github/` means owning
+   governance — `CODEOWNERS`, `policy_check.py` — not the build.
+4. **`sim/out/` → Senior Controls** as harness output. Media *promoted* for publication moves
+   to a Content-owned path and is Content's from that point; it does not become Content's by
+   being written into this directory.
+5. **`.claude/` → CEO**, explicitly. It contains role definitions; it must not arrive via the
+   `*` default by accident.
+6. **Ownership governs write, not read or import.** Without this a cautious session files a
+   row before importing a module — over-escalation freezing, which is the same failure as
+   trespassing pointed the other way.
+7. **CMO's null claim stated on purpose**, alongside Senior Digital Marketer and Archivist,
+   so their absence reads as a decision rather than an oversight.
+8. **Root-level source files are not a valid resting place** — they get a directory and an
+   owner before commit. A verbatim GPLv3 `comm_can.c` once sat untracked at this root, one
+   `git add .` from a public MIT repo.
+
+**Still outstanding — the seam itself.** Review's primary finding was that a filename-prefix
+seam is discoverable only from `CODEOWNERS`, whereas a directory is discoverable from `ls`.
+A fresh Mechanical session naming a file `param_id_sweep.py` lands in Controls' territory
+with no error, no conflict and no signal. The durable fix is
+`sim/scenarios/plant/` vs `sim/scenarios/control/`, mirrored in `tests/` — roughly six file
+moves **in two other roles' territory**, so it is filed to them rather than done here.
+
+## Ratification — unopposed, not agreed
+
+The escalation row to the CEO was open and unanswered when this was promoted. It was promoted
+early rather than at its deadline because leaving a **known-wrong** binding map in force is
+worse than the paperwork being untidy, and because ADR-0005's registry checks and the turf CI
+check both treat `CODEOWNERS` as authoritative.
+
+`INDEX.md` requires the record to distinguish *agreed* from *unopposed*. **This is unopposed.**
+Reversing it is a one-line status change plus a revert of the corrections above.
 
 ## Options considered
 

--- a/docs/decisions/ADR-0004-decisions-handoffs-and-work-requests.md
+++ b/docs/decisions/ADR-0004-decisions-handoffs-and-work-requests.md
@@ -1,0 +1,84 @@
+# ADR-0004 — Three lanes: decisions, handoffs, and work requests
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Ratified by:** COO
+- **Closes:** [Escalations — "Fix three org-system defects"](https://app.notion.com/p/3a9472a5fb698109a519d1c5283ae999) (defect 3)
+- **Constrains:** every role
+- **Enforced by:** `Kind` field on the Escalations database; the `CLAUDE.md` org block; convention
+
+## Context
+
+Four days were lost on content that was already finished. The Senior Digital Marketer
+believed it was blocked on Digital Content Production, filed a queue row asking for delivery
+with a six-day deadline, and waited. Both roles were active and filing rows **within eleven
+minutes of each other**. Neither read the other's. The CEO had to override manually.
+
+The queue was at ten rows, nearly all `Open`, near-zero answered.
+
+## The invariant that was violated
+
+> **If you cannot name a default action you could execute alone, it is not an escalation.**
+
+That is what the queue is for: *"I can proceed without you — here is what I do if you stay
+silent."* A request for someone else's deliverable has the opposite invariant: *"I cannot
+proceed; you own the thing."* Rows with no executable default cannot self-close, so they rot.
+Ten open rows is that invariant failing, not people being slow.
+
+## Decision
+
+Three lanes, chosen by what the traffic actually is.
+
+| Traffic | Lane | Why |
+|---|---|---|
+| **Decision** — choose between options | The **Escalations queue** | Has a default action; the filer can proceed either way |
+| **Handoff** — finished work crossing a boundary | A **pull request**, review requested from the receiving role | Observable without a reply, and it already carries the artefact |
+| **Work request** — something that does not exist yet | A **GitHub issue** in the owning repo, assigned via the role registry | Closed by a merged PR (`Closes #N`), so completion is *state*, not a message |
+
+And the rule that would have saved the four days:
+
+> **Before filing a row asking "is X ready?" or "please send me X" — go and look.** Repo
+> state, open PRs and merged branches are visible without a conversation. **Prefer what you
+> can observe over what you must wait for.**
+
+**Blocked on a human-only act** — money, publication, physical hardware — stays in the queue.
+It has a real default action: descope.
+
+## Honesty about what this does and does not fix
+
+The third lane **would not have prevented this particular stall.** The content was already
+done; no lane routes around "nobody looked." Only the go-and-look rule does.
+
+What the third lane prevents is a *different* recurrence: a genuine "I need X built", with no
+executable default, sitting `Open` for days because the queue was the only container with an
+owner and a deadline. That is queue pollution, and it is worth fixing on its own terms — but
+it is not the thing that cost four days, and this ADR should not be read as claiming it is.
+
+## Options considered
+
+- **Two lanes (decisions, handoffs).** The CEO's original framing. Rejected: it has no home
+  for a request for work that does not yet exist, which is precisely what the stalled row
+  was. Omitting it sends that traffic back into the queue and re-creates the pollution.
+- **A Notion task database for work requests.** Rejected: a second polling surface, with no
+  link to the artefact and no way to close itself.
+- **Three lanes as above.** Chosen. Cost of the losing options: the queue keeps filling with
+  rows nobody can close.
+
+## Consequences
+
+- Each role's real inbox becomes `gh pr list --search "review-requested:@me"` and
+  `gh issue list --assignee @me`. **Caveat, stated plainly:** with one GitHub account behind
+  every role, `@me` does not discriminate by role today. The lane discipline is real; the
+  per-role inbox is aspirational until identities diverge.
+- The queue should shrink. If it does not, the lanes are not being used.
+- `Kind` is now a field on the Escalations database, so misclassification is visible at the
+  point of filing rather than discovered four days later.
+
+## How this is enforced
+
+Weakly, and deliberately so. Whether a row is "really" a decision is not machine-decidable,
+and a false positive on that judgement would get the whole gate switched off — the same
+reasoning as the advisory check in ADR-0003. So: the `Kind` select forces the classification
+at write time, the database description carries the rule, and `CLAUDE.md` carries it into
+every session automatically. The default-action test above is the thing to apply; it is prose
+because it has to be.

--- a/docs/decisions/ADR-0005-role-registry.md
+++ b/docs/decisions/ADR-0005-role-registry.md
@@ -1,0 +1,71 @@
+# ADR-0005 — One home for the role list; existence is not ratification
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Ratified by:** COO
+- **Closes:** [Escalations — "Register the Senior Digital Marketer role"](https://app.notion.com/p/3a9472a5fb6981f49a8bed0501998c66)
+- **Constrains:** every role; the COO owes the registration
+- **Enforced by:** `policy` CI job (registry parsing, tag resolution, ratified-role coverage)
+
+## Context
+
+The Senior Digital Marketer was granted by the CEO with its own escalation chain, owned
+surface and branch prefix — and existed in **none** of the org's data structures. It filed as
+`From: CMO` with a `[Senior Digital Marketer]` title prefix, so every row it filed was
+misattributed and two rows appeared to come from the CMO and did not. The Archivist was
+missing too.
+
+The underlying defect, which that role identified and which matters more than its own
+registration: **the role list lived in two unlinked places with no owner** — the policy
+check's hardcoded `KNOWN_ROLES` set and the Notion select options. It broke on first contact
+with a new role and would have broken identically for every future one.
+
+Worse, the partial state produced a deadlock: a `# role:` tag for an unregistered role
+red-builds `policy` for everyone, so the role could not claim its own paths — and it filed
+**an escalation asking permission to escalate.**
+
+## Decision
+
+1. **`docs/decisions/ROLES.md` is the single home** and the identity of record.
+   `policy_check.py` parses it; `CODEOWNERS` tags are validated against it; the Notion select
+   is a **declared mirror**, direction registry → Notion, never back.
+2. **`Ratified` means all three** — registry entry, CODEOWNERS rule (or an explicit
+   owns-nothing declaration), and Notion select option.
+3. **Existence is not ratification.** A role exists the moment the CEO grants it. A grant
+   obliges the COO to add a `Provisional` entry within one working day — one file, one
+   commit. **`Provisional` roles may file rows, open PRs, and be named in `# role:` tags.**
+   They may not hold *exclusive* path ownership; that is the only right all-three-or-none
+   should gate, and the only one that genuinely needs three-way consistency.
+4. **"May I exist" is never a valid escalation row.** Role creation is a CEO act.
+5. **A missing Notion option is a COO defect, never a blocker on the filer.** File under the
+   nearest registered seat in your chain with `UNREGISTERED ROLE: <name>` as the first line
+   of the body, address it to the COO, and carry on.
+
+## Options considered
+
+- **Register the two roles and move on.** Rejected: fixes the instance, not the duplication.
+  The third role would have hit it again.
+- **All-three-or-none as a hard precondition.** Rejected — this is the deadlock that already
+  happened. It is right as a *definition* of ratified and wrong as a gate on working.
+- **Have CI read Notion and reconcile.** Rejected: needs a token, fails on network, and
+  produces red builds the PR author cannot fix. That would poison the one interrupt in this
+  org that reliably works. Named owner and a declared mirror instead.
+- **Registry + Provisional/Ratified split.** Chosen. Cost of the losing options: either the
+  duplication persists, or new roles are blocked on paperwork they cannot do themselves.
+
+## Consequences
+
+- Adding a role is one commit to `ROLES.md`; ratifying it is three edits, and the COO owes
+  them.
+- `policy` now fails on a `# role:` tag that does not resolve, and on a `Ratified` role that
+  appears nowhere in `CODEOWNERS`.
+- Attribution on the three misfiled rows has been repaired retroactively.
+- **Residual risk, not papered over:** Notion is still a copy CI cannot reach. Named owner
+  (COO), declared direction, no pretence of automation.
+
+## How this is enforced
+
+`policy_check.py` parses `ROLES.md` instead of hardcoding roles; checks every `# role:` tag
+resolves; checks every `Ratified` role appears in `CODEOWNERS`. It also gains
+`--who <path>`, so *"am I trespassing?"* is one command rather than a human applying
+last-match-wins down a file they have never seen.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -24,8 +24,13 @@ primitive the org has.
 | # | Title | Status | Constrains |
 |---|---|---|---|
 | [0001](ADR-0001-decision-record-and-escalation-queue.md) | Decision record and escalation queue | Accepted | Every role's process |
-| [0002](ADR-0002-path-ownership-map.md) | Path ownership map | **Proposed** | Who may edit which directory |
+| [0002](ADR-0002-path-ownership-map.md) | Path ownership map | Accepted ⚠️ *unopposed* | Who may edit which directory |
 | [0003](ADR-0003-policy-ci-gate.md) | `policy` CI gate | Accepted | Public claims in this repo |
+| [0004](ADR-0004-decisions-handoffs-and-work-requests.md) | Three lanes: decisions, handoffs, work requests | Accepted | How every role routes traffic |
+| [0005](ADR-0005-role-registry.md) | One home for the role list | Accepted | Who exists, and who owes registration |
+
+**Roles:** [`ROLES.md`](ROLES.md) is the single home for the role list — `policy` parses it.
+`python3 .github/policy_check.py --who <path>` answers "who owns this?".
 
 ## Conventions
 

--- a/docs/decisions/ROLES.md
+++ b/docs/decisions/ROLES.md
@@ -1,0 +1,69 @@
+# Role registry — the single home
+
+**This file is the identity of record for what roles exist.** `policy_check.py` parses the
+table below; `.github/CODEOWNERS` `# role:` tags are validated against it; the Notion
+Escalations `From`/`To` selects are a **declared mirror** of it.
+
+Before this file existed the role list lived in two unlinked places — the policy check's
+hardcoded set and the Notion select — with no owner. It broke on first contact with a new
+role: the Senior Digital Marketer was granted by the CEO with its own escalation chain,
+owned surface and branch prefix, and appeared in none of the org's data structures. It filed
+under the CMO seat with a title prefix, so **every row it filed was misattributed**, and two
+rows appeared to come from the CMO and did not. See ADR-0005.
+
+## Existence is not ratification
+
+**A role exists the moment the CEO grants it.** Ratification is the COO's paperwork, not the
+role's permission slip. Conflating the two produced a real escalation row *asking permission
+to escalate*.
+
+| Status | Means | May file rows? | May be a `# role:` tag? | Exclusive path ownership? |
+|---|---|---|---|---|
+| `Provisional` | CEO has granted it; COO paperwork incomplete | **Yes** | **Yes** | No — shared/additive only |
+| `Ratified` | Registry entry **+** CODEOWNERS rule **+** Notion select option | Yes | Yes | Yes |
+
+All-three-or-none is the definition of `Ratified`. It is **not** a precondition for working.
+
+- A CEO grant obliges the COO to add a `Provisional` row here within one working day. One
+  file, one commit — no Notion, no CODEOWNERS needed.
+- **"May I exist" is never a valid escalation row.** Role creation is a CEO act.
+- If your role is missing from the Notion select, that is a **COO defect, never a blocker on
+  you.** File under the nearest registered seat in your chain, put
+  `UNREGISTERED ROLE: <name>` as the first line of the row body, address it to the COO, and
+  carry on. The COO repairs attribution when registering.
+
+## The roles
+
+| Role | Status | Escalates to | Branch prefix | Owns |
+|---|---|---|---|---|
+| `CEO` | Ratified | — | — | Direction, public claims, licence, money. Final arbiter |
+| `COO` | Ratified | `CEO` | `feat/ops/` | Cross-role operations, the decision record, the escalation queue for the engineering line |
+| `CMO` | Ratified | `CEO` | — | The marketing line. Peer of COO — neither escalates to the other. Owns nothing in this repo by design; brand lives in `overboard-web` |
+| `Senior Digital Marketer` | Provisional | `CMO` | `feat/web/` | Landing page, brand and visual identity, page copy, analytics — in `overboard-web` |
+| `Digital Content Production` | Ratified | `Senior Digital Marketer` | `feat/content/` | Renders and published media. Explicitly **not** page markup or CSS |
+| `Sr. Mechanical & Systems` | Ratified | `COO` | — | BoM, platform selection, the bench rig, the sim-to-hardware fidelity contract |
+| `Senior Controls` | Ratified | `COO` | — | The control law and its harness |
+| `Archivist` | Provisional | `CEO` | — | *Surface not yet declared* |
+
+⚠️ **Unverified entries.** Escalation targets for `Sr. Mechanical & Systems` and
+`Senior Controls`, the branch prefixes for `Digital Content Production` and
+`Senior Digital Marketer`, and everything about the `Archivist` are **inferred** — from the
+COO's own charter ("receives from Sr. Mechanical and Systems Engineering"), from branch
+conventions observed in sibling repos, and from a CEO remark that the Archivist reports
+directly. Inferring turf from a branch prefix is guessing, which is the thing this registry
+exists to stop. Each is flagged rather than asserted, and each wants one line of confirmation
+from the role itself or the CEO. `Provisional` roles stay provisional until that lands.
+
+## Residual risk, stated rather than papered over
+
+**Notion is a copy that CI cannot reach.** There is no automated link between this file and
+the Escalations select options — a token-bearing CI job that queries Notion would produce red
+builds the PR author cannot fix, which would poison the one interrupt that works. So the
+mirror has a named owner (**COO**), a declared direction (registry → Notion, never back), and
+no pretence of automation.
+
+## Repo scope
+
+This registry covers all three repos — `overboard`, `overboard-web`, `overboard-viz`. Only
+`overboard` has a `CODEOWNERS` today, so "do not edit paths another role owns" is still
+unfalsifiable in two thirds of the estate. Open item in ADR-0002.


### PR DESCRIPTION
Fixes the three org defects reported after a four-day stall on finished content, plus eight ownership corrections adversarial review found.

## The four-day stall

The Senior Digital Marketer believed it was blocked on Digital Content Production. It was not — the content was done. It filed a queue row asking for delivery with a six-day deadline and waited. Both roles were active and filing rows **eleven minutes apart**. Neither read the other's.

**ADR-0004 — three lanes.** Decisions → the queue. **Handoffs → a pull request.** Work requests → a GitHub issue. The invariant:

> If you cannot name a default action you could execute alone, it is not an escalation.

Stated honestly in the ADR: the third lane would **not** have prevented this stall — the content was already done, and only *go and look* fixes that. It prevents a different recurrence.

## The role that did not exist

Senior Digital Marketer had an escalation chain, an owned surface and a branch prefix, and appeared in none of the org's data structures — so it filed as `From: CMO` with a title prefix and **every row it filed was misattributed**. One of its rows was an escalation asking permission to escalate.

**ADR-0005 + `docs/decisions/ROLES.md`** — one home for the role list, parsed by CI instead of hardcoded. The deeper fix: **existence is not ratification.** A role exists when the CEO grants it; `Provisional` roles may file rows and hold `# role:` tags. *"May I exist"* is never a valid row. A missing Notion option is a COO defect, never a blocker on the filer.

Registered: Senior Digital Marketer, Archivist. Attribution on three rows repaired retroactively.

## ADR-0002 → Accepted, ⚠️ unopposed not agreed

Review found the map **wrong in the tree as it stood**: the `bench_*` prefix seam assigned `sim/scenarios/plant.py` and `imperfections.py` — the fidelity contract, verbatim Mechanical's — to Controls. Eight corrections applied. The remaining finding (a filename-prefix seam is discoverable only from CODEOWNERS; a directory is discoverable from `ls`) needs ~6 file moves in two other roles' territory, so it is filed to them rather than done here.

Promoted early rather than at its deadline because a known-wrong binding map in force is worse than untidy paperwork. **One-line revert if you disagree.**

## New CI teeth

- Roles parsed from `ROLES.md`; a tag that does not resolve fails the build.
- Every `Ratified` role must appear in CODEOWNERS or declare it owns nothing.
- Every ADR must carry a `Closes:` line.
- **Turf enforced at the moment of offence** — a branch whose prefix resolves to a registered role may not edit another role's paths without a `TURF-OVERRIDE:` line. Fails open for roles that have not declared a prefix, so blast radius is limited to roles that opted in.
- `--who <path>` resolver, so "am I trespassing?" is one command.

**The gate caught three defects in this very PR** — two unindexed ADRs and a malformed status line — which is the first time it has earned its place. And the turf check fires on this PR's `CLAUDE.md` edit, overridden in the commit message with a reason.

## CLAUDE.md

13 lines, on explicit CEO instruction that the three-lane rule reach every session. CEO-owned path; `TURF-OVERRIDE` recorded. It is the only surface that auto-loads without someone choosing to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)