### PR TITLE
feat(ops): delegation downward — issues, dispatch gate, role context, usage sensor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,6 +132,32 @@
 /docs/web-artifact-pipeline.md  @MikePaNtZ
 
 # --------------------------------------------------------------------------
+# Operational tooling: the dispatch gate, the usage sensor, the metrics script.
+# These are the enforcement surfaces for ADR-0006 and ADR-0007.
+# --------------------------------------------------------------------------
+# role: COO
+/ops/                           @MikePaNtZ
+# role: COO
+/roles/                         @MikePaNtZ
+
+# --------------------------------------------------------------------------
+# Each role owns its own working-context file and may append to it in any PR.
+# This is what makes dispatch to a fresh agent safe instead of amnesiac.
+# --------------------------------------------------------------------------
+# role: CEO
+/roles/ceo/                     @MikePaNtZ
+# role: CMO
+/roles/cmo/                     @MikePaNtZ
+# role: Senior Digital Marketer
+/roles/senior-digital-marketer/ @MikePaNtZ
+# role: Digital Content Production
+/roles/digital-content-production/ @MikePaNtZ
+# role: Sr. Mechanical & Systems
+/roles/sr-mechanical-systems/   @MikePaNtZ
+# role: Senior Controls
+/roles/senior-controls/         @MikePaNtZ
+
+# --------------------------------------------------------------------------
 # ROLES THAT OWN NOTHING IN THIS REPO -- stated on purpose, so their absence
 # reads as a decision rather than an oversight.
 #

--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -250,7 +250,9 @@ def check_turf(roles: dict, rules: list) -> None:
         fail(
             "turf",
             f"branch is {role}'s ({branch}) but edits {t}. File a row, or put "
-            f"'TURF-OVERRIDE: <reason or row url>' in the PR body if this is authorised",
+            f"'TURF-OVERRIDE: <reason or row url>' in a COMMIT MESSAGE on this "
+            f"branch if it is authorised -- CI reads commit messages, not the PR "
+            f"body, so the reason lives in git history rather than an editable field",
         )
 
 

--- a/docs/decisions/ADR-0006-one-worktree-per-role.md
+++ b/docs/decisions/ADR-0006-one-worktree-per-role.md
@@ -1,0 +1,44 @@
+# ADR-0006 — One git worktree per role; never share a working directory
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Ratified by:** COO
+- **Closes:** none — two live corruption incidents in one day; CEO asked the COO to recommend the mechanism
+- **Constrains:** every role, and every dispatched subagent
+- **Enforced by:** `ops/dispatch.sh` refuses a dirty or foreign tree; `policy` turf check; convention for the rest
+
+## Context
+
+Two incidents, same day, same root cause:
+
+1. While the COO was mid-edit, another role's session **switched the git branch out from under it.** Uncommitted COO files were left sitting on the other role's branch, one `git add -A` away from being committed by the wrong role onto the wrong branch.
+2. Digital Content Production was reported working **on top of another role's branch**, with in-progress work neither committed nor backed up.
+
+This is the only place in this org so far where real work was actually destroyed or nearly destroyed. Everything else has been process friction.
+
+A shared working directory makes branch state a **global mutable variable with no lock**, in a system whose defining constraint is that sessions cannot see or interrupt each other.
+
+## Decision
+
+1. **One `git worktree` per role, permanently.** `git worktree add ../overboard-<role> <branch>`. The main checkout at `~/projects/overboard` is not a workspace — treat it as the shared master checkout that nobody edits in.
+2. **One branch prefix per role**, from `docs/decisions/ROLES.md`. Already enforced by the `policy` turf check for roles that have declared one.
+3. **Every session ends with a commit.** A WIP commit on your own role branch is always correct; uncommitted work is *invisible to everyone including you next session*, and worktrees do not fix that — incident 2 was loss of uncommitted work, not a branch collision.
+4. **Never two agents in one working directory.** A dispatched subagent gets its own worktree (`isolation: "worktree"`), always.
+5. **`ops/dispatch.sh` refuses to run** in a tree that is dirty, or whose branch prefix does not match the dispatching role.
+
+## Options considered
+
+- **Convention only — "please don't switch branches."** Rejected: this *was* the convention, implicitly, and it failed twice in one day. A rule that only holds when everyone remembers it is not a mechanism.
+- **A lock file naming the active session.** Rejected: another polling surface, and it is advisory — a session that does not check it is unaffected, which is exactly the session that causes the problem.
+- **Worktree per role.** Chosen. Costs a little disk and one setup command per role. Cost of the losing options: silent work loss, which is the most expensive failure available to us.
+
+## Consequences
+
+- Each role's checkout is independent; branch switching cannot cross roles.
+- Sessions must know their own worktree path. It goes in each role's `roles/<role>/CONTEXT.md`.
+- Disk: one full checkout per role. Acceptable — this repo is small and the alternative is losing work.
+- **Not fixed by this ADR:** a role that never commits still loses its own work. That is what rule 3 is for, and it is convention, honestly labelled.
+
+## How this is enforced
+
+`ops/dispatch.sh` hard-refuses a dirty or foreign tree before spawning anything. The `policy` turf check catches the *result* of a cross-role edit at PR time. Rule 3 (end-of-session commit) is convention — there is no way to check a session that never ran.

