### PR TITLE
ops: catch documentation drift at PR time, and cap doc size

### DIFF
--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -51,6 +51,13 @@ CAPABILITY = re.compile(
 )
 
 TURF_OVERRIDE = re.compile(r"TURF-OVERRIDE:\s*(\S.*)")
+DOC_OK = re.compile(r"DOC-OK:\s*(\S.*)")
+
+# A doc declares what it describes in an HTML comment, so it stays invisible
+# when rendered:  <!-- covers: [glob, ...]  reconciled: <sha> -->
+COVERS = re.compile(r"<!--\s*covers:\s*(.*?)-->", re.S)
+DOC_WARN_BYTES = 20_000
+DOC_FAIL_BYTES = 40_000
 
 failures: list[str] = []
 advisories: list[str] = []
@@ -256,6 +263,82 @@ def check_turf(roles: dict, rules: list) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Documentation drift
+# ---------------------------------------------------------------------------
+def doc_manifests() -> list[tuple[Path, list[str]]]:
+    """[(doc path, covered globs)] for implementation-tier docs."""
+    out = []
+    for path in sorted((REPO / "docs").rglob("*.md")):
+        if DECISIONS in path.parents:
+            continue
+        m = COVERS.search(path.read_text(encoding="utf-8"))
+        if not m:
+            continue
+        globs = [ln.strip().lstrip("-").strip()
+                 for ln in m.group(1).splitlines()
+                 if ln.strip().lstrip("-").strip() and not ln.strip().startswith("reconciled:")]
+        out.append((path, [g for g in globs if g]))
+    return out
+
+
+def check_doc_drift() -> None:
+    """A change to code must carry the doc that describes it, in the same PR.
+
+    Caught at the moment of creation rather than discovered months later. The
+    check never judges CONTENT -- only that somebody looked since the code
+    moved. `DOC-OK: <reason>` in a commit message is the escape hatch, same
+    shape as TURF-OVERRIDE, so the reason lands in git history.
+    """
+    base = os.environ.get("POLICY_BASE_REF", "origin/master")
+    merge_base = git("merge-base", base, "HEAD")
+    if not merge_base:
+        print("doc-drift: cannot resolve base -- skipping")
+        return
+    changed = set(p for p in git("diff", "--name-only", f"{merge_base}...HEAD").split() if p)
+    if not changed:
+        return
+
+    override_text = (os.environ.get("POLICY_PR_BODY", "") + "\n"
+                     + git("log", f"{merge_base}..HEAD", "--format=%B"))
+    om = DOC_OK.search(override_text)
+
+    for doc, globs in doc_manifests():
+        rel_doc = str(doc.relative_to(REPO))
+        if rel_doc in changed:
+            continue  # the doc moved with the code
+        hits = sorted({c for c in changed for g in globs if fnmatch.fnmatch(c, g)})
+        if not hits:
+            continue
+        if om:
+            print(f"doc-drift: {rel_doc} not updated alongside {len(hits)} covered file(s), "
+                  f"overridden -- {om.group(1).strip()}")
+            continue
+        fail(
+            "doc-drift",
+            f"{rel_doc} describes {', '.join(hits[:3])}"
+            f"{' and others' if len(hits) > 3 else ''}, which this PR changes, but the doc "
+            f"was not touched. Update it, or put 'DOC-OK: <reason>' in a commit message",
+        )
+
+
+def check_doc_size() -> None:
+    """Stop docs becoming historical logs.
+
+    A 55,000-character BoM is what prompted this: excellent research, unusable
+    as the thing it claimed to be. Superseded reasoning belongs in an appendix
+    or deleted, not accreted at the top of the file someone has to act on.
+    """
+    for path in sorted((REPO / "docs").rglob("*.md")):
+        n = len(path.read_text(encoding="utf-8"))
+        rel = path.relative_to(REPO)
+        if n > DOC_FAIL_BYTES:
+            fail("doc-size", f"{rel} is {n:,} chars (limit {DOC_FAIL_BYTES:,}). "
+                             f"Move superseded material to an appendix, or cut it")
+        elif n > DOC_WARN_BYTES:
+            advisories.append(f"{rel} is {n:,} chars -- approaching the {DOC_FAIL_BYTES:,} limit")
+
+
 def public_markdown() -> list[Path]:
     """README plus docs/, excluding docs/decisions/.
 
@@ -319,7 +402,30 @@ def who(path: str) -> int:
     return 0
 
 
+def reconcile(doc: str) -> int:
+    """Stamp the current HEAD into a doc's manifest, marking it reconciled."""
+    p = REPO / doc
+    if not p.is_file():
+        print(f"{doc}: not found")
+        return 1
+    text = p.read_text(encoding="utf-8")
+    m = COVERS.search(text)
+    if not m:
+        print(f"{doc}: no <!-- covers: --> manifest to stamp")
+        return 1
+    head = git("rev-parse", "HEAD")[:7]
+    body = m.group(1)
+    body = (re.sub(r"reconciled:\s*\S+", f"reconciled: {head}", body)
+            if "reconciled:" in body else body.rstrip() + f"\nreconciled: {head}\n")
+    p.write_text(text[:m.start(1)] + body + text[m.end(1):], encoding="utf-8")
+    print(f"{doc}: reconciled at {head}")
+    return 0
+
+
 def main(argv: list[str]) -> int:
