### PR TITLE
Tilted ground plane for the hill scenarios — cross-checked against rotated gravity

### DIFF
--- a/sim/scenarios/plant.py
+++ b/sim/scenarios/plant.py
@@ -185,18 +185,196 @@ def rider_geoms(style: str, com_height: float) -> str:
     return "".join(parts)
 
 
+# ---------------------------------------------------------------------------
+# Terrain — a genuinely tilted ground plane
+# ---------------------------------------------------------------------------
+#
+# WHY THIS EXISTS ALONGSIDE THE ROTATED-GRAVITY HILL, NOT INSTEAD OF IT
+# ---------------------------------------------------------------------
+# `hill.py` models a grade by rotating the gravity vector and leaving the
+# ground flat. That was the right first call: it keeps the nose-strike contact
+# geometry bit-identical to every other scenario, so an 18.57 deg strike on a
+# hill means what it means on the flat. Changing the geometry to get a hill
+# would have moved the one contact case the scenario exists to measure.
+#
+# It has two ceilings, and one of them is not a physics problem at all:
+#
+#   1. IT CANNOT BE FILMED. A gravity-rotated hill renders as a board on flat
+#      ground accelerating for no visible reason. For the build log and the
+#      design-doc video that footage is actively misleading -- it reads as a
+#      bug, not a hill. A real tilted plane is the only version with a slope in
+#      frame.
+#   2. IT CAN ONLY EVER BE AN INFINITE UNIFORM PLANE. No crest, no grade
+#      transition, no compression at the bottom of a dip. The transition ONTO a
+#      slope is a plausible place for a balancer to fail and rotated gravity
+#      cannot express it at all.
+#
+# Here gravity stays vertical and the ground tilts, so the two models are
+# genuinely independent routes to the same answer and can be cross-checked
+# against each other. `test_plant_terrain.py` does exactly that on the flat and
+# at a mid grade. If they ever disagree, that disagreement is a finding.
+#
+# SIGN, MEASURED NOT ASSERTED
+# ---------------------------
+# Forward is -X. `grade_pct > 0` means DOWNHILL IS FORWARD, matching hill.py.
+# That requires a rotation of -phi about +Y, giving a ground normal of
+# (-sin phi, 0, cos phi). The opposite sign puts the hill the other way up, and
+# the failure mode of getting it wrong is a scenario that quietly measures a
+# climb while its filename says descent. Asserted against actual rolling
+# direction in `test_positive_grade_rolls_forward_downhill`, not derived and
+# trusted -- this repo has already shipped one frame convention that was
+# "derived" and wrong.
+
+_GROUND_GEOM = '<geom name="ground" type="plane" size="20 20 0.1" material="ground_mat"/>'
+_FRAME_BODY = '<body name="frame" pos="0 0 0.1454">'
+
+
+def slope_rad(grade_pct: float) -> float:
+    """Slope angle from a percentage grade. `grade_pct = 100 * rise / run`."""
+    import math
+
+    return math.atan(grade_pct / 100.0)
+
+
+def slope_normal(grade_pct: float):
+    """Unit normal of the tilted ground plane, world frame.
+
+    `(-sin phi, 0, cos phi)`. Verified against MuJoCo's compiled `geom_xmat`
+    rather than assumed -- see `test_slope_normal_matches_the_compiled_model`.
+    """
+    import math
+
+    import numpy as np
+
+    phi = slope_rad(grade_pct)
+    return np.array([-math.sin(phi), 0.0, math.cos(phi)])
+
+
+def tilt_ground(xml: str, grade_pct: float) -> str:
+    """Tilt the ground plane to `grade_pct` and stand the board back on it.
+
+    Two edits, and the second is the one that is easy to forget. Tilting the
+    plane alone leaves the axle at its flat-ground height, which is *inside*
+    the slope: the perpendicular distance from the axle to a plane through the
+    origin is `h*cos(phi)`, i.e. short of the rolling radius by `h*(1-cos phi)`.
+    MuJoCo would resolve that as a penetration and spit the board out on the
+    first step. The axle therefore rises to `r / cos(phi)`, which puts it
+    exactly `r` from the tilted surface.
+
+    Both replacements are checked, not trusted. A silent no-op here produces a
+    model that looks tilted in the XML and behaves flat, which is far worse
+    than an exception -- it is the same failure class as a strip that does not
+    strip.
+    """
+    import math
+
+    if grade_pct == 0.0:
+        return xml
+
+    phi_deg = math.degrees(slope_rad(grade_pct))
+    tilted = _GROUND_GEOM.replace(
+        'size="20 20 0.1"', f'size="20 20 0.1" euler="0 {-phi_deg:.9g} 0"'
+    )
+    out, n = xml.replace(_GROUND_GEOM, tilted), xml.count(_GROUND_GEOM)
+    if n != 1:
+        raise RuntimeError(
+            f"expected exactly one ground plane geom to tilt, found {n}. The "
+            "markup in overboard_onewheel.xml changed; update _GROUND_GEOM."
+        )
+
+    if out.count(_FRAME_BODY) != 1:
+        raise RuntimeError(
+            "could not find the frame body to raise onto the slope. Tilting the "
+            "ground without raising the axle buries the wheel in the plane."
+        )
+    r = float(_FRAME_BODY.split('pos="0 0 ')[1].rstrip('">'))
+    raised = _FRAME_BODY.replace(
+        f'pos="0 0 {r}"', f'pos="0 0 {r / math.cos(slope_rad(grade_pct)):.9g}"'
+    )
+    return out.replace(_FRAME_BODY, raised)
+
+
+def strike_angles_deg(model, grade_pct: float = 0.0) -> dict:
+    """Pitch at which each bumper first reaches the ground, from geometry.
+
+    Returns nose and tail SEPARATELY, in world nose-up-positive radians-as-
+    degrees (ICD 10.1), plus the relative angle they share.
+
+    WHY SEPARATELY. On the flat the two are symmetric -- both bumpers reach the
+    ground at 18.57 deg, in opposite directions -- so one number was enough and
+    `nose_strike_angle_deg` collapses them with a min(). On a slope they are
+    NOT symmetric, because the board sits nose-down by the slope angle before
+    it has pitched at all:
+
+        board resting flat on the slope  =>  world pitch = -phi
+        nose reaches the ground at        =>  world pitch = -(rel + phi)
+        tail reaches the ground at        =>  world pitch = +(rel - phi)
+
+    So a DESCENT (grade > 0) brings the tail strike closer and pushes the nose
+    strike away; a CLIMB does the reverse. That is exactly the asymmetry the
+    hill gate measured -- descents fail tail-down, climbs fail nose-down -- and
+    it falls out of the geometry rather than having to be discovered per grade.
+
+    The angle is derived from the collision hull's vertices against the tilted
+    plane, so it stays correct if the meshes, the tire radius or the grade
+    change. The critical vertex is NOT the bumper tip: the bumper curves up
+    toward its nose, so the underside heel lands first, ~90 mm inboard.
+    """
+    import math
+
+    import mujoco
+    import numpy as np
+
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "frame")
+    axle = np.array(data.xpos[body], dtype=float)
+    n = slope_normal(grade_pct)
+
+    out = {}
+    for name, key in (("front_bumper_geom", "nose"), ("rear_bumper_geom", "tail")):
+        gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, name)
+        mesh = model.geom_dataid[gid]
+        adr, num = model.mesh_vertadr[mesh], model.mesh_vertnum[mesh]
+        verts = model.mesh_vert[adr : adr + num].astype(float)
+        # hull vertices in frame-body coordinates, axle at the origin
+        v = data.geom_xpos[gid] + verts @ data.geom_xmat[gid].reshape(3, 3).T - axle
+
+        # Sweep world pitch. Nose-up-positive about +Y (ICD 10.1): a rotation of
+        # +theta maps the body -x axis (the nose) toward +z.
+        hit = None
+        for deg in np.arange(0.0, 89.0, 0.01):
+            th = math.radians(deg) * (-1.0 if key == "nose" else 1.0)
+            c, s = math.cos(th), math.sin(th)
+            R = np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+            if float(((axle + v @ R.T) @ n).min()) <= 0.0:
+                hit = math.copysign(deg, th)
+                break
+        out[key] = hit
+    out["relative_deg"] = (
+        None if out["tail"] is None else out["tail"] + math.degrees(slope_rad(grade_pct))
+    )
+    return out
+
+
 def build_model(ballast_mass: float, ballast_height: float, clamp_a: float,
-                rider_style: str = "figure"):
+                rider_style: str = "figure", grade_pct: float = 0.0):
     """The stock model, optionally with a rigid rider-proxy mass above the axle.
 
     A rigid ballast is NOT a rider: a real one is compliant at the ankles and
     knees, which changes the dynamics substantially. It is the honest
     order-of-magnitude stand-in for "what happens when the centre of mass moves
     above the axle", which is the property that matters here.
+
+    `grade_pct` tilts the GROUND and leaves gravity vertical (see `tilt_ground`).
+    It defaults to 0.0, so every existing caller is unaffected. This is the
+    filmable hill and the one that can later carry a crest or a grade
+    transition; `hill.py`'s rotated-gravity model remains the reference for the
+    infinite uniform plane, and the two are cross-checked against each other.
     """
     import mujoco
 
