### PR TITLE
ops: enable auto-merge on all three repos; stop polling PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Extends the global `~/.claude/CLAUDE.md`. Project: a DIY **lean-to-steer self-ba
 - **Stay in your own git worktree and branch prefix.** Two sessions in one working directory
   corrupt each other — this has already happened. `python3 .github/policy_check.py --who <path>`
   answers "am I trespassing?"; roles are in `docs/decisions/ROLES.md`.
+- **Never poll your own PR.** `gh pr merge <n> --squash --auto` queues it — GitHub updates the
+  branch and merges when green. Queue it and start the next thing.
 - Escalate on **Promise, Door, or Turf**; difficulty is not a trigger. Every row needs a default
   action and a deadline, so nobody is ever parked.
 
@@ -37,7 +39,9 @@ Extends the global `~/.claude/CLAUDE.md`. Project: a DIY **lean-to-steer self-ba
   so requiring it would hang every PR forever waiting for a check that never reports.
 - `enforce_admins` is off, so Mike can break glass in an emergency. Claude must not.
 - Open the PR with a body that states what changed and *why*, and call out any acceptance criteria
-  that moved. Wait for CI, then merge (squash) — do not merge red or bypass protection.
+  that moved. Then **queue it — `gh pr merge <n> --squash --auto`** — and start the next thing.
+  Auto-merge and auto-delete-on-merge are on for all three repos, so GitHub brings the branch up
+  to date and merges when green. Do not sit and poll; do not merge red or bypass protection.
 
 ## Public artifacts
 - Both repos are **public**. CI publishes the sim render + metrics to the rolling `sim-latest`

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -43,6 +43,18 @@ primitive the org has.
 - `Proposed` ADRs are visible on purpose: they are the current working assumption, and a
   role that disagrees files a row rather than editing around it.
 
+## Never wait on your own PR
+
+Branch protection is **strict** — a PR must be up to date with master before it merges, and
+master moves several times a day. Polling for that is wasted time and wasted tokens.
+
+```sh
+gh pr merge <n> --squash --auto      # queues it; GitHub updates the branch and merges when green
+```
+
+Auto-merge and auto-delete-on-merge are enabled on all three repos. **Queue the merge and move
+on to the next thing.** Come back only if a check actually fails.
+
 ## Escalate when any one is true — Promise, Door, or Turf
 
 - **Promise** — it changes something outside your role relies on: a public claim, a


### PR DESCRIPTION
PR #15 needed two rebases and eight polling rounds to land, because branch protection is strict and master moves several times a day. That is wasted wall clock and wasted tokens on a shared quota.

**Enabled on `overboard`, `overboard-web` and `overboard-viz`:** `allow_auto_merge`, `delete_branch_on_merge`.

New workflow, now documented in `CLAUDE.md` (auto-loads into every session) and `INDEX.md` (read before every PR):

```sh
gh pr merge <n> --squash --auto   # queue it and move on
```

**Strict is deliberately kept.** Dropping it would remove the rebases too, but it lets a PR merge green against a stale base — and a silently broken master costs more than a CI re-run. Auto-merge removes the *waiting* without weakening the *gate*.

This PR is merged with `--auto` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)