### PR TITLE
fix(sim): derive IMU frame handedness instead of asserting it

### DIFF
--- a/sim/models/overboard_onewheel.xml
+++ b/sim/models/overboard_onewheel.xml
@@ -143,7 +143,10 @@
       <inertial pos="0 0 -0.03" mass="8.0" diaginertia="0.040 0.400 0.420"/>
 
       <!-- IMU mounting point: on the electronics platform, just aft of the
-           axle, axes aligned with the frame (x fwd-negative, y left, z up). -->
+           axle, axes aligned with the frame. Right-handed only (MuJoCo
+           cannot represent a left-handed frame): forward = -x, up = +z,
+           so right is derived, not asserted:
+             (-x_hat) x y_hat = -z_hat  =>  right = +y. -->
       <site name="imu" pos="-0.06 0 -0.007" size="0.008" group="4"/>
 
       <!-- Openwheel shells: visual only. -->


### PR DESCRIPTION
## What
`sim/models/overboard_onewheel.xml:146` read *"x fwd-negative, y left, z up"* — a left-handed frame, which MuJoCo cannot represent. The comment was self-refuting on inspection, and it is the comment that licensed the frame bug fixed in PR #12 (IMU->ICD map was a reflection, det = -1, wrong at 8 of 9 attitudes, error exactly -2θ, invisible at upright).

## Why not just swap left->right
That replaces one unfalsifiable assertion with another. Instead the comment now states the derivation, so a reader can falsify it from geometry alone:

    forward = -x, up = +z  =>  (-x_hat) x y_hat = -z_hat  =>  right = +y

## Change
Comment-only change in `sim/models/overboard_onewheel.xml`. No sim numbers, no geometry, no behavior change.

Closes #22.