-    xml = MODEL_PATH.read_text()
+    xml = tilt_ground(MODEL_PATH.read_text(), grade_pct)
     if clamp_a is not None:
         lim = clamp_a * KT_NM_PER_A
         xml = xml.replace('ctrlrange="-28 28"', f'ctrlrange="{-lim:g} {lim:g}"')

--- a/tests/test_plant_terrain.py
+++ b/tests/test_plant_terrain.py
@@ -1,0 +1,309 @@
+"""Tilted ground plane — the filmable hill, and the cross-check against the
+rotated-gravity one.
+
+Answers issue #17 from Senior Controls. `hill.py` models a grade by rotating
+gravity and leaving the ground flat; this adds a variant that tilts the ground
+and leaves gravity vertical.
+
+THE POINT OF HAVING BOTH IS THAT THEY ARE INDEPENDENT
+-----------------------------------------------------
+Rotated gravity and a tilted plane are the same problem for a body on an
+infinite uniform slope, reached by completely different routes: one changes
+`opt.gravity`, the other changes the contact geometry. So they are a genuine
+cross-check on each other, and
+`test_tilted_ground_agrees_with_rotated_gravity` is the test this file exists
+for. If those two ever disagree, one of them is wrong and the disagreement is
+the finding.
+
+They are not redundant, either. Rotated gravity can only ever be an infinite
+uniform plane -- no crest, no grade transition -- and it CANNOT BE FILMED: it
+renders as a board on flat ground accelerating for no visible reason, which
+reads as a bug rather than a hill. Tilted ground is the one that can carry a
+crest later, and the only one that can go in a build log.
+
+WHAT IS DELIBERATELY NOT HERE
+-----------------------------
+No control-loop assertions, no envelope numbers, no estimator error. Those are
+Senior Controls' acceptance criteria and live in `test_hill.py`. This file
+tests the WORLD: that the plane is where it says it is, the board starts on it,
+the contact geometry is right at both ends, and the two hill models agree.
+Keeping the seam clean is what stops a terrain test becoming a tripwire on
+somebody else's tuning.
+"""
+
+import math
+
+import mujoco
+import numpy as np
+import pytest
+
+from sim.scenarios.plant import (
+    MODEL_PATH,
+    build_model,
+    slope_normal,
+    slope_rad,
+    strike_angles_deg,
+    tilt_ground,
+)
+
+GRADES = [-20.0, -10.0, -5.0, 0.0, 5.0, 10.0, 15.0, 20.0]
+
+#: Flat-ground strike angle, derived from the collision hull in the model.
+FLAT_STRIKE_DEG = 18.57
+
+
+def _model(grade_pct=0.0):
+    return build_model(0.0, 0.0, 40.0, grade_pct=grade_pct)
+
+
+def _downhill_unit(grade_pct):
+    """In-plane direction of steepest descent, world frame."""
+    phi = slope_rad(grade_pct)
+    return np.array([-math.cos(phi), 0.0, -math.sin(phi)])
+
+
+# ---------------------------------------------------------------------------
+# The plane is where it claims to be
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("grade", GRADES)
+def test_slope_normal_matches_the_compiled_model(grade):
+    """The analytic normal and MuJoCo's compiled one, to machine precision.
+
+    `slope_normal` is used to derive strike angles and to project displacement,
+    so if it drifts from what MuJoCo actually compiled, every number downstream
+    is quietly wrong while the model still looks tilted.
+    """
+    m = _model(grade)
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+    gid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_GEOM, "ground")
+    compiled = d.geom_xmat[gid].reshape(3, 3)[:, 2]
+    assert np.allclose(compiled, slope_normal(grade), atol=1e-12)
+
+
+def test_zero_grade_is_a_byte_for_byte_no_op():
+    """Every existing caller passes no grade, so grade 0 must change nothing.
+
+    Checked on the XML rather than on behaviour: a model that merely *behaves*
+    identically could still have picked up a 0-degree euler that a later diff
+    would have to explain.
+    """
+    xml = MODEL_PATH.read_text()
+    assert tilt_ground(xml, 0.0) == xml
+
+
+def test_tilt_refuses_to_silently_no_op():
+    """A strip that does not strip is the failure this repo has already had.
+
+    If the ground geom's markup changes, tilting must raise rather than hand
+    back a flat model that the caller believes is a hill.
+    """
+    with pytest.raises(RuntimeError, match="ground plane geom"):
+        tilt_ground("<mujoco><worldbody/></mujoco>", 10.0)
+
+
+@pytest.mark.parametrize("grade", [g for g in GRADES if g != 0.0])
+def test_the_axle_starts_exactly_one_rolling_radius_off_the_slope(grade):
+    """Tilting the plane without raising the axle buries the wheel.
+
+    The perpendicular distance from the un-raised axle to a plane through the
+    origin is `h*cos(phi)` -- short of the rolling radius, so MuJoCo resolves it
+    as a penetration and ejects the board on the first step. This is the edit
+    that is easy to forget because the XML still looks right.
+    """
+    m = _model(grade)
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+    bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, "frame")
+    flat = mujoco.MjData(_model(0.0))
+    mujoco.mj_forward(_model(0.0), flat)
+    r_flat = float(flat.xpos[bid][2])
+    assert float(np.array(d.xpos[bid]) @ slope_normal(grade)) == pytest.approx(
+        r_flat, abs=1e-6
+    )
+
+
+@pytest.mark.parametrize("grade", [0.0, 10.0, 20.0])
+def test_the_board_settles_on_the_slope_rather_than_being_spat_out(grade):
+    """Two seconds of free settling: the axle stays a rolling radius off the
+    surface, to within tyre compression.
+
+    A model that starts penetrated does not fail loudly -- it launches, then
+    lands, and every early sample of whatever scenario is running is garbage.
+    """
+    m = _model(grade)
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+    bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, "frame")
+    n = slope_normal(grade)
+    dists = []
+    for _ in range(1000):
+        mujoco.mj_step(m, d)
+        dists.append(float(np.array(d.xpos[bid]) @ n))
+    excursion_mm = 1000.0 * (max(dists) - min(dists))
+    assert excursion_mm < 5.0, f"{excursion_mm:.2f} mm of bounce — board was ejected"
+
+
+# ---------------------------------------------------------------------------
+# Sign convention — measured, not asserted
+# ---------------------------------------------------------------------------
+
+def test_positive_grade_rolls_forward_downhill():
+    """`grade_pct > 0` means downhill is FORWARD (-x), matching hill.py.
+
+    Measured by letting the board roll, not derived. Getting this backwards
+    gives a scenario that quietly measures a climb while its filename says
+    descent, and this repo has already shipped one 'derived' frame convention
+    that was wrong.
+    """
+    bid = None
+    drift = {}
+    for grade in (+10.0, -10.0):
+        m = _model(grade)
+        d = mujoco.MjData(m)
+        bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, "frame")
+        mujoco.mj_forward(m, d)
+        for _ in range(3000):
+            mujoco.mj_step(m, d)
+        drift[grade] = float(d.xpos[bid][0])
+
+    assert drift[+10.0] < -0.5, (
+        f"positive grade drifted x={drift[+10.0]:+.3f}; downhill must be FORWARD (-x)"
+    )
+    assert drift[-10.0] > +0.5, (
+        f"negative grade drifted x={drift[-10.0]:+.3f}; downhill must be BACKWARD (+x)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contact geometry at BOTH ends
+# ---------------------------------------------------------------------------
+
+def test_flat_ground_reproduces_the_known_strike_angle_at_both_bumpers():
+    """The anchor. On the flat the geometry is symmetric and both bumpers reach
+    the ground at the same angle in opposite directions."""
+    s = strike_angles_deg(_model(0.0), 0.0)
+    assert s["nose"] == pytest.approx(-FLAT_STRIKE_DEG, abs=0.02)
+    assert s["tail"] == pytest.approx(+FLAT_STRIKE_DEG, abs=0.02)
+
+
+@pytest.mark.parametrize("grade", GRADES)
+def test_relative_strike_angle_is_invariant_across_grades(grade):
+    """Tilting the world must not move the contact case.
+
+    This is the property that made rotated gravity the right first call, and it
+    has to survive here or the two hill models are measuring different vehicles.
+    The angle BETWEEN the deck and the ground at which a bumper lands is a rigid
+    -body fact; only its expression in world pitch changes with the slope.
+    """
+    s = strike_angles_deg(_model(grade), grade)
+    assert s["relative_deg"] == pytest.approx(FLAT_STRIKE_DEG, abs=0.05)
+
+
+@pytest.mark.parametrize("grade", [5.0, 10.0, 15.0, 20.0])
+def test_a_descent_brings_the_tail_strike_closer_and_a_climb_the_nose(grade):
+    """The asymmetry Senior Controls measured, falling out of geometry.
+
+    The hill gate found that descents fail tail-down and climbs fail nose-down.
+    That is not a control result — it is where the board already sits before it
+    has pitched at all. Resting flat on a slope IS a world pitch of -phi, so a
+    descent has already spent `phi` of its tail margin and gained `phi` of nose
+    margin.
+
+    Asserting it here means the model reproduces a measured hardware-shaped
+    finding rather than merely being self-consistent.
+    """
+    phi = math.degrees(slope_rad(grade))
+    down = strike_angles_deg(_model(+grade), +grade)
+    up = strike_angles_deg(_model(-grade), -grade)
+
+    assert down["tail"] == pytest.approx(FLAT_STRIKE_DEG - phi, abs=0.05)
+    assert down["nose"] == pytest.approx(-(FLAT_STRIKE_DEG + phi), abs=0.05)
+    assert up["nose"] == pytest.approx(-(FLAT_STRIKE_DEG - phi), abs=0.05)
+    assert up["tail"] == pytest.approx(FLAT_STRIKE_DEG + phi, abs=0.05)
+
+    assert abs(down["tail"]) < abs(down["nose"]), "descent must fail tail-first"
+    assert abs(up["nose"]) < abs(up["tail"]), "climb must fail nose-first"
+
+
+# ---------------------------------------------------------------------------
+# The cross-check this file exists for
+# ---------------------------------------------------------------------------
+
+def _roll_tilted(grade, steps):
+    """Free-roll on a tilted plane; return along-slope displacement."""
+    m = _model(grade)
+    d = mujoco.MjData(m)
+    bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, "frame")
+    mujoco.mj_forward(m, d)
+    p0 = np.array(d.xpos[bid], dtype=float)
+    u = _downhill_unit(grade)
+    out = []
+    for _ in range(steps):
+        mujoco.mj_step(m, d)
+        out.append(float((np.array(d.xpos[bid]) - p0) @ u))
+    return np.asarray(out)
+
+
+def _roll_rotated_gravity(grade, steps):
+    """Free-roll on flat ground with gravity rotated; return the same quantity.
+
+    This is `hill.py`'s model, reproduced here directly rather than imported, so
+    the cross-check does not depend on that module's scenario plumbing.
+    """
+    m = _model(0.0)
+    phi = slope_rad(grade)
+    m.opt.gravity = [-9.81 * math.sin(phi), 0.0, -9.81 * math.cos(phi)]
+    d = mujoco.MjData(m)
+    bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, "frame")
+    mujoco.mj_forward(m, d)
+    x0 = float(d.xpos[bid][0])
+    out = []
+    for _ in range(steps):
+        mujoco.mj_step(m, d)
+        out.append(-(float(d.xpos[bid][0]) - x0))   # downhill is -x
+    return np.asarray(out)
+
+
+@pytest.mark.parametrize("grade", [0.0, 10.0])
+def test_tilted_ground_agrees_with_rotated_gravity(grade):
+    """**The reason both models exist.**
+
+    Two independent routes to a slope — one changes `opt.gravity`, the other
+    changes the contact geometry — must produce the same free-roll down it. On
+    the flat they are the same model and must agree exactly; at a mid grade they
+    are genuinely different formulations and are allowed to differ only by
+    contact-solver detail.
+
+    Senior Controls asked for this explicitly in issue #17: *"if they disagree,
+    that disagreement is itself a finding and I would rather see it early."*
+    """
+    steps = 1500                      # 3 s at the model's 2 ms step
+    a = _roll_tilted(grade, steps)
+    b = _roll_rotated_gravity(grade, steps)
+
+    if grade == 0.0:
+        assert np.allclose(a, b, atol=1e-9), "on the flat these must be one model"
+        return
+
+    travelled = abs(b[-1])
+    assert travelled > 0.5, "the reference model barely moved; test proves nothing"
+    err = abs(a[-1] - b[-1]) / travelled
+    assert err < 0.02, (
+        f"tilted ground and rotated gravity disagree by {err:.2%} over "
+        f"{travelled:.2f} m at {grade:g}% — one of the two hill models is wrong"
+    )
+
+
+def test_the_two_models_disagree_when_they_should():
+    """A negative control, so the agreement test above cannot pass vacuously.
+
+    Comparing a 10% tilted plane against 0% rotated gravity has to fail the same
+    tolerance the real comparison passes. Without this, a bug that made both
+    helpers return zeros would look like perfect agreement.
+    """
+    steps = 1500
+    a = _roll_tilted(10.0, steps)
+    b = _roll_rotated_gravity(0.0, steps)
+    assert abs(a[-1] - b[-1]) > 0.5, "the comparison is not sensitive to grade"