+    if "--reconcile" in argv:
+        i = argv.index("--reconcile")
+        return reconcile(argv[i + 1]) if i + 1 < len(argv) else 2
     if "--who" in argv:
         i = argv.index("--who")
         if i + 1 >= len(argv):
@@ -332,6 +438,8 @@ def main(argv: list[str]) -> int:
     check_adr_index()
     check_ownership(roles, rules)
     check_turf(roles, rules)
+    check_doc_drift()
+    check_doc_size()
     check_claims()
 
     if advisories:

--- a/docs/decisions/ADR-0008-documentation-drift.md
+++ b/docs/decisions/ADR-0008-documentation-drift.md
@@ -1,0 +1,95 @@
+# ADR-0008 — Two documentation tiers; catch implementation drift at PR time
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+- **Ratified by:** COO
+- **Closes:** none — CEO direction, 2026-07-27
+- **Constrains:** anyone editing code that a doc describes; anyone writing docs
+- **Enforced by:** `policy` CI job — `doc-drift` and `doc-size` checks
+
+## Context
+
+The project rule is that Notion is the primary home for design docs and repo `docs/` holds
+mirrors that track the implementation. In practice the mirrors drift, and the CEO's
+observation is sharper than "docs get stale": pages accrete **historical editorial trails**
+until the current state is buried in a log of how we got here. A 55,000-character BoM was the
+proof — excellent research, and unusable as the thing it claimed to be.
+
+The obvious fix — have a role update docs on request, triggered by an issue — does not work,
+and the reason is structural: **drift is definitionally the thing nobody noticed.** A
+request-based process requires someone to spot it first. That is the same failure that left
+two escalation rows deadlocked for hours over a question a merged PR had already settled.
+
+## Decision
+
+**1. Two tiers, because docs drift for different reasons.**
+
+| Tier | Examples | Primary home | How it stays current |
+|---|---|---|---|
+| **Strategy** | Charter, M0/M1, P0, roadmap | **Notion** | Describes *intent*; cannot drift from code. Swept on a cadence at the board meeting |
+| **Implementation** | ICD, controls design, sim test designs, BoM | **git** | Describes *code*; drift is mechanically detectable, and CI detects it |
+
+Notion remains primary for strategy. For the implementation tier git becomes authoritative and
+Notion is a mirror — because CI cannot read Notion, and a rule CI cannot check is a rule that
+depends on someone choosing to look.
+
+**2. Every implementation doc carries a manifest** naming what it describes, in an HTML
+comment so it stays invisible when rendered:
+
+```
+<!--
+covers:
+  - sim/scenarios/impulse_response.py
+  - tests/test_impulse_response.py
+reconciled: e4ddb82
+-->
+```
+
+**3. The build fails when code moves without its doc.** If a PR changes a covered file and
+does not touch the doc, `doc-drift` fails — unless a commit message carries
+`DOC-OK: <reason>`. Same shape as `TURF-OVERRIDE`, which has worked three times in one day,
+and the reason lands in git history rather than in an editable PR body.
+
+**The check never judges content.** It asserts only that somebody *looked* since the code
+moved. That is the part a machine can check, and checking it is enough — a human who opens the
+doc will fix what is wrong.
+
+**4. Docs are capped at 40,000 characters, with a warning at 20,000.** Crude, and it creates
+steady pressure toward the appendix-and-prune discipline without anyone policing prose.
+
+**5. Notion sync becomes a publish step, not a task.** Once git is authoritative for the
+implementation tier, pushing to Notion is mechanical: no judgement, no drift, no owner.
+
+## Options considered
+
+- **Archivist updates docs on request, triggered by issues.** Rejected. Requires someone to
+  notice drift first, and one role cannot know what changed *semantically* across three repos.
+- **Convention: every role tidies its docs when it finishes.** Rejected as the *only*
+  mechanism — it is a discipline surface with no enforcement, which is precisely what failed
+  twice on 2026-07-26. Kept as a norm on top of the check.
+- **A scheduled drift report.** Useful, insufficient: it tells you about drift *after* it
+  exists. The PR-time check prevents it being created.
+- **Manifest + PR-time check + size cap.** Chosen. Cost of the losing options: docs that are
+  trusted and wrong, which is worse than docs that are obviously absent.
+
+## Consequences
+
+- A trivial refactor of a covered file now needs either a doc touch or one line of override.
+  That is the intended tax; it is one line, and it forces a moment's thought about whether the
+  doc is still true.
+- The **Archivist gets a real surface** — it currently has none, which is why it is still
+  `Provisional`. Not per-change updates: **own the drift tooling, and sweep the strategy tier**,
+  which is exactly the part CI cannot reach because there is no code to compare against. That
+  is where human judgement earns its cost.
+- Adding a doc to the implementation tier is opt-in: no manifest, no check. Deliberate — it
+  keeps the gate honest rather than universal on day one.
+
+## How this is enforced
+
+`.github/policy_check.py`:
+- `doc-drift` — covered file changed, doc untouched, no `DOC-OK` → fail.
+- `doc-size` — over 40k → fail; over 20k → advisory.
+- `--reconcile <doc>` stamps the current HEAD into the manifest.
+
+Verified before merge: the check fires on a covered change with the doc untouched, and clears
+with `DOC-OK` in a commit message.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -30,9 +30,11 @@ primitive the org has.
 | [0005](ADR-0005-role-registry.md) | One home for the role list | Accepted | Who exists, and who owes registration |
 | [0006](ADR-0006-one-worktree-per-role.md) | One git worktree per role | Accepted | Where every session may work |
 | [0007](ADR-0007-delegation-dispatch-and-utilization.md) | Delegation: board → issues → dispatch | Accepted | How work flows downward, and the concurrency cap |
