### PR TITLE
Rolling terrain: ride a crest, a dip, and back up to the next crest

### DIFF
--- a/sim/scenarios/terrain.py
+++ b/sim/scenarios/terrain.py
@@ -1,0 +1,521 @@
+"""Rolling terrain — crest, descent, dip, ascent, crest. One continuous ride.
+
+The scenario the uniform-grade hill could not express, and the one that looks
+like riding.
+
+WHAT THE BOARD DOES
+-------------------
+It starts standing at the **crest of a hill**, rides **down** the far side,
+through the **dip** at the bottom, and back **up** to the **crest of the next
+hill**, where the run ends. One full cosine period of ground:
+
+    z(x) = A cos(2 pi x / L)          A = amplitude, L = crest-to-crest
+
+    s = 0        crest      slope 0, about to tip over the edge
+    s = L/4      steepest   maximum descending grade
+    s = L/2      dip        slope 0 again, but curvature reversed
+    s = 3L/4     steepest   maximum climbing grade
+    s = L        crest      arrives, ends
+
+WHY THIS IS A HARDER TEST THAN A CONSTANT GRADE
+-----------------------------------------------
+`hill.py` models a slope by rotating gravity on flat ground. That is exact for
+an infinite uniform plane and it was the right first model -- it preserved the
+nose-strike contact geometry bit-identically, so a strike on a hill meant what a
+strike meant everywhere else. But it can only ever be *one* grade, held forever,
+and it is **invisible in a render**: the board appears on flat ground,
+accelerating and tipping for no reason a viewer can see.
+
+This model tilts the actual ground, so:
+
+1. **The grade CHANGES under the board**, continuously. The controller never
+   reaches the steady state a constant grade eventually allows, and the
+   estimator's slope-absorption error is chasing a moving target rather than
+   converging to a constant offset.
+2. **At the dip the grade REVERSES.** Descending becomes climbing through zero.
+   `hill.py` measured those as two separate runs and found they fail in opposite
+   directions -- descents tail-down, climbs nose-down. Here the board has to
+   pass through the handover in one continuous ride, which is the case neither
+   uniform run could produce.
+3. **Curvature is a load the flat model has none of.** Through the dip the
+   contact point is on the inside of a curve, so holding the line needs centripetal
+   force the board can only get by pushing harder into the ground -- exactly when
+   the drive is fastest and cutback is most likely to bind.
+4. **It can be filmed.** There is a hill in frame.
+
+The terrain is a MuJoCo heightfield generated here, in Senior Controls' own
+file, by string-transforming the model XML. `sim/models/` and
+`sim/scenarios/plant.py` belong to Sr. Mechanical & Systems and are not touched;
+this reuses their `rider_geoms` and constants by import, so a rename over there
+fails loudly here rather than silently producing flat ground.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+from .imperfections import (
+    STAGE0_CUTBACK,
+    ImperfectionProfile,
+    ImperfectionState,
+)
+from .impulse_response import KT_NM_PER_A, _bumper_ground_contact, frame_pitch_rad
+from .plant import (
+    _FRAME_BODY,
+    _GROUND_GEOM,
+    MODEL_PATH,
+    imu_readings,
+    plant_summary,
+    rider_geoms,
+)
+
+R_EFF_M = 0.14605
+
+#: Samples along the ride. 512 over a ~30 m ride is ~6 cm between samples --
+#: fine enough that the wheel never sees a facet, coarse enough to compile fast.
+HFIELD_COLS = 512
+
+
+def amplitude_for_grade(max_grade_pct: float, crest_to_crest_m: float) -> float:
+    """Amplitude that makes the STEEPEST point of the profile a given grade.
+
+    `z = A cos(2 pi x / L)`, so `dz/dx = -A (2 pi / L) sin(...)` and the maximum
+    magnitude of the slope is `2 pi A / L`. Parameterising by peak grade rather
+    than by amplitude is deliberate: the hill gate is expressed in grades, and
+    this way the two scenarios can be compared without arithmetic in between.
+    """
+    return (max_grade_pct / 100.0) * crest_to_crest_m / (2.0 * math.pi)
+
+
+def surface_z(x: float, amplitude_m: float, crest_to_crest_m: float) -> float:
+    """Ground height at world x. `cos` is even, so travelling toward -x (the
+    board's forward) sees the same profile as travelling toward +x."""
+    return amplitude_m * math.cos(2.0 * math.pi * x / crest_to_crest_m)
+
+
+def surface_grade_pct(x: float, amplitude_m: float, crest_to_crest_m: float) -> float:
+    """Local grade at world x, SIGNED THE WAY `hill.py` SIGNS IT.
+
+    Forward is -x. Positive means downhill-is-forward, matching
+    `hill.gravity_for_grade`, so a number from here can be read against the hill
+    envelope directly.
+    """
+    k = 2.0 * math.pi / crest_to_crest_m
+    dz_dx = -amplitude_m * k * math.sin(k * x)
+    # ds = -dx when moving forward, so dz/ds = -dz/dx; downhill-forward is
+    # dz/ds < 0, which we report as POSITIVE grade.
+    return 100.0 * dz_dx
+
+
+@dataclass(frozen=True)
+class TerrainParams:
+    #: Grade at the steepest point of the profile, percent.
+    #:
+    #: 8% is the steepest profile the board completes on the attitude ESTIMATE.
+    #: It fails at 10%, which the uniform-grade gate passes as a steady descent
+    #: -- that gap is the headline result of this scenario, so the default sits
+    #: deliberately at the edge rather than comfortably inside it. A default
+    #: that always passed would be a clip, not a gate.
+    max_grade_pct: float = 8.0
+    #: Crest to crest, metres. One full period: crest, dip, crest.
+    crest_to_crest_m: float = 24.0
+    #: Commanded forward speed once rolling, m/s.
+    v_ref_m_s: float = 2.0
+    duration_s: float = 30.0
+    settle_s: float = 2.0
+    ramp_s: float = 2.0
+    ballast_mass_kg: float = 70.0
+    ballast_height_m: float = 0.75
+    max_current_a: float = 40.0
+    estimator_tau_s: float = 2.0
+    use_estimator: bool = True
+    accel_ff_current_source: int = 0
+    rider_style: str = "figure"
+
+
+@dataclass
+class TerrainMetrics:
+    # --- validity, outside the statistics ---
+    survived: bool = False
+    reached_next_crest: bool = False
+    """Did it actually complete the ride? A board that stops in the dip has not
+    done the manoeuvre, and a run that only asserts `survived` would pass."""
+
+    # --- the ride ---
+    travel_m: float = 0.0
+    crest_to_crest_m: float = 0.0
+    fraction_completed: float = 0.0
+    t_reached_dip_s: float | None = None
+    t_reached_crest_s: float | None = None
+
+    # --- outcome ---
+    nose_strike: bool = False
+    struck_end: str = ""
+    t_strike_s: float | None = None
+    struck_phase: str = ""
+    """Which part of the ride it failed on -- descent, dip, or ascent. The
+    uniform-grade gate says descents fail tail-down and climbs nose-down; this
+    says which one the board actually reaches first."""
+
+    peak_abs_pitch_deg: float = 0.0
+    max_grade_seen_pct: float = 0.0
+
+    # --- speed authority ---
+    held_speed: bool = False
+    v_ref_m_s: float = 0.0
+    max_speed_error_m_s: float = 0.0
+    peak_abs_speed_m_s: float = 0.0
+
+    # --- the estimator, per phase ---
+    pitch_est_rms_deg: float = 0.0
+    pitch_est_max_deg: float = 0.0
+    est_rms_descent_deg: float = 0.0
+    est_rms_dip_deg: float = 0.0
+    est_rms_ascent_deg: float = 0.0
+    est_error_at_dip_deg: float = 0.0
+    """Estimator error at the moment the grade reverses. The handover is the
+    case a constant-grade run cannot produce."""
+
+    # --- drive ---
+    cutback_binding_cycles: int = 0
+    min_available_a: float = 0.0
+    peak_abs_current_a: float = 0.0
+    saturated_cycles: int = 0
+
+    # --- provenance ---
+    duration_s: float = 0.0
+    model_sha256: str = ""
+    mujoco_version: str = ""
+    timestep_s: float = 0.0
+    imperfection_profile_id: str = ""
+
+
+@dataclass
+class TerrainResult:
+    params: TerrainParams
+    metrics: TerrainMetrics
+    plant: dict = field(default_factory=dict)
+    t: np.ndarray = field(default_factory=lambda: np.empty(0))
+    travel_m: np.ndarray = field(default_factory=lambda: np.empty(0))
+    v_m_s: np.ndarray = field(default_factory=lambda: np.empty(0))
+    grade_pct: np.ndarray = field(default_factory=lambda: np.empty(0))
+    pitch_deg: np.ndarray = field(default_factory=lambda: np.empty(0))
+    pitch_est_deg: np.ndarray = field(default_factory=lambda: np.empty(0))
+    motor_current_a: np.ndarray = field(default_factory=lambda: np.empty(0))
+
+    def to_json_dict(self) -> dict:
+        return {"params": asdict(self.params), "plant": self.plant,
+                "metrics": asdict(self.metrics)}
+
+
+def build_terrain_model(params: TerrainParams):
+    """The stock model with its ground plane replaced by a rolling heightfield.
+
+    Every replacement is COUNTED, not trusted. A silent no-op here yields a
+    model that reads as terrain in the XML and behaves as a flat plane, which is
+    strictly worse than an exception -- it is the same failure class as a strip
+    that does not strip, and it would turn this whole scenario into an
+    expensively-dressed flat-ground run.
+    """
+    amp = amplitude_for_grade(params.max_grade_pct, params.crest_to_crest_m)
+    length = params.crest_to_crest_m
+
+    # The board starts at x = 0 and travels toward -x, so the field must span a
+    # full period in -x plus margin at both ends for settling and overrun.
+    margin = 4.0
+    x_lo, x_hi = -length - margin, margin
+    radius_x = (x_hi - x_lo) / 2.0
+    centre_x = (x_lo + x_hi) / 2.0
+
+    xml = MODEL_PATH.read_text()
+
+    asset = (
+        f'\n    <hfield name="rolling" nrow="2" ncol="{HFIELD_COLS}" '
+        f'size="{radius_x:.6f} 6.0 {2 * amp:.6f} 0.5"/>'
+    )
+    if xml.count("</asset>") != 1:
+        raise RuntimeError("expected exactly one </asset> to extend with the hfield")
+    xml = xml.replace("</asset>", asset + "\n  </asset>", 1)
+
+    # `pos z = -amp` puts the mid-range of the field at z = 0, so the surface
+    # runs between -amp and +amp and the crest sits at +amp.
+    ground = (
+        f'<geom name="ground" type="hfield" hfield="rolling" '
+        f'pos="{centre_x:.6f} 0 {-amp:.6f}" material="ground_mat"/>'
+    )
+    if xml.count(_GROUND_GEOM) != 1:
+        raise RuntimeError(
+            f"expected exactly one ground plane geom to replace, found "
+            f"{xml.count(_GROUND_GEOM)}. The markup in overboard_onewheel.xml "
+            "changed; plant._GROUND_GEOM is stale."
+        )
+    xml = xml.replace(_GROUND_GEOM, ground, 1)
+
+    # Stand the board on the crest. The crest is flat, so the axle sits exactly
+    # one rolling radius above it -- no cos(phi) correction needed here, unlike
+    # the tilted-plane case.
+    if xml.count(_FRAME_BODY) != 1:
+        raise RuntimeError("could not find the frame body to stand on the crest")
+    r = float(_FRAME_BODY.split('pos="0 0 ')[1].rstrip('">'))
+    xml = xml.replace(_FRAME_BODY, f'<body name="frame" pos="0 0 {r + amp:.6f}">', 1)
+
+    if params.max_current_a is not None:
+        lim = params.max_current_a * KT_NM_PER_A
+        xml = xml.replace('ctrlrange="-28 28"', f'ctrlrange="{-lim:g} {lim:g}"')
+
+    if params.ballast_mass_kg > 0:
+        m_b, h_b = params.ballast_mass_kg, params.ballast_height_m
+        body = (
+            f'\n      <body name="ballast" pos="0 0 {h_b}">'
+            f'<inertial pos="0 0 0" mass="{m_b}" '
+            f'diaginertia="{m_b * 0.15:.4f} {m_b * 0.15:.4f} {m_b * 0.08:.4f}"/>'
+            + rider_geoms(params.rider_style, h_b)
+            + "</body>\n"
+        )
+        xml = xml.replace('      <site name="imu"', body + '      <site name="imu"', 1)
+
+        # Widen the stock cameras, which are framed for a bare 0.3 m board and
+        # crop out a rider 0.75 m above the axle.
+        xml = xml.replace('fovy="26"', 'fovy="66"').replace('fovy="24"', 'fovy="64"')
+
+    # A world-fixed camera that can hold the whole ride. The stock cameras are
+    # `trackcom`: tracked, a crest-to-crest descent looks like a stationary
+    # board on a scrolling texture, which is exactly the "hill you cannot see"
+    # problem this scenario exists to fix. Pulled back and up to keep both
+    # crests and the dip in frame.
+    # Framed by trial against rendered output, not derived, and it is a
+    # COMPROMISE rather than a good shot. Two constraints pull apart: seeing the
+    # whole crest-to-crest profile needs distance, and at 8% a 24 m roller is
+    # only 0.6 m tall, so from far enough back to hold both crests the hill
+    # flattens toward a texture. Close enough for the rider to read, and the
+    # profile leaves frame.
+    #
+    # That is physics, not framing -- the board's envelope caps the grade at
+    # single digits, and a single-digit grade is a gentle hill. Set here so the
+    # scenario is inspectable; **Digital Content Production owns the real shot**
+    # and should not treat this as the intended composition.
+    wide = (
+        f'\n    <camera name="terrain" pos="{-length / 2:.3f} {length * 0.62:.3f} '
+        f'{amp * 2 + 2.0:.3f}" xyaxes="-1 0 0 0 -0.22 0.98" fovy="34"/>\n  '
+    )
+    xml = xml.replace("</worldbody>", wide + "</worldbody>", 1)
+
+    # Meshes supplied in memory rather than by writing a temp MJCF next to the
+    # real model -- a stray temp file is indistinguishable from a real model to
+    # whoever looks next. Keyed by both the bare name and the path the XML
+    # actually asks for, since this string is compiled without a base directory.
+    mesh_dir = MODEL_PATH.parent / "meshes" / "openwheel"
+    assets = {f"meshes/openwheel/{p.name}": p.read_bytes()
+              for p in mesh_dir.glob("*.stl")}
+    model = mujoco.MjModel.from_xml_string(xml, assets)
+
+    # Fill the elevation data. `data` is in [0, 1] and scales the field's
+    # elevation, so (cos + 1) / 2 maps the profile onto the full range.
+    adr = int(model.hfield_adr[0])
+    ncol, nrow = int(model.hfield_ncol[0]), int(model.hfield_nrow[0])
+    xs = np.linspace(x_lo, x_hi, ncol)
+    row = (np.cos(2.0 * np.pi * xs / length) + 1.0) / 2.0
+    model.hfield_data[adr:adr + nrow * ncol] = np.tile(row, nrow).astype(np.float32)
+
+    # Verify the terrain is actually terrain. A flat field would make every
+    # result in this module a flat-ground result wearing a hill's name.
+    span = float(np.ptp(model.hfield_data[adr:adr + ncol]))
+    if span < 0.9:
+        raise RuntimeError(
+            f"heightfield is nearly flat (normalised span {span:.4f}); the "
+            "profile did not take"
+        )
+    return model, amp
+
+
+def run(
+    params: TerrainParams | None = None,
+    profile: ImperfectionProfile = STAGE0_CUTBACK,
+    controller_factory=None,
+) -> TerrainResult:
+    """Ride crest → dip → crest and measure whether control holds throughout."""
+    params = params or TerrainParams()
+    if profile.is_ideal():
+        raise ValueError("refusing to gate on an ideal profile: it models nothing")
+
+    model, amp = build_terrain_model(params)
+    summary = plant_summary(model)
+    if not summary["inverted_pendulum"]:
+        raise ValueError(
+            "rolling terrain requires a RIDDEN plant (centre of mass above the "
+            f"axle). Got mgl {summary['mgl_n_m_per_rad']:+.2f}."
+        )
+
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    frame = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "frame")
+    ground = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "ground")
+    bumper_ids = {
+        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, n): end
+        for n, end in (("front_bumper_geom", "nose"), ("rear_bumper_geom", "tail"))
+    }
+
+    def v_ref_at(t: float) -> float:
+        if t < params.settle_s:
+            return 0.0
+        if params.ramp_s <= 0.0:
+            return params.v_ref_m_s
+        return params.v_ref_m_s * min(1.0, (t - params.settle_s) / params.ramp_s)
+
+    if controller_factory is None:
+        from .rust_controller import RustController
+
+        def controller_factory():
+            return RustController(
+                kp_a_per_rad=200.0, kd_a_per_rad_s=30.0,
+                max_current_a=params.max_current_a,
+                kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02,
+                com_above_axle=True, v_ref_fn=v_ref_at,
+                use_estimator=params.use_estimator,
+                estimator_tau_s=params.estimator_tau_s,
+                accel_ff_current_source=params.accel_ff_current_source,
+            )
+
+    dt = float(model.opt.timestep)
+    n_steps = int(round(params.duration_s / dt))
+    imp = ImperfectionState(profile=profile, dt_s=dt)
+    length = params.crest_to_crest_m
+
+    ts, travels, vs, grades, pitches, ests, currents = [], [], [], [], [], [], []
+    x0 = float(data.xpos[frame][0])
+    flowing_a = 0.0
+    m = TerrainMetrics()
+
+    with controller_factory() as ctl:
+        for _ in range(n_steps):
+            t = float(data.time)
+            pitch_rad = frame_pitch_rad(model, data)
+            wheel_true = float(data.qvel[6])
+            true_gyro, true_accel = imu_readings(model, data)
+
+            proposed = float(ctl(
+                t, pitch_rad, imp.gyro(float(data.qvel[4])),
+                imp.wheel_rate(wheel_true, t),
+                gyro_rad_s=imp.gyro_vec(true_gyro),
+                accel_m_s2=imp.accel_vec(true_accel),
+                motor_current_a=flowing_a,
+            ))
+
+            available = profile.available_current_a(wheel_true)
+            if abs(proposed) > available + 1e-9:
+                m.cutback_binding_cycles += 1
+
+            current = imp.apply_current(proposed, wheel_true)
+            flowing_a = current
+            data.ctrl[0] = current * KT_NM_PER_A
+            mujoco.mj_step(model, data)
+
+            x = float(data.xpos[frame][0])
+            fwd = -(x - x0)
+            pitch_deg = math.degrees(frame_pitch_rad(model, data))
+            grade = surface_grade_pct(x, amp, length)
+
+            ts.append(float(data.time))
+            travels.append(fwd)
+            vs.append(float(data.qvel[6]) * R_EFF_M)
+            grades.append(grade)
+            pitches.append(pitch_deg)
+            ests.append(math.degrees(float(ctl.pitch_used_rad)))
+            currents.append(current)
+
+            m.peak_abs_pitch_deg = max(m.peak_abs_pitch_deg, abs(pitch_deg))
+            m.max_grade_seen_pct = max(m.max_grade_seen_pct, abs(grade))
+            if m.t_reached_dip_s is None and fwd >= length / 2.0:
+                m.t_reached_dip_s = float(data.time)
+                m.est_error_at_dip_deg = ests[-1] - pitch_deg
+            if m.t_reached_crest_s is None and fwd >= length:
+                m.t_reached_crest_s = float(data.time)
+
+            if _bumper_ground_contact(model, data, ground, set(bumper_ids)) is not None:
+                m.nose_strike = True
+                m.t_strike_s = float(data.time)
+                ends = set()
+                for i in range(data.ncon):
+                    c = data.contact[i]
+                    for a, b in ((c.geom1, c.geom2), (c.geom2, c.geom1)):
+                        if a == ground and b in bumper_ids:
+                            ends.add(bumper_ids[b])
+                m.struck_end = ends.pop() if len(ends) == 1 else ("both" if ends else "")
+                m.struck_phase = (
+                    "descent" if fwd < length / 2.0 * 0.9
+                    else "dip" if fwd < length / 2.0 * 1.1
+                    else "ascent"
+                )
+                break
+
+            if m.t_reached_crest_s is not None:
+                break
+
+        m.saturated_cycles = int(ctl.saturated_cycles)
+
+    t_arr = np.asarray(ts)
+    trav = np.asarray(travels)
+    v_arr = np.asarray(vs)
+    err = np.asarray(ests) - np.asarray(pitches)
+
+    m.survived = not m.nose_strike
+    m.reached_next_crest = m.t_reached_crest_s is not None
+    m.travel_m = float(trav[-1])
+    m.crest_to_crest_m = length
+    m.fraction_completed = float(min(1.0, trav[-1] / length))
+
+    cruise = t_arr >= params.settle_s + params.ramp_s
+    if not cruise.any():
+        cruise = np.zeros_like(t_arr, dtype=bool)
+        cruise[-1] = True
+    m.v_ref_m_s = params.v_ref_m_s
+    m.peak_abs_speed_m_s = float(np.max(np.abs(v_arr[cruise])))
+    m.max_speed_error_m_s = float(np.max(np.abs(v_arr[cruise]) - abs(params.v_ref_m_s)))
+    m.held_speed = m.survived and m.max_speed_error_m_s < max(1.0, params.v_ref_m_s)
+
+    m.pitch_est_rms_deg = float(np.sqrt(np.mean(err ** 2)))
+    m.pitch_est_max_deg = float(np.max(np.abs(err)))
+
+    def phase_rms(lo, hi):
+        sel = (trav >= lo) & (trav < hi)
+        return float(np.sqrt(np.mean(err[sel] ** 2))) if sel.any() else 0.0
+
+    m.est_rms_descent_deg = phase_rms(0.0, length * 0.45)
+    m.est_rms_dip_deg = phase_rms(length * 0.45, length * 0.55)
+    m.est_rms_ascent_deg = phase_rms(length * 0.55, length)
+
+    m.min_available_a = float(min(profile.available_current_a(w / R_EFF_M) for w in v_arr))
+    m.peak_abs_current_a = float(np.max(np.abs(currents)))
+    m.duration_s = float(t_arr[-1])
+    m.timestep_s = dt
+    m.mujoco_version = mujoco.__version__
+    m.imperfection_profile_id = profile.profile_id
+    m.model_sha256 = hashlib.sha256(Path(MODEL_PATH).read_bytes()).hexdigest()[:16]
+
+    return TerrainResult(
+        params=params, metrics=m, plant=summary, t=t_arr, travel_m=trav,
+        v_m_s=v_arr, grade_pct=np.asarray(grades), pitch_deg=np.asarray(pitches),
+        pitch_est_deg=np.asarray(ests), motor_current_a=np.asarray(currents),
+    )
+
+
+def summary_line(r: TerrainResult) -> str:
+    m = r.metrics
+    if m.nose_strike:
+        outcome = f"{m.struck_end.upper()} in the {m.struck_phase} @{m.t_strike_s:.1f}s"
+    elif m.reached_next_crest:
+        outcome = f"reached the crest @{m.t_reached_crest_s:.1f}s"
+    else:
+        outcome = f"stalled at {m.fraction_completed * 100:.0f}%"
+    return (
+        f"max grade {r.params.max_grade_pct:>5.1f}%  v_ref {r.params.v_ref_m_s:>4.1f}  "
+        f"{outcome:<34s} est RMS {m.pitch_est_rms_deg:>6.3f}°  "
+        f"(descent {m.est_rms_descent_deg:>6.3f} / dip {m.est_rms_dip_deg:>6.3f} / "
+        f"ascent {m.est_rms_ascent_deg:>6.3f})"
+    )

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -1,0 +1,204 @@
+"""Rolling terrain: the profile contract, the build guards, and the gate.
+
+The headline this file exists to pin: **a rolling profile is harder than a
+steady grade of the same steepness.** The uniform-grade gate passes the
+estimator on a steady +10% descent; the same peak grade with a crest, a dip and
+two transitions puts the board down.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from sim.scenarios.hill import HillParams
+from sim.scenarios.hill import run as hill_run
+from sim.scenarios.imperfections import IDEAL, STAGE0_CUTBACK
+from sim.scenarios.terrain import (
+    TerrainParams,
+    amplitude_for_grade,
+    build_terrain_model,
+    run,
+    summary_line,
+    surface_grade_pct,
+    surface_z,
+)
+
+
+# --------------------------------------------------------------------------
+# PROFILE CONTRACT — arithmetic, no plant
+# --------------------------------------------------------------------------
+
+def test_the_profile_is_crest_dip_crest():
+    """Exactly one period: starts high, bottoms out halfway, ends high."""
+    L = 24.0
+    A = amplitude_for_grade(10.0, L)
+    assert surface_z(0.0, A, L) == pytest.approx(A)          # crest
+    assert surface_z(-L / 2, A, L) == pytest.approx(-A)      # dip
+    assert surface_z(-L, A, L) == pytest.approx(A)           # next crest
+
+
+def test_the_steepest_point_is_the_requested_grade():
+    """Parameterising by peak grade rather than amplitude is what lets this
+    scenario be read against the uniform-grade envelope without arithmetic."""
+    L = 24.0
+    for want in (4.0, 8.0, 15.0):
+        A = amplitude_for_grade(want, L)
+        got = max(abs(surface_grade_pct(-s, A, L)) for s in np.linspace(0, L, 2001))
+        assert got == pytest.approx(want, abs=1e-3)
+
+
+def test_grade_sign_matches_the_uniform_hill_convention():
+    """Positive = downhill-forward, as `hill.gravity_for_grade` signs it. If
+    these disagreed, every cross-comparison in this file would be backwards and
+    would look like a physics result rather than a sign error."""
+    L = 24.0
+    A = amplitude_for_grade(10.0, L)
+    assert surface_grade_pct(-L / 4, A, L) > 0.0, "quarter point should be descending"
+    assert surface_grade_pct(-3 * L / 4, A, L) < 0.0, "three-quarter point should climb"
+    assert surface_grade_pct(0.0, A, L) == pytest.approx(0.0, abs=1e-9)
+    assert surface_grade_pct(-L / 2, A, L) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_the_grade_reverses_through_the_dip():
+    """The case a constant-grade run cannot produce: descending becomes
+    climbing, continuously, through zero."""
+    L, A = 24.0, amplitude_for_grade(10.0, 24.0)
+    before = surface_grade_pct(-L / 2 + 1.0, A, L)
+    after = surface_grade_pct(-L / 2 - 1.0, A, L)
+    assert before > 0.0 and after < 0.0, "grade did not change sign across the dip"
+
+
+# --------------------------------------------------------------------------
+# BUILD GUARDS
+# --------------------------------------------------------------------------
+
+def test_the_heightfield_is_actually_terrain():
+    """A silent no-op in the XML transform yields a model that reads as terrain
+    and behaves as a flat plane -- every result in this module would then be a
+    flat-ground result wearing a hill's name."""
+    model, amp = build_terrain_model(TerrainParams(max_grade_pct=10.0))
+    adr, ncol = int(model.hfield_adr[0]), int(model.hfield_ncol[0])
+    span = float(np.ptp(np.asarray(model.hfield_data[adr:adr + ncol])))
+    assert span > 0.9, f"heightfield normalised span {span:.4f} -- near flat"
+    assert amp == pytest.approx(amplitude_for_grade(10.0, 24.0))
+
+
+def test_the_board_starts_standing_on_the_crest():
+    """Not buried in the ground and not dropped from a height -- either would
+    make the first second of every run a contact transient."""
+    import mujoco
+
+    model, amp = build_terrain_model(TerrainParams())
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    frame = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "frame")
+    axle_z = float(data.xpos[frame][2])
+    assert axle_z == pytest.approx(amp + 0.1454, abs=1e-3)
+
+
+def test_run_refuses_an_ideal_profile():
+    with pytest.raises(ValueError, match="ideal"):
+        run(TerrainParams(duration_s=4.0), profile=IDEAL)
+
+
+def test_run_refuses_the_driverless_plant():
+    with pytest.raises(ValueError, match="RIDDEN"):
+        run(TerrainParams(ballast_mass_kg=0.0, duration_s=4.0))
+
+
+# --------------------------------------------------------------------------
+# GATE
+# --------------------------------------------------------------------------
+
+def test_the_board_rides_crest_to_crest():
+    """**The gate.** Start on a crest, descend, cross the dip, climb to the next
+    crest, arrive. On the attitude estimate, at the default 8% peak grade.
+    """
+    m = run(TerrainParams()).metrics
+    assert m.survived, f"struck the {m.struck_end} in the {m.struck_phase} at {m.t_strike_s}s"
+    assert m.reached_next_crest, (
+        f"only got {m.fraction_completed * 100:.0f}% of the way -- surviving "
+        "without completing is not doing the manoeuvre"
+    )
+    assert m.held_speed
+    assert m.t_reached_dip_s is not None and m.t_reached_crest_s is not None
+    assert m.t_reached_dip_s < m.t_reached_crest_s, "reached the crest before the dip"
+
+
+def test_completing_is_asserted_separately_from_surviving():
+    """A board that stalls halfway is upright and useless. `survived` alone
+    would pass it, which is the same shape of hole as scoring a crashed run as
+    holding speed."""
+    m = run(TerrainParams(duration_s=6.0)).metrics
+    assert m.survived, "6 s should not be enough to crash, only enough to be short"
+    assert not m.reached_next_crest
+    assert m.fraction_completed < 1.0
+
+
+def test_a_rolling_profile_is_harder_than_a_steady_grade_of_the_same_steepness():
+    """**The headline.**
+
+    `hill.py` passes the estimator on a steady +10% descent. The same 10% as the
+    *peak* of a rolling profile -- with a crest to leave, a dip to cross and two
+    transitions -- puts the board down. Transitions cost margin that a steady
+    grade never charges, and only a real tilted surface can express them.
+    """
+    steady = hill_run(HillParams(grade_pct=10.0, v_ref_m_s=2.0, duration_s=10.0)).metrics
+    rolling = run(TerrainParams(max_grade_pct=10.0)).metrics
+
+    assert steady.survived, (
+        "the uniform 10% descent now fails too -- the comparison this test makes "
+        "has lost its baseline, so re-derive both envelopes rather than editing here"
+    )
+    assert not rolling.survived, (
+        "the rolling 10% profile now survives. If the controller genuinely "
+        "improved, re-derive the terrain envelope -- do not loosen this"
+    )
+    assert rolling.struck_phase in ("descent", "dip", "ascent")
+
+
+def test_the_estimator_costs_terrain_envelope():
+    """Truth pitch rides a profile the estimate cannot. Same plant, same
+    terrain, same commanded speed -- only the source of attitude differs."""
+    truth = run(TerrainParams(max_grade_pct=10.0, use_estimator=False)).metrics
+    est = run(TerrainParams(max_grade_pct=10.0, use_estimator=True)).metrics
+    assert truth.survived and truth.reached_next_crest, (
+        "truth pitch should complete a 10% rolling profile"
+    )
+    assert not est.survived, "the estimate should not"
+
+
+@pytest.mark.parametrize("grade", [4.0, 8.0])
+def test_estimator_error_is_lowest_through_the_dip(grade):
+    """Where the ground is flattest the estimate is best, which is the
+    slope-absorption mechanism showing up inside a single continuous ride
+    rather than across separate runs.
+
+    Note this does NOT reproduce the uniform gate's `error ~= slope angle`. On a
+    rolling profile the grade never holds still long enough for the error to
+    converge to it, so total RMS is roughly grade-independent (~0.96 deg across
+    2-8%) while its DISTRIBUTION along the ride still tracks the terrain.
+    """
+    m = run(TerrainParams(max_grade_pct=grade)).metrics
+    assert m.reached_next_crest
+    assert m.est_rms_dip_deg < m.est_rms_descent_deg, (
+        f"dip {m.est_rms_dip_deg:.3f}° vs descent {m.est_rms_descent_deg:.3f}° -- "
+        "the estimate should be at its best where the ground is flattest"
+    )
+
+
+def test_the_ride_is_reported_in_one_readable_line():
+    """The deliverable is a scenario someone can read the outcome of, not a
+    boolean. Used by the analysis scripts and by anyone looking for the edge."""
+    text = summary_line(run(TerrainParams()))
+    assert "crest" in text and "est RMS" in text and "descent" in text
+
+
+def test_cutback_does_not_bind_on_the_default_ride():
+    """Stated so the presence of a cutback model is never mistaken for evidence
+    that cutback was the mechanism. At 8% over 24 m the board never gets fast
+    enough to be derated; the estimator is the constraint, as everywhere else."""
+    m = run(TerrainParams()).metrics
+    assert m.imperfection_profile_id == STAGE0_CUTBACK.profile_id
+    assert m.cutback_binding_cycles == 0