### PR DESCRIPTION
**Closes #17.** Handoff to Senior Controls. I've added the world; the scenario-side wiring and the envelope re-derivation stay with you, as you asked.

> Requested reviewers silently no-op in this repo (you flagged it on #17 — GitHub forbids requesting review from the PR author, and every PR here has the one author). So this links the issue instead. Nobody is waiting on a review request that will never arrive.

## What this adds, and what it deliberately does not replace

Your rotated-gravity model stays. It was the right first call and your reasoning holds: tilting the geometry would have moved the one contact case the scenario exists to measure, and you'd have had no way to tell a real hill result from a changed strike geometry.

This adds an **independent second route** — gravity stays vertical, the ground tilts — so the two can be cross-checked against each other. They are different formulations of the same problem, reached by changing entirely different things.

| grade | tilted ground | rotated gravity | disagreement |
|---|---|---|---|
| 0% | 0.0000 m | 0.0000 m | **bit-identical** |
| 5% | 1.4388 m | 1.4354 m | 0.235% |
| 10% | 2.8674 m | 2.8233 m | 1.560% |
| 15% | 4.0813 m | 4.1053 m | 0.584% |
| 20% | 5.2995 m | 5.3958 m | 1.784% |

Free-roll displacement along the slope over 3 s. There's also a **negative control** — a 10% tilted plane compared against 0% rotated gravity must fail the same tolerance — so agreement can't pass vacuously if both helpers ever return zeros.

## The asymmetry you measured falls out of the geometry

`strike_angles_deg()` returns nose and tail **separately** now, derived from the collision hull against the tilted plane. On the flat they're symmetric (both 18.57°, opposite directions), which is exactly why one number was enough and `nose_strike_angle_deg` could collapse them with a `min()`.

On a slope they aren't, because **a board resting flat on a slope is already at world pitch −φ before it has pitched at all**:

```
nose reaches ground at   world pitch = −(18.57 + φ)
tail reaches ground at   world pitch = +(18.57 − φ)
```

| grade | nose strike | tail strike | relative |
|---|---|---|---|
| −20% (climb) | **−7.26°** | +29.88° | 18.57° |
| −10% | **−12.86°** | +24.28° | 18.57° |
| 0% | −18.57° | +18.57° | 18.57° |
| +10% | −24.28° | **+12.86°** | 18.57° |
| +20% (descent) | −29.88° | **+7.26°** | 18.57° |

So a descent has already spent φ of its tail margin and gained φ of nose margin. That reproduces your measured finding — **descents fail tail-down, climbs fail nose-down** — from geometry alone, instead of it having to be rediscovered per grade.

**The relative angle stays 18.57° at every grade tested.** That's the invariant that made rotated gravity trustworthy, and it had to survive here or the two models would be measuring different vehicles. It's asserted across the full range.

## Two things worth knowing before you wire it up

**The axle has to rise.** Tilting the plane alone leaves the axle at `h·cos φ` from it — short of the rolling radius — so MuJoCo resolves it as penetration and ejects the board on step one. It now goes to `r / cos φ`. This is the edit that's easy to miss because the XML still looks correct; there's a settling test at 0/10/20% that pins it (bounce excursion stays under 0.2 mm at 10%, 2.1 mm at 20%).

**Sign is measured, not derived.** `grade_pct > 0` = downhill forward (−x), matching yours. That needs a −φ rotation about +Y. I asserted it by rolling the board and watching which way it goes, in *both* directions — after the frame-map reflection, I'm not shipping another convention that was derived and trusted.

## Interface

```python
build_model(..., grade_pct=10.0)     # defaults to 0.0
tilt_ground(xml, grade_pct)          # pure string surgery, testable
slope_rad(grade_pct) / slope_normal(grade_pct)
strike_angles_deg(model, grade_pct)  # -> {"nose", "tail", "relative_deg"}
```

`grade_pct` defaults to 0.0 and `tilt_ground` returns the XML unchanged at zero — asserted **byte-for-byte**, not by behaviour, so a stray `euler="0 0 0"` can't creep in. Both string edits raise rather than silently no-op, following the flywheel-strip precedent: a model that looks tilted and behaves flat is worse than an exception.

I have not touched `hill.py`, `impulse_response.py` or `nose_strike_angle_deg` — yours, and your call whether the slope-aware derivation replaces the flat one or sits beside it.

## Scope I stayed out of

No control-loop assertions, no envelope numbers, no estimator error in these tests. Those are your acceptance criteria and belong in `test_hill.py`. A terrain test that also encoded them would become a tripwire on your tuning.

## Verification

- `170 passed, 5 xfailed` (was `133 + 5`) — your hill gate still green, unchanged
- `policy` green: all hard checks pass, 8 roles, 28 ownership rules

## Path note

`plant.py` is Mechanical's under the current CODEOWNERS, but `tests/test_plant_*.py` still resolves to Senior Controls — the tests didn't follow the file when it moved. Filed to the COO as a boundary correction. Either way this PR is a proposal in that path and I have not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPqmiktJQkmGc14UaUAPFS