+| [0008](ADR-0008-documentation-drift.md) | Two doc tiers; drift caught at PR time | Accepted | Anyone changing code a doc describes |
 
 **Roles:** [`ROLES.md`](ROLES.md) is the single home for the role list — `policy` parses it.
 `python3 .github/policy_check.py --who <path>` answers "who owns this?".
+`--reconcile <doc>` stamps a doc's manifest after you have brought it back in line with the code.
 
 ## Conventions
 

--- a/docs/sim-impulse-response.md
+++ b/docs/sim-impulse-response.md
@@ -1,5 +1,14 @@
 # Sim Test — Impulse Disturbance Response
 
+<!--
+covers:
+  - sim/scenarios/impulse_response.py
+  - tests/test_impulse_response.py
+  - sim/models/overboard_onewheel.xml
+  - scripts/render_scenario.py
+reconciled: e4ddb82
+-->
+
 Implementation mirror of the Notion mini design doc
 [Overboard — Sim Test: Impulse Disturbance Response](https://app.notion.com/p/3a8472a5fb6981d8b9e6f749517498dd)
 (GitHub issue [#2](https://github.com/MikePaNtZ/overboard/issues/2)).

--- a/docs/web-artifact-pipeline.md
+++ b/docs/web-artifact-pipeline.md
@@ -1,5 +1,12 @@
 # Landing Page — Hosting & Automatic Sim-Artifact Pipeline
 
+<!--
+covers:
+  - .github/workflows/ci.yml
+  - scripts/render_scenario.py
+reconciled: e4ddb82
+-->
+
 **Status: design only. Nothing here is implemented.** Phases A (sim scenario)
 and B (CI renders + publishes) have shipped; this is the deferred Phase C.
 

--- a/sim/scenarios/impulse_response.py
+++ b/sim/scenarios/impulse_response.py
@@ -447,3 +447,4 @@ def run(
         motor_current_a=np.asarray(currents),
         qpos=np.asarray(states) if states else np.empty(0),
     )
+


### PR DESCRIPTION
Implements the Notion/docs anti-drift design. **Verified firing before merge**, not just passing.

## Why not the obvious approach
Have a role update docs when someone files an issue about drift. That cannot work: **drift is definitionally the thing nobody noticed.** It needs someone to spot it first, and no single role knows what changed *semantically* across three repos. It is the same failure that left two escalation rows deadlocked over a question a merged PR had already settled.

## Two tiers, because docs drift for different reasons
- **Strategy** (charter, M0/M1, P0, roadmap) — describes *intent*, cannot drift from code. Notion stays primary; swept on a cadence.
- **Implementation** (ICD, controls design, sim tests, BoM) — describes *code*. git primary, drift mechanically detectable.

## The mechanism
Each implementation doc carries an invisible manifest:

```
<!--
covers:
  - sim/scenarios/impulse_response.py
  - tests/test_impulse_response.py
reconciled: e4ddb82
-->
```

Change a covered file without touching the doc → **build fails**, unless a commit carries `DOC-OK: <reason>`. Same shape as `TURF-OVERRIDE` (which has now worked three times in one day), so the reason lands in git history rather than an editable field.

**The check never judges content** — only that somebody *looked* since the code moved. That is the checkable part, and it is enough: a human who opens the doc fixes what is wrong.

## Proof it works
```
x doc-drift: docs/sim-impulse-response.md describes sim/scenarios/impulse_response.py,
  which this PR changes, but the doc was not touched.
```
and with the override:
```
doc-drift: ... overridden -- whitespace only, no behavioural change
policy: all hard checks pass
```

## Size cap
40k chars fails, 20k warns. The 55,000-character BoM is the proof case: excellent research, unusable as the thing it claimed to be.

## Turf note
Seeding manifests into `docs/sim-impulse-response.md` (Controls) and `docs/web-artifact-pipeline.md` (Content) is a cross-boundary edit — recorded with `TURF-OVERRIDE` and a reason. Content untouched; only an HTML comment added. Each role owns its manifest from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)