### PR DESCRIPTION
The ride the uniform-grade hill could not express, on the tilted ground @MikePaNtZ's Sr. Mech work landed in #18.

Start standing on a **crest**, ride **down**, cross the **dip**, climb back up to the **next crest**, arrive. One continuous ride, one full cosine period of ground, parameterised by the grade at its *steepest* point so the numbers read directly against `hill.py`'s envelope.

## The headline: a rolling profile is harder than a steady grade of the same steepness

| peak grade | truth pitch | estimator (τ = 2 s) |
|---|---|---|
| 4% | — | reached the crest @14.0s |
| 8% | — | reached the crest @13.4s |
| **10%** | **reached the crest @13.6s** | **NOSE in the descent @3.3s** |
| 14% | TAIL in the descent @5.4s | — |

`hill.py` passes the estimator on a **steady +10% descent**. The same 10% as the *peak* of a rolling profile puts the board down. Truth pitch pays the same tax — it holds a steady 20% but loses a rolling 14%.

**Transitions cost margin that a constant grade never charges**, and only a real tilted surface can express them. That is the concrete answer to "was the tilted plane worth building": yes, and it moved the envelope.

## Why rotated gravity could not do this

- **The grade changes under the board**, continuously — the controller never reaches the steady state a constant grade eventually allows.
- **At the dip the grade reverses.** `hill.py` measured descents and climbs as separate runs, failing in opposite directions (tail-down vs nose-down). Here the board passes through the handover in one ride.
- **Curvature is a load** the flat model has none of.
- **It can be filmed.** There is a hill in frame.