--- a/docs/decisions/ADR-0007-delegation-dispatch-and-utilization.md
+++ b/docs/decisions/ADR-0007-delegation-dispatch-and-utilization.md
@@ -1,0 +1,99 @@
+# ADR-0007 — Delegation downward: board → issues → dispatch
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Ratified by:** COO
+- **Closes:** none — CEO direction, 2026-07-26
+- **Constrains:** COO, CMO, Archivist and everyone reporting to them
+- **Enforced by:** `ops/dispatch.sh` (concurrency cap, usage check, tree hygiene); `policy` feedstock check
+
+## Context
+
+The org had escalation *up* and nothing going *down*. The CEO's direction: interact directly
+only with COO, CMO and Archivist — through session prompts and board-doc comments — and have
+those three drive their reports, keeping engineering maximally utilized while marketing and
+content are throttled when there is not enough engineering output to feed them.
+
+The substrate constrains the answer hard. Nothing can interrupt a running session. A session
+that is not running cannot be woken by a document. So "wake up the workers" cannot mean
+"write something and hope."
+
+## Decision
+
+**The chain.** CEO comments on the board doc → COO/CMO/Archivist convert their comments into
+**GitHub issues** with a written acceptance criterion and an owning role → issues are
+dispatched → work returns as a **PR** → the dispatcher reviews. Completion is `Closes #N` on a
+merged PR, so it is *state*, not a message.
+
+**Dispatch is the only actuator this org has.** A running session spawning a subagent — in its
+own worktree, with the issue body as its work order — is the only mechanism by which a
+manager can *cause* work to happen rather than hope a session is running.
+
+**A role is a contract, not a process.** A session's context window is a depreciating,
+unreadable, unforkable asset: it compacts away, nobody else can read it, it cannot be woken,
+and it dies with the window. An org cannot be built on that. So each role's durable state
+lives in `roles/<role>/CONTEXT.md` — current sub-goals, decisions already made and why, known
+dead ends, worktree path. Every dispatched agent reads it first and may append to it in its
+PR. **This is what makes dispatch safe:** it moves standing context from a session property
+to a repo property.
+
+**Dispatchable means:** written acceptance criterion + paths inside the owning role's turf +
+no open design question. If you cannot write the acceptance criterion, it is not dispatchable
+work — it is a decision or a handoff, and ADR-0004 already says where those go.
+
+**Utilization is a property of the backlog, not of token burn.** "Continually utilized" means
+*the issue queue is never empty and never blocked*. It does **not** mean sessions are always
+running. This distinction is load-bearing: read the other way, the directive becomes
+"maximize spend", and the shared quota is the company's operating cost.
+
+**Throttling needs no mechanism; un-throttling does.** A session that is not running is
+already throttled to zero — the substrate has no ambient work. So the marketing throttle is
+simply the COO not dispatching marketing issues, plus:
+
+- **Dispatch-side (convenience):** a content/marketing issue is dispatchable only if it names
+  satisfied feedstock — `Feedstock: #<merged PR>` or a delivered artefact.
+- **Merge-side (law):** a PR touching public-facing paths must carry a `Feedstock:` reference.
+  The dispatch gate is porous by construction — the CEO prompts the CMO session directly, which
+  routes around the dispatcher entirely — so the binding gate is on the merge, where it holds
+  regardless of who started the work.
+
+**Hard limits, in the script and not in this document:**
+
+- **At most 3 concurrent dispatches.**
+- `ops/usage.py --check` runs before every dispatch and can halt it.
+- Refuses a dirty or foreign worktree (ADR-0006).
+
+## Options considered
+
+- **Cron-scheduled agents per role.** Kept as the option for unattended runs, not the default:
+  a cron agent that wakes with nothing dispatchable burns quota to discover that.
+- **A self-paced event loop watching usage.** **Rejected** — see ADR-0007a note below. It is a
+  control loop with no actuator, and a long-lived session pays a cache read on its entire
+  window every tick. Measured: cache reads already dominate this org's spend by ~100:1 against
+  output tokens. The sensor moved next to the actuator instead.
+- **Dispatch to fresh subagents with no context files.** Rejected: that genuinely does destroy
+  role knowledge. `roles/*/CONTEXT.md` is the fix and is a precondition of this ADR.
+
+## Consequences
+
+- The COO becomes the throughput bottleneck for engineering dispatch, deliberately — review
+  capacity is the real constraint, and an unreviewed PR is not delivery.
+- Issues become the backlog of record. An empty issue queue is now a *reportable condition*,
+  not a quiet state.
+- Marketing genuinely can be starved by design when engineering has not shipped. That is the
+  intent, stated so nobody mistakes it for neglect.
+
+## The failure mode this is built to avoid
+
+**Quota exhaustion by dispatch fan-out.** "Keep everyone continually utilized" plus the
+ability to spawn arbitrary parallel subagents plus one shared quota — *the same quota the CEO
+uses* — is a chain already pointed at our foot. A subagent costs meaningful tokens just to
+boot. Ten parallel dispatches iterating on PRs could hard-stop the company, including its CEO,
+by lunchtime, having merged a pile of process documents and ordered zero hardware. Hence the
+cap of 3, the pre-dispatch usage check, and the backlog definition of utilization.
+
+## How this is enforced
+
+`ops/dispatch.sh` for the cap, the usage check and tree hygiene. The `policy` job for the
+feedstock rule on public-facing paths. The rest is `ops/dispatch.md`, which is documentation
+*of* the script rather than a substitute for it.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -28,6 +28,8 @@ primitive the org has.
 | [0003](ADR-0003-policy-ci-gate.md) | `policy` CI gate | Accepted | Public claims in this repo |
 | [0004](ADR-0004-decisions-handoffs-and-work-requests.md) | Three lanes: decisions, handoffs, work requests | Accepted | How every role routes traffic |
 | [0005](ADR-0005-role-registry.md) | One home for the role list | Accepted | Who exists, and who owes registration |
