### PR TITLE
Gate the Python filter replica, and run the estimator by default on the shuttle

### DIFF
--- a/scripts/analyse_estimator.py
+++ b/scripts/analyse_estimator.py
@@ -54,10 +54,28 @@ def collect(kind: str) -> dict:
         n = int(8.0 / dt)
 
     t, th, ax, az, gy, v = [], [], [], [], [], []
+    # TRUTH PITCH, DELIBERATELY, AND STATED SO RATHER THAN INHERITED.
+    #
+    # `harvest` flies the trajectory on truth and records the raw IMU; the
+    # filter is then run OFFLINE over those arrays by `run_filter` below. That
+    # is a legitimate open-loop analysis and it is what this function is for.
+    #
+    # It is written out because leaving it to the default cost real time. The
+    # numbers this produces (<1 deg RMS) were compared against the scenario
+    # harness's closed-loop numbers (7.4 deg RMS) as though the two measured the
+    # same thing, and the 10x gap was carried in the handoff as an unexplained
+    # defect. They are not the same measurement: open-loop replay over a
+    # truth-flown trajectory versus closed-loop error that moves the trajectory
+    # it is measured on. Nothing was broken; the comparison was.
+    #
+    # Do NOT "fix" this to use_estimator=1. That would make `run_filter`'s
+    # offline pass meaningless, because the trajectory would already have been
+    # flown on the estimate.
     with RustController(
         kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
         kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02, com_above_axle=True,
         v_ref_fn=vref_fn,
+        use_estimator=False,
     ) as c:
         for _ in range(n):
             now = float(data.time)

