### PR TITLE
ops: declare mech/controls branch prefixes, and check agent-type fit before dispatch

### DIFF
--- a/docs/decisions/ROLES.md
+++ b/docs/decisions/ROLES.md
@@ -41,11 +41,18 @@ All-three-or-none is the definition of `Ratified`. It is **not** a precondition 
 | `CMO` | Ratified | `CEO` | — | The marketing line. Peer of COO — neither escalates to the other. Owns nothing in this repo by design; brand lives in `overboard-web` |
 | `Senior Digital Marketer` | Provisional | `CMO` | `feat/web/` | Landing page, brand and visual identity, page copy, analytics — in `overboard-web` |
 | `Digital Content Production` | Ratified | `Senior Digital Marketer` | `feat/content/` | Renders and published media. Explicitly **not** page markup or CSS |
-| `Sr. Mechanical & Systems` | Ratified | `COO` | — | BoM, platform selection, the bench rig, the sim-to-hardware fidelity contract |
-| `Senior Controls` | Ratified | `COO` | — | The control law and its harness |
+| `Sr. Mechanical & Systems` | Ratified | `COO` | `feat/mech/` | BoM, platform selection, the bench rig, the sim-to-hardware fidelity contract |
+| `Senior Controls` | Ratified | `COO` | `feat/controls/` | The control law and its harness |
 | `Archivist` | Provisional | `CEO` | — | *Surface not yet declared* |
 
-⚠️ **Unverified entries.** Escalation targets for `Sr. Mechanical & Systems` and
+✅ **Branch prefixes for `Sr. Mechanical & Systems` (`feat/mech/`) and `Senior Controls`
+(`feat/controls/`) are now OBSERVED**, not inferred — both appear repeatedly in merged branch
+history. They were blank until 2026-07-27, which meant the `policy` turf check **silently
+skipped** every branch those two roles pushed: it fails open for roles with no declared prefix,
+so the two most active engineering roles had no turf enforcement at all. Caught by a dispatched
+agent, not by me.
+
+⚠️ **Still unverified.** Escalation targets for `Sr. Mechanical & Systems` and
 `Senior Controls`, the branch prefixes for `Digital Content Production` and
 `Senior Digital Marketer`, and everything about the `Archivist` are **inferred** — from the
 COO's own charter ("receives from Sr. Mechanical and Systems Engineering"), from branch

--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -56,7 +56,22 @@ fi
 python3 ops/usage.py --check || fail "daily usage ceiling reached -- do not dispatch.
          Raise OPS_USAGE_CEILING_M deliberately, or wait."
 
-# --- 5. Dispatchability ---------------------------------------------------
+# --- 5. Agent-type fit ----------------------------------------------------
+# Learned the hard way: sonnet-executor has Read/Write/Edit/Bash/Grep/Glob and
+# NOTHING ELSE -- no ToolSearch, no WebSearch, no MCP. A research or Notion
+# task handed to it fails instantly, having spent ~22k tokens discovering that
+# its own toolbox is empty. Match the agent type to the work BEFORE spawning.
+cat <<'FIT'
+
+  AGENT-TYPE FIT -- check before you spawn:
+    repo edits, tests, builds, refactors ....... sonnet-executor  (no web, no MCP)
+    web research, Notion, anything needing MCP .. general-purpose  (all tools)
+    read-only search across many files ......... Explore
+    a bounded judgement call ................... opus5-oracle     (read-only)
+  Wrong type = a guaranteed no-op that still costs a full agent boot.
+FIT
+
+# --- 6. Dispatchability ---------------------------------------------------
 # A work request without an acceptance criterion is a decision or a handoff in
 # disguise (ADR-0004). Checked by eye against the issue body; reminded here.
 for issue in "$@"; do

--- a/roles/coo/CONTEXT.md
+++ b/roles/coo/CONTEXT.md
@@ -16,7 +16,13 @@
 
 ## Decisions made (append as you go)
 
-_Nothing recorded yet by this role._
+- **2026-07-27 — match the agent type to the work before dispatching.** `sonnet-executor`
+  carries Read/Write/Edit/Bash/Grep/Glob only. A Notion + web-research task sent to it burned
+  a full agent boot to report that it had no tools. Use `general-purpose` for anything needing
+  MCP or the web. Now printed by `ops/dispatch.sh`.
+- **2026-07-27 — issues beat queue rows for getting work done.** Issue #21 was argued over in
+  two mutually-blocking escalation rows for hours; the moment it became a GitHub issue with an
+  acceptance criterion, Controls closed it unprompted and without dispatch.
 
 ## Known dead ends
 


### PR DESCRIPTION
Two defects surfaced by actually running the dispatch loop.

**1. The turf check was silently disabled for the two most active roles.** `Sr. Mechanical & Systems` and `Senior Controls` had no branch prefix in `ROLES.md`. The check fails open for roles with no declared prefix — a deliberate choice to limit blast radius — which meant every branch those two pushed skipped turf enforcement entirely. Both prefixes are now **observed** from merged branch history (`feat/mech/`, `feat/controls/`) rather than inferred.

Found by a dispatched agent reporting an out-of-scope observation, not by me. That is the review loop working.

**2. Agent-type mismatch is a guaranteed no-op that still costs a full boot.** `sonnet-executor` has Read/Write/Edit/Bash/Grep/Glob and nothing else. A Notion + web-research task sent to it spent ~22k tokens discovering its own toolbox was empty. `ops/dispatch.sh` now prints a fit table before spawning.

Both recorded in `roles/coo/CONTEXT.md` so the next COO session does not relearn them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)