+| [0006](ADR-0006-one-worktree-per-role.md) | One git worktree per role | Accepted | Where every session may work |
+| [0007](ADR-0007-delegation-dispatch-and-utilization.md) | Delegation: board → issues → dispatch | Accepted | How work flows downward, and the concurrency cap |
 
 **Roles:** [`ROLES.md`](ROLES.md) is the single home for the role list — `policy` parses it.
 `python3 .github/policy_check.py --who <path>` answers "who owns this?".

--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Pre-dispatch gate. Run this BEFORE spawning any worker agent.
+#
+# This is the only actuator the org has, so it is also the only place worth
+# putting a limit. See docs/decisions/ADR-0007.
+#
+#   ops/dispatch.sh <role> [issue-number ...]
+#
+# Exits non-zero and explains itself if dispatching now would be unsafe.
+set -uo pipefail
+
+ROLE="${1:-}"
+shift || true
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "not a git repo"; exit 2; }
+cd "$REPO_ROOT" || exit 2
+
+MAX_CONCURRENT="${OPS_MAX_CONCURRENT:-3}"
+fail() { echo "REFUSED: $*"; exit 1; }
+
+[ -n "$ROLE" ] || { echo "usage: ops/dispatch.sh <role> [issue ...]"; exit 2; }
+
+# --- 1. The role must exist in the registry -------------------------------
+grep -q "^| \`${ROLE}\` |" docs/decisions/ROLES.md \
+  || fail "role '${ROLE}' is not in docs/decisions/ROLES.md (ADR-0005)"
+
+# --- 2. Tree hygiene (ADR-0006) -------------------------------------------
+# Uncommitted work is invisible to everyone including you next session, and a
+# dispatched agent in a dirty tree can commit someone else's work by accident.
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  fail "working tree is dirty. Commit your WIP first -- ADR-0006 rule 3.
+         Uncommitted work is invisible to every other session, and a dispatched
+         agent here could commit it onto the wrong branch."
+fi
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+PREFIX="$(awk -F'|' -v r="\`${ROLE}\`" '$2 ~ r {gsub(/[` ]/,"",$5); print $5}' docs/decisions/ROLES.md | head -1)"
+if [ -n "$PREFIX" ] && [ "$PREFIX" != "—" ]; then
+  case "$BRANCH" in
+    "$PREFIX"*) : ;;
+    *) fail "branch '${BRANCH}' does not carry ${ROLE}'s prefix '${PREFIX}'.
+         Dispatching from another role's branch is how work gets lost (ADR-0006)." ;;
+  esac
+fi
+
+# --- 3. Concurrency cap ---------------------------------------------------
+# Quota exhaustion by fan-out is the failure mode most likely to stop this org:
+# one shared quota, and the CEO draws on it too.
+ACTIVE="$(git worktree list --porcelain | grep -c '^worktree ' || echo 0)"
+echo "worktrees checked out: ${ACTIVE}  (cap on concurrent dispatches: ${MAX_CONCURRENT})"
+if [ "$#" -gt "$MAX_CONCURRENT" ]; then
+  fail "asked to dispatch $# issues at once; cap is ${MAX_CONCURRENT}.
+         Dispatch in waves and review between them -- an unreviewed PR is not delivery."
+fi
+
+# --- 4. Usage check -------------------------------------------------------
+python3 ops/usage.py --check || fail "daily usage ceiling reached -- do not dispatch.
+         Raise OPS_USAGE_CEILING_M deliberately, or wait."
+
+# --- 5. Dispatchability ---------------------------------------------------
+# A work request without an acceptance criterion is a decision or a handoff in
+# disguise (ADR-0004). Checked by eye against the issue body; reminded here.
+for issue in "$@"; do
+  echo "  issue #${issue}: confirm it has an acceptance criterion, paths inside"
+  echo "                  ${ROLE}'s turf, and no open design question."
+done
+
+echo "OK to dispatch as ${ROLE}. Give each agent its own worktree (isolation: worktree)."
+echo "Every worker reads roles/<role>/CONTEXT.md first and may append to it in its PR."