## An honest contrast in the estimator numbers

On a steady grade, estimator RMS tracks ≈0.85× the slope angle — the filter absorbs the slope. Here it is roughly **grade-independent** (~0.96° across 2–8%), because the grade never holds still long enough for the error to converge to it. Its *distribution* still tracks the terrain — lowest through the dip, highest on the descent — and that is asserted, not just described.

## Defaults and guards

Default peak grade is **8%**: the steepest profile the board completes on the estimate, one step below where it fails. A default that always passed would be a clip, not a gate.

`survived` and `reached_next_crest` are asserted **separately** — a board that stalls halfway is upright and useless, and `survived` alone would pass it. Same shape of hole as the crashed-run-holds-speed bug from #16.

## Turf

`sim/models/` and `sim/scenarios/plant.py` are Sr. Mech's and are **not touched**. The heightfield is generated in `sim/scenarios/terrain.py` by string-transforming the model XML, reusing their `rider_geoms` and constants by import so a rename over there fails loudly here rather than silently producing flat ground. Every replacement is counted, and the compiled field is checked for actual relief — a silent no-op would make every result here a flat-ground result wearing a hill's name.

## On the visuals

The `terrain` camera is a **compromise and says so in the code**. Holding both crests in frame needs distance; at 8% a 24 m roller is only 0.6 m tall, so from far enough back it flattens toward a texture. That is the board's envelope, not the framing — a single-digit grade is a gentle hill. **Digital Content Production owns the real shot** and should not read this as the intended composition.

## Next

`hill.py`'s rotated-gravity model is now the *reference* for the infinite uniform plane rather than the primary hill scenario. Retiring it is a separate change once this has run in CI for a bit — deleting the cross-check in the same PR that adds its replacement would remove the only independent thing to check against.

Verification: `190 passed, 2 xfailed`. `policy_check.py` — all hard checks pass. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TEaAUBtHvVLRdFfnSBpHt