--- a/sim/scenarios/shuttle_run.py
+++ b/sim/scenarios/shuttle_run.py
@@ -286,6 +286,21 @@ def run(
         from .rust_controller import RustController
 
         def controller_factory(vprofile):
+            # THE ESTIMATOR IS ON BY DEFAULT, and this is the point of the
+            # default rather than an incidental setting.
+            #
+            # This scenario used to default to TRUTH PITCH -- a board that knows
+            # its own tilt exactly, which no hardware ever will. That made the
+            # headline number (return error) a measurement of the control law
+            # with the hardest part of the problem deleted, and it meant a
+            # fresh session could easily believe the estimator was running when
+            # it was not. Both of those happened.
+            #
+            # tau = 2 s with command feedforward is the recommended
+            # configuration and was recorded nowhere in code until now. A caller
+            # that genuinely wants truth pitch -- isolating the regulator, for
+            # instance -- passes its own factory and says so, which makes the
+            # unusual case the explicit one instead of the default.
             return RustController(
                 kp_a_per_rad=200.0,
                 kd_a_per_rad_s=30.0,
@@ -294,6 +309,9 @@ def run(
                 ki_v_rad_per_m=0.02,
                 v_ref_fn=vprofile.v_ref,
                 com_above_axle=True,
+                use_estimator=1,
+                estimator_tau_s=2.0,
+                estimator_accel_aiding=2,   # command feedforward
             )
 
     dt = float(model.opt.timestep)

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -240,6 +240,49 @@ def _shuttle(**kw):
     )
 
 
+def test_the_shuttle_runs_the_estimator_BY_DEFAULT():
+    """**The default is the claim.** A headline scenario must not measure the
+    control law with the hardest part of the problem deleted.
+
+    The shuttle used to default to truth pitch -- a board that knows its own
+    tilt exactly, which no hardware will ever be. Two things followed: the
+    published return error was flattering by ~3.6x, and a fresh session could
+    believe the estimator was running when it was not. Both happened.
+
+    Gated here because the whole test suite passed before and after the default
+    was flipped -- every other test supplies its own controller factory, so
+    nothing exercised the default at all. A default nothing tests is a default
+    that will silently revert.
+
+    Checked by OUTCOME rather than by inspecting the factory: truth pitch
+    returns to 0.0648 m and the estimator to 0.2331 m, so the number itself says
+    which one ran.
+    """
+    from sim.scenarios.shuttle_run import run as shuttle_run
+
+    default = shuttle_run().metrics
+    assert not default.nose_strike
+
+    # Far from the truth-pitch figure, close to the estimator's.
+    assert default.return_error_m > 0.15, (
+        f"default shuttle returned {default.return_error_m:.4f} m, which is the "
+        "truth-pitch answer (0.0648 m). The estimator is not in the default path"
+    )
+    assert default.return_error_m == pytest.approx(0.2331, abs=0.02), (
+        f"default shuttle returned {default.return_error_m:.4f} m; expected the "
+        "estimator+command-feedforward figure of 0.2331 m. If the recommended "
+        "configuration changed, re-derive this rather than widening it"
+    )
+
+    # And the recommended configuration is what it runs -- same number.
+    recommended = _shuttle(use_estimator=1, estimator_tau_s=2.0,
+                           estimator_accel_aiding=COMMAND_FEEDFORWARD).metrics
+    assert default.return_error_m == pytest.approx(recommended.return_error_m, abs=1e-9), (
+        "the default is no longer the recommended tau=2 s + command-feedforward "
+        "configuration"
+    )
+
+
 def test_the_shuttle_hands_the_controller_a_live_imu():
     """The regression for a bug that ran clean and reported garbage.
 

--- a/tests/test_replica_fidelity.py
+++ b/tests/test_replica_fidelity.py
@@ -1,0 +1,76 @@
+"""The Python replica of the Rust complementary filter, gated.
+
+`scripts/analyse_estimator_phase.py` carries `PyComplementary` and
+`PyWheelAccel` -- a second implementation of `control-core`'s filter, in Python.
+It exists because the FFI exposes one switch for the estimator and separating
+the P and D paths for the frequency-domain analysis needed a replica that could
+be taken apart.
+
+**Every number in notebook 4 flows through that replica.** It was validated
+once, by hand, to 2.19e-05 deg -- and then nothing ran the validation again.
+`validate_replica()` has existed the whole time and no test called it, so a
+change to the Rust filter would have let the replica drift silently and turned
+notebook 4 into fiction without a single test going red.
+
+This is that test. It is cheap (one shadow-mode shuttle run) and it is the only
+thing standing between `control-core` changing and a published notebook quietly
+becoming wrong.
+"""
+
+import pytest
+
+from scripts.analyse_estimator_phase import validate_replica
+
+#: The replica is a line-for-line transcription, not an approximation, so the
+#: bar is machine precision rather than "close enough". `validate_replica`
+#: itself uses 1e-3 as its own `faithful` flag; this is tighter on purpose --
+#: the hand validation came out at 2.19e-05 deg, and anything materially above
+#: that means the two implementations have genuinely diverged rather than
+#: merely rounded differently.
+MAX_DIVERGENCE_DEG = 1e-3
+EXPECTED_ORDER_DEG = 1e-4
+
+
+def test_the_python_replica_still_matches_the_shipped_rust_filter():
+    """If this fails, do NOT relax it. Notebook 4 is downstream.
+
+    The failure means one of two things, and both are worse than a red test:
+    `control-core`'s filter changed and the replica did not follow, or the
+    replica was edited and the shipped filter did not. Either way every figure
+    in `04-estimator-in-the-loop.ipynb` and every conclusion drawn from the
+    Bode plots is measuring something that is not the flight code.
+
+    Fix the replica, re-run `scripts/analyse_estimator_phase.py`, and
+    re-execute the notebook -- in that order, per notebooks/README.md.
+    """
+    v = validate_replica()
+
+    assert v["samples"] > 1000, (
+        f"only {v['samples']} samples compared -- the validation run is too "
+        "short to be evidence of anything"
+    )
+    assert v["faithful"], (
+        f"replica diverged from the shipped Rust filter: max "
+        f"{v['max_abs_deg']:.3e} deg, RMS {v['rms_deg']:.3e} deg"
+    )
+    assert v["max_abs_deg"] < MAX_DIVERGENCE_DEG, (
+        f"max divergence {v['max_abs_deg']:.3e} deg exceeds {MAX_DIVERGENCE_DEG:.0e}. "
+        "Notebook 4's numbers all flow through this replica -- fix the replica, "
+        "do not loosen the bound"
+    )
+
+
+def test_the_replica_matches_at_the_precision_it_was_originally_validated_to():
+    """Separate from the pass/fail bound above, and deliberately tighter.
+
+    The hand validation recorded 2.19e-05 deg. A drift to, say, 5e-4 would
+    still clear `faithful` while indicating the two implementations had started
+    to disagree in a way that was not there before. This catches that early,
+    while it is still a curiosity rather than a published error.
+    """
+    v = validate_replica()
+    assert v["max_abs_deg"] < EXPECTED_ORDER_DEG, (
+        f"max divergence {v['max_abs_deg']:.3e} deg. Still within the hard bound, "
+        f"but well above the {EXPECTED_ORDER_DEG:.0e} the replica was validated to -- "
+        "the implementations are drifting apart. Investigate before it matters."
+    )


### PR DESCRIPTION
Two items from MikePaNtZ/overboard#24 (O1 — sim fidelity). Both are unambiguous regardless of what the MikePaNtZ/overboard#33 roadmap session decides, so they don't need to wait on it.

## 1. The replica is gated

`scripts/analyse_estimator_phase.py` carries `PyComplementary` / `PyWheelAccel` — a second implementation of `control-core`'s complementary filter, in Python. **Every number in notebook 4 flows through it.**

`validate_replica()` has existed the whole time and **nothing ever called it**. A change to the Rust filter would let the replica drift silently and turn a published notebook into fiction without a single test going red.

That exposure got worse an hour ago: MikePaNtZ/overboard#23 re-executed notebook 4 against that replica. So this is cleaning up something I made more load-bearing.

Now gated at **9.309e-06° max divergence over 10,000 samples**, with two separate bounds on purpose:

- a **1e-3 hard bound** (`faithful`), and
- a tighter **1e-4 early-warning bound** — a drift to 5e-4 would still clear `faithful` while telling you the two implementations had started to disagree. Catches it while it's a curiosity rather than a published error.

The test says explicitly: if this fails, fix the replica — do not relax the bound. Notebook 4 is downstream.

## 2. The shuttle runs the estimator by default

It defaulted to **truth pitch** — a board that knows its own tilt exactly, which no hardware will ever be. Two consequences, both of which actually happened: the headline number measured the control law with the hardest part of the problem deleted, and a fresh session could believe the estimator was running when it wasn't.

The default is now the recommended **τ = 2 s + command feedforward**, a configuration that was recorded nowhere in code until now.

| | return error |
|---|---|
| old default (truth pitch) | 0.0648 m |
| **new default (estimator + cmd-ff)** | **0.2331 m** |

Worse, and honest. This also clears the CMO's launch condition 1.

**Gated, and that mattered:** the entire suite passed *before and after* the flip, because every other test supplies its own controller factory — nothing exercised the default at all. A default nothing tests is a default that will silently revert. The new test checks by **outcome** (0.0648 vs 0.2331) rather than by inspecting the factory, so it can't be satisfied by a factory that looks right and behaves wrong.

## What I deliberately did not do

**Did not flip `RustController`'s own default.** 11 call sites rely on it, including `scripts/render_scenario.py` — Digital Content Production's file, feeding the public artifact. Flipping it underneath them would silently change a published video, which is the exact class of change this codebase keeps getting burned by. Fixed at the scenario level instead.

**Made `analyse_estimator.py`'s truth-pitch choice explicit** rather than inherited. It flies truth and filters offline, which is correct for what it does — but leaving that to the default is what allowed its <1° open-loop number to be compared against a 7.4° closed-loop number as though they measured the same thing, and carried into the handoff as an unexplained 10× defect. Now it says so, and says not to "fix" it.

## Still open on AC1 — flagged to DCP on MikePaNtZ/overboard-viz#5

`render_scenario.py:475` builds a bare `RustController()`, so **the published open-vs-closed comparison clip renders its closed pane on truth pitch.** The most visible artifact the project produces — embedded in the public README — shows a board with perfect knowledge of its own tilt. Their file, not touched; commented on MikePaNtZ/overboard-viz#5 with the one-line change and an offer to prepare it for their review.

## Acceptance criteria

- MikePaNtZ/overboard#24 AC1 **partially met**: the shuttle is honest by default and gated. The published impulse render is not yet, and is not mine.
- Handoff §7 item 4 (**wire `validate_replica()` into CI**) — **done**.

Verification: `193 passed, 2 xfailed`. `policy_check.py` — all hard checks pass. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TEaAUBtHvVLRdFfnSBpHt