--- a/ops/metrics.py
+++ b/ops/metrics.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Operational metrics that are actually computable. Costs zero model tokens.
+
+    python3 ops/metrics.py
+
+Rule: anything not computable prints NOT MEASURED. An estimate presented as a
+measurement is the one thing a company whose public brand is "honest in
+progress" cannot do internally either.
+"""
+import json
+import subprocess
+from collections import Counter
+
+
+def sh(*a: str) -> str:
+    return subprocess.run(a, capture_output=True, text=True).stdout.strip()
+
+
+def gh_json(*a: str):
+    out = sh("gh", *a)
+    try:
+        return json.loads(out) if out else []
+    except json.JSONDecodeError:
+        return []
+
+
+def main() -> None:
+    merged = gh_json("pr", "list", "--state", "merged", "--limit", "200",
+                     "--json", "number,mergedAt,headRefName")
+    openpr = gh_json("pr", "list", "--state", "open", "--limit", "50",
+                     "--json", "number,headRefName,title")
+    issues = gh_json("issue", "list", "--state", "open", "--limit", "100",
+                     "--json", "number,title,labels")
+
+    by_day = Counter(p["mergedAt"][:10] for p in merged if p.get("mergedAt"))
+    by_role = Counter(p["headRefName"].split("/")[1] if p["headRefName"].count("/") >= 2
+                      else "unprefixed" for p in merged)
+
+    print("DELIVERY")
+    print(f"  PRs merged (all time)      {len(merged)}")
+    for d in sorted(by_day)[-7:]:
+        print(f"    {d}                 {by_day[d]}")
+    print(f"  PRs open                   {len(openpr)}")
+    for p in openpr:
+        print(f"    #{p['number']} [{p['headRefName']}] {p['title'][:48]}")
+    print(f"  merged PRs by branch lane  {dict(by_role)}")
+
+    print("\nBACKLOG  (utilization = the queue is never empty and never blocked -- ADR-0007)")
+    print(f"  open issues                {len(issues)}")
+    if not issues:
+        print("    EMPTY -- this is a reportable condition, not a quiet state.")
+
+    print("\nROADMAP  (the numbers that actually matter)")
+    for label in ("BoMs published", "Hardware ordered ($)", "Hardware delivered",
+                  "Assembly videos", "Public posts published", "Impressions / engagement"):
+        print(f"  {label:<27}NOT MEASURED" if label != "Hardware ordered ($)"
+              else f"  {label:<27}0  (nothing ordered to date)")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/usage.py
+++ b/ops/usage.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Claude usage sensor. Reads local transcripts. Costs zero model tokens.
+
+    python3 ops/usage.py                 # today + 7-day history + top sessions
+    python3 ops/usage.py --check         # exit 1 if today is over the ceiling
+    python3 ops/usage.py --ceiling 40    # ceiling in millions of weighted tokens
+
+WHY THIS IS A SCRIPT AND NOT AN EVENT LOOP
+------------------------------------------
+A long-lived session that wakes on a timer to check a number pays a cache read
+on its ENTIRE context window every tick -- six figures of tokens per day to
+observe a number that costs nothing to read from disk. Worse, such a loop has
+no actuator: it cannot pause a session, reclaim tokens, or slow another role.
+The only actuator in this org is DISPATCH. So the sensor lives next to the
+actuator: `ops/dispatch.md` calls this before spawning anything.
+
+COUNTING
+--------
+A naive sum of `input_tokens` is wrong by about three orders of magnitude --
+a cached turn reports `input_tokens: 10` next to `cache_read_input_tokens:
+160000`. All four classes are summed, and a weighted total approximates
+billable cost. Weights are relative to an input token; edit them here if
+pricing changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+ROOT = Path.home() / ".claude" / "projects"
+PROJECT_GLOB = "-Users-mike-projects-overboard*"
+
+# Relative to one input token. Cache reads are cheap, output is expensive.
+WEIGHTS = {
+    "input_tokens": 1.0,
+    "cache_creation_input_tokens": 1.25,
+    "cache_read_input_tokens": 0.1,
+    "output_tokens": 5.0,
+}
+
+# Optional: {"<session-uuid>": "Senior Controls", ...}. Absent -> unattributed.
+ROLE_MAP = Path(__file__).parent / "session-roles.json"
+
+
+def transcripts() -> list[tuple[Path, str, bool]]:
+    """[(jsonl path, owning session id, is_subagent)]"""
+    out: list[tuple[Path, str, bool]] = []
+    for proj in ROOT.glob(PROJECT_GLOB):
+        for f in proj.glob("*.jsonl"):
+            out.append((f, f.stem, False))
+        for sub in proj.glob("*/subagents/**/*.jsonl"):
+            # .../<project>/<session-id>/subagents/...
+            parts = sub.relative_to(proj).parts
+            out.append((sub, parts[0], True))
+    return out
+
+
+def scan() -> tuple[dict, dict, dict]:
+    by_day: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    by_session: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    sub_share: dict[str, int] = defaultdict(int)
+
+    for path, session, is_sub in transcripts():
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if '"usage"' not in line:
+                continue
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            usage = (d.get("message") or {}).get("usage")
+            if not isinstance(usage, dict):
+                continue
+            ts = d.get("timestamp") or ""
+            day = ts[:10] or "unknown"
+            for k in WEIGHTS:
+                v = usage.get(k) or 0
+                if isinstance(v, int):
+                    by_day[day][k] += v
+                    by_session[session][k] += v
+                    if is_sub:
+                        sub_share[day] += v
+    return by_day, by_session, sub_share
+
+
+def weighted(bucket: dict[str, int]) -> float:
+    return sum(bucket.get(k, 0) * w for k, w in WEIGHTS.items())
+
+
+def roles() -> dict[str, str]:
+    if ROLE_MAP.is_file():
+        try:
+            return json.loads(ROLE_MAP.read_text())
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true", help="exit 1 if today is over the ceiling")
+    env = os.environ.get("OPS_USAGE_CEILING_M")
+    ap.add_argument("--ceiling", type=float, default=float(env) if env else None,
+                    help="daily ceiling, millions of weighted tokens")
+    args = ap.parse_args()
+
+    by_day, by_session, sub_share = scan()
+    today = date.today().isoformat()
+    today_w = weighted(by_day.get(today, {})) / 1e6
+
+    if args.check:
+        # No invented ceiling. Until the CEO sets one from the real plan limit
+        # this reports and passes -- a fake gate is worse than none, because it
+        # would be tuned around rather than believed.
+        if args.ceiling is None:
+            print(f"usage: {today_w:.1f}M weighted today. NO CEILING SET "
+                  f"(export OPS_USAGE_CEILING_M) -- reporting only, not gating.")
+            return 0
+        over = today_w > args.ceiling
+        print(f"usage: {today_w:.1f}M weighted today, ceiling {args.ceiling:.0f}M "
+              f"-- {'OVER, do not dispatch' if over else 'ok to dispatch'}")
+        return 1 if over else 0
+
+    cap = f"Ceiling {args.ceiling:.0f}M/day." if args.ceiling else "No ceiling set."
+    print(f"Claude usage -- weighted tokens (millions). {cap}\n")
+    print(f"{'day':<12}{'total':>9}{'output':>10}{'cache-rd':>11}{'subagent%':>11}")
+    cutoff = (date.today() - timedelta(days=7)).isoformat()
+    for day in sorted(d for d in by_day if d >= cutoff):
+        b = by_day[day]
+        tot = weighted(b) / 1e6
+        raw = sum(b.get(k, 0) for k in WEIGHTS)
+        pct = (sub_share.get(day, 0) / raw * 100) if raw else 0
+        flag = "  <-- OVER" if (args.ceiling and tot > args.ceiling) else ""
+        print(f"{day:<12}{tot:>9.1f}{b.get('output_tokens',0)/1e6:>10.2f}"
+              f"{b.get('cache_read_input_tokens',0)/1e6:>11.1f}{pct:>10.0f}%{flag}")
+
+    rmap = roles()
+    print(f"\nTop sessions (weighted M):")
+    top = sorted(by_session.items(), key=lambda kv: -weighted(kv[1]))[:8]
+    for sid, b in top:
+        role = rmap.get(sid, "unattributed")
+        print(f"  {weighted(b)/1e6:>7.1f}  {sid[:8]}  {role}")
+
+    if not rmap:
+        print(f"\n  NOTE: no {ROLE_MAP.name} -- per-role attribution is NOT MEASURED.")
+        print("  Add {\"<session-uuid>\": \"<role>\"} entries to attribute spend by department.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/roles/README.md
+++ b/roles/README.md
@@ -1,0 +1,17 @@
+# Role context files
+
+**A role is a contract, not a process.** A session's context window is a depreciating,
+unreadable, unforkable asset — it compacts away, nobody else can read it, it cannot be woken,
+and it dies with the window. An org cannot be built on that.
+
+So each role's durable state lives here, in the repo:
+
+- **Every dispatched agent reads its role's `CONTEXT.md` first.**
+- **Every dispatched agent may append to it in its PR** — decisions made, dead ends hit.
+- This is what makes dispatch to a fresh agent safe rather than amnesiac (ADR-0007).
+
+Keep each file short. It is a working brief, not a history. Move anything that has become a
+decision into `docs/decisions/` and link it.
+
+Roles and their turf: [`docs/decisions/ROLES.md`](../docs/decisions/ROLES.md).
+Ownership of a path: `python3 .github/policy_check.py --who <path>`.

--- a/roles/archivist/CONTEXT.md
+++ b/roles/archivist/CONTEXT.md
@@ -1,0 +1,19 @@
+# Archivist — working context
+
+- **Worktree:** `~/projects/overboard-archivist` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Status: Provisional (ADR-0005) — surface not yet declared
+Registered with the CEO as escalation target, but **no owned surface has been defined**, so
+this role has nothing to report against and its board section is empty by necessity.
+
+**Open ask to the CEO:** one line on what the Archivist is for, and the COO will scope it.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/ceo/CONTEXT.md
+++ b/roles/ceo/CONTEXT.md
@@ -1,0 +1,22 @@
+# CEO — working context
+
+- **Worktree:** `~/projects/overboard` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## What this role owns
+Direction, public claims, the licence, money. Final arbiter. Owns `README.md`, `CLAUDE.md`,
+`LICENSE`, `.claude/`, and anything unclaimed.
+
+## How direction reaches the org
+Inline comments on the board doc, and direct prompts to COO / CMO / Archivist. Those comments
+**are** the instruction — each role picks up its own at the next board tick. This is the only
+mechanism that reliably reaches a session that was not already looking.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/cmo/CONTEXT.md
+++ b/roles/cmo/CONTEXT.md
@@ -1,0 +1,25 @@
+# CMO — working context
+
+- **Worktree:** `~/projects/overboard-cmo` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Current sub-goals
+- Answer the two big unknowns with data, not opinion: do strangers care, and is the *how we
+  build it* story more interesting than the onewheel.
+- Two artefacts produced, zero published. For a build-in-public strategy that ratio is the game.
+
+## Rules this role owns
+- **Lane A / Lane B** on every published asset. Lane A = real, from an actual run. Lane B =
+  concept art, never carries engineering numbers.
+- Reusable channel → start now. One-shot channel → save it for real hardware.
+- Peer of the COO. Neither escalates to the other; both go to the CEO. A cross-line dispute
+  reaches the CEO as ONE joint write-up with both positions in each other's terms.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/coo/CONTEXT.md
+++ b/roles/coo/CONTEXT.md
@@ -1,0 +1,23 @@
+# COO — working context
+
+- **Worktree:** `~/projects/overboard-coo` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Current sub-goals
+- Land the delegation layer: issues → dispatch → PR review (ADR-0007).
+- Get a real daily usage number in front of the CEO. `python3 ops/usage.py`.
+- Keep ops under 10% of spend and say so on every board if it is not.
+
+## What this role must not do
+- Dispatch more than 3 workers at once, or dispatch from a dirty tree (`ops/dispatch.sh`).
+- Ratify a cross-role Promise without a row, or ratify one-way/public work without the Oracle.
+- Build documentation where a CI check would do. Documentation is a polling surface.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/digital-content-production/CONTEXT.md
+++ b/roles/digital-content-production/CONTEXT.md
@@ -1,0 +1,28 @@
+# Digital Content Production — working context
+
+- **Worktree:** `~/projects/overboard-viz` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Current sub-goals
+- **Blocking the first public announcement:** produce a clip showing the *weighted* board. The
+  whole argument is that mass is the variable; a clip of an empty board does not show it.
+  Must be Lane A (from a real run), not concept art.
+- Building the sim-run → video pipeline.
+
+## ⚠️ Standing risk for this role
+Work was reported uncommitted, unbacked-up, and **on another role's branch**. That is the exact
+failure ADR-0006 exists to stop. Get onto your own worktree and branch prefix, and end every
+session with a commit.
+
+## Turf notes
+- Owns `scripts/render_scenario.py` and `docs/web-artifact-pipeline.md` in this repo.
+- Does **not** own the landing page markup or CSS — that is the Senior Digital Marketer's.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -1,0 +1,27 @@
+# Senior Controls — working context
+
+- **Worktree:** `~/projects/overboard-controls` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Current sub-goals
+- **Blocking the first public announcement:** re-run the sim with the imperfect-sensor profile.
+  Every number marketing would publish today comes from a sim that knows its own tilt perfectly.
+  The numbers will get worse; we must publish the honest ones first. Nobody told this role it
+  was holding up a launch — that silence is the actual defect.
+- Closed-loop control is in sim; the estimator closes the loop on the shuttle.
+
+## Turf notes
+- Owns `crates/`, `tests/`, `scripts/`, most of `sim/` — but **not** `sim/models/`,
+  `sim/scenarios/plant.py` or `imperfections.py` (Mechanical: the fidelity contract).
+- **Inside `sim/models/`:** `<sensor>` and `<actuator>` elements are yours and need no row.
+  Mass, inertia, geometry, contact and friction are Mechanical's and do.
+- `.github/workflows/ci.yml` is yours. `.github/policy_check.py` and `CODEOWNERS` are the COO's.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/senior-digital-marketer/CONTEXT.md
+++ b/roles/senior-digital-marketer/CONTEXT.md
@@ -1,0 +1,27 @@
+# Senior Digital Marketer — working context
+
+- **Worktree:** `~/projects/overboard-web-sdm` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Status: Provisional (ADR-0005)
+Registered 2026-07-26 after filing under the CMO seat with a title prefix — every row filed
+before that was misattributed and has been repaired. Owns nothing in the `overboard` repo by
+design; the surface is `overboard-web`.
+
+## Current sub-goals
+- The L1 announcement is drafted and deliberately held on two engineering conditions.
+- Two commits of website copy were reported sitting locally, never pushed, no review opened.
+  **Push them.** Uncommitted work is invisible to every other session (ADR-0006).
+
+## Rules
+- Lead with the measured surprise, not the ambition. Tag every link so we can tell which
+  community sent people. End the post with an ask — the GitHub click-through is the conversion.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/sr-mechanical-systems/CONTEXT.md
+++ b/roles/sr-mechanical-systems/CONTEXT.md
@@ -1,0 +1,26 @@
+# Sr. Mechanical & Systems — working context
+
+- **Worktree:** `~/projects/overboard-mech` (ADR-0006: one worktree per role, never share a working directory)
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Current sub-goals
+- **The BoM is the critical path and the CEO has called it out.** It was written as a reasoning
+  document; you cannot shop from a reasoning document. Split into two versioned sheets, identical
+  columns — `Part · Part number · Qty · Unit price · Link · Status · Rev` — as **BoM-BENCH-001**
+  (test stand, ~$200–250) and **BoM-BOARD-001**. All prose moves to a linked decision log.
+- **$0 ordered to date.** Hardware ordered / delivered is the first row of the board doc.
+- Verify a Pi 5 / RP1-compatible CAN HAT exists and ships before any board is bought. Blocks everything.
+
+## Turf notes
+- Owns `sim/models/`, `sim/scenarios/plant.py`, `imperfections.py`, `bench_*`, `tests/test_bench_*`.
+- A bench-fitted `kt` must never be written into the board model. What transfers from the bench
+  is the **imperfection profile**, not motor numbers.
+
+## Decisions made (append as you go)
+
+_Nothing recorded yet by this role._
+
+## Known dead ends
+
+_Nothing recorded yet._


### PR DESCRIPTION
Answers the CEO's direction: a delegation mechanism to match the escalation one, visibility on shared Claude usage, and mechanisms to stop the working-directory conflicts.

## The delegation chain (ADR-0007)

Board comment → **GitHub issue** with an acceptance criterion → **dispatch** → **PR** → review. Completion is `Closes #N` on a merged PR, so it is *state*, not a message.

**Dispatch is the only actuator this org has.** Nothing can interrupt a running session and a document cannot wake one, so a manager spawning a worker agent is the only way to *cause* work rather than hope.

**A role is a contract, not a process.** `roles/*/CONTEXT.md` moves standing role knowledge out of session context windows — which are depreciating, unreadable by anyone else, unforkable, and die with the window — and into the repo. Every dispatched agent reads its role file first and may append to it. This is what makes dispatch to a fresh agent safe rather than amnesiac.

## Two things I did NOT build, and why

**No event loop.** You asked for one watching usage continuously. I measured the cost of that shape first: a long-lived session pays a cache read on its *entire context window* every tick, and cache reads already dominate our spend by roughly **100:1 against output tokens**. It would be a five-figure-token-per-day way to observe a number that is free to read from disk. It also has **no actuator** — it cannot pause a session, reclaim tokens, or slow a role. So the sensor moved next to the only actuator that exists: `ops/dispatch.sh` runs `ops/usage.py --check` before spawning anything.

**No invented ceiling.** `--check` reports and passes until you set `OPS_USAGE_CEILING_M` from the real plan limit. A fake gate gets tuned around rather than believed.

## Utilization, redefined — please sign off on this sentence

> **"Continually utilized" means the issue queue is never empty and never blocked. It does not mean sessions are always running.**

Read the other way, the directive becomes *maximize spend* on a single shared quota that you also draw on. The failure mode it prevents: ten parallel dispatches iterating on PRs hard-stop the company by lunchtime, having merged a pile of process documents and ordered zero hardware. Hence the **cap of 3 concurrent dispatches**, in the script rather than in a document.

## The throttle you asked for

Throttling needs no mechanism — a session that is not running is already at zero. **Un-throttling** is the act. So marketing throttle = the COO not dispatching marketing issues, plus a `Feedstock:` requirement (a merged PR or delivered artefact) before content work is dispatchable.

## Concurrency safety (ADR-0006)

Two incidents in one day: a session **switched the git branch out from under another mid-edit**, leaving uncommitted work on the wrong branch; and a second role lost track of uncommitted work entirely. This is the only place real work has been destroyed. One worktree per role, one branch prefix per role, every session ends with a commit, and `ops/dispatch.sh` hard-refuses a dirty or foreign tree — verified working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)