### PR TITLE
ops: ratify the Archivist — Option A, plus docs/vocabulary/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -158,6 +158,23 @@
 /roles/senior-controls/         @MikePaNtZ
 
 # --------------------------------------------------------------------------
+# The canonical term list, in git so a machine can read it.
+#
+# The Archivist owns strategy-tier Notion and vocabulary consistency across all
+# three repos -- but vocabulary lives in EVERY role's files, so granting turf
+# there would be wrong. Those changes land as small PRs with review requested
+# from whoever owns the file. This directory is the one exception, and it earns
+# it: CI cannot read Notion, so a term list that exists only there can never be
+# enforced. Put the retired-to-current mapping here and the policy gate can
+# consume it.
+#
+# Deliberately NOT granted: docs/decisions/INDEX.md. Ratification is the COO's
+# to close (ADR-0001); splitting that authority would defeat the record.
+# --------------------------------------------------------------------------
+# role: Archivist
+/docs/vocabulary/               @MikePaNtZ
+
+# --------------------------------------------------------------------------
 # ROLES THAT OWN NOTHING IN THIS REPO -- stated on purpose, so their absence
 # reads as a decision rather than an oversight.
 #
@@ -165,7 +182,6 @@
 #                              overboard-web; nothing here.
 #   Senior Digital Marketer -- landing page, brand identity, page copy and
 #                              analytics, all in overboard-web. Provisional.
-#   Archivist               -- surface not yet declared. Provisional.
 #
 # Neither sibling repo has a CODEOWNERS yet, so turf is still unfalsifiable in
 # two thirds of the estate. Open item in ADR-0002.

--- a/docs/decisions/ROLES.md
+++ b/docs/decisions/ROLES.md
@@ -43,7 +43,7 @@ All-three-or-none is the definition of `Ratified`. It is **not** a precondition 
 | `Digital Content Production` | Ratified | `Senior Digital Marketer` | `feat/content/` | Renders and published media. Explicitly **not** page markup or CSS |
 | `Sr. Mechanical & Systems` | Ratified | `COO` | `feat/mech/` | BoM, platform selection, the bench rig, the sim-to-hardware fidelity contract |
 | `Senior Controls` | Ratified | `COO` | `feat/controls/` | The control law and its harness |
-| `Archivist` | Provisional | `CEO` | — | *Surface not yet declared* |
+| `Archivist` | Ratified | `CEO` | `feat/archive/` | Strategy-tier Notion, shared vocabulary across all three repos, drift tooling. Owns `docs/vocabulary/` and no other repo path |
 
 ✅ **Branch prefixes for `Sr. Mechanical & Systems` (`feat/mech/`) and `Senior Controls`
 (`feat/controls/`) are now OBSERVED**, not inferred — both appear repeatedly in merged branch
@@ -54,10 +54,10 @@ agent, not by me.
 
 ⚠️ **Still unverified.** Escalation targets for `Sr. Mechanical & Systems` and
 `Senior Controls`, the branch prefixes for `Digital Content Production` and
-`Senior Digital Marketer`, and everything about the `Archivist` are **inferred** — from the
+and the branch prefix for `Senior Digital Marketer` are **inferred** — from the
 COO's own charter ("receives from Sr. Mechanical and Systems Engineering"), from branch
-conventions observed in sibling repos, and from a CEO remark that the Archivist reports
-directly. Inferring turf from a branch prefix is guessing, which is the thing this registry
+conventions observed in sibling repos. The `Archivist` is no longer among them — the CEO
+declared its surface on 2026-07-27 and it was ratified the same day. Inferring turf from a branch prefix is guessing, which is the thing this registry
 exists to stop. Each is flagged rather than asserted, and each wants one line of confirmation
 from the role itself or the CEO. `Provisional` roles stay provisional until that lands.
 

--- a/docs/vocabulary/README.md
+++ b/docs/vocabulary/README.md
@@ -1,0 +1,36 @@
+# Canonical vocabulary — machine-readable
+
+**Owner: Archivist.** Seeded by the COO on ratification; the Archivist owns it from here.
+
+The canonical *definitions* live in
+[Shared Vocabulary (canonical)](https://app.notion.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b).
+This directory exists because **CI cannot read Notion** — so a term list that lives only there
+can never be enforced, and a retired term goes on quietly appearing in issues, docs and role
+files for as long as nobody happens to notice.
+
+That is not hypothetical. On 2026-07-27 "Lane A / Lane B" was retired in favour of
+**Footage · Sim Replay · Hardware Replay · Concept**, and stale copies were still live in one
+issue and two role context files hours later. The documentation-drift gate could not catch it,
+because that gate watches code↔doc, not vocabulary.
+
+## What belongs here
+
+A **retired → current** mapping the policy gate can consume, e.g.
+
+```
+Lane A          -> Sim Replay | Hardware Replay   (a Replay always names its source)
+Lane B          -> Concept
+```
+
+Plus any term whose misuse would mislead — particularly ones that could put an unbacked
+capability claim in front of the public.
+
+## What does not belong here
+
+Definitions, rationale, or the argument for a term. Those are Notion's. Keep this file
+mechanical, so the gate stays cheap and the human-readable version stays single-sourced.
+
+## Status
+
+**Empty by design.** The COO wires a `vocab` check into `.github/policy_check.py` once a
+mapping lands here — this role owns the data, the COO owns the gate.

--- a/roles/archivist/CONTEXT.md
+++ b/roles/archivist/CONTEXT.md
@@ -1,19 +1,41 @@
 # Archivist — working context
 
-- **Worktree:** `~/projects/overboard-archivist` (ADR-0006: one worktree per role, never share a working directory)
-- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
+- **Worktree:** `~/projects/overboard-archivist` (ADR-0006: one worktree per role)
+- **Branch prefix:** `feat/archive/`
+- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md) — **Ratified 2026-07-27**
 - **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
 
-## Status: Provisional (ADR-0005) — surface not yet declared
-Registered with the CEO as escalation target, but **no owned surface has been defined**, so
-this role has nothing to report against and its board section is empty by necessity.
+## Surface
 
-**Open ask to the CEO:** one line on what the Archivist is for, and the COO will scope it.
+Declared by the CEO 2026-07-27, ratified by the COO the same day.
+
+1. **Strategy-tier Notion** — charter, M-series, P0, roadmap. These describe *intent*, so they
+   cannot drift from code and CI can never check them. That is exactly why they need a human
+   sweep, and why it is this role's.
+2. **Shared vocabulary across all three repos.** The canonical definition lives in
+   [Shared Vocabulary](https://app.notion.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b).
+3. **Drift tooling.**
+
+## Turf
+
+Owns **`docs/vocabulary/`** and no other repository path — on purpose. Vocabulary lives in every
+role's files; owning it everywhere would make each sweep a turf negotiation. Vocabulary fixes
+land as **small PRs with review requested from whoever owns the file**, which is how the
+2026-07-27 sweep ran and it worked.
+
+The **policy gate itself** (`.github/policy_check.py`) stays with the COO. Division: this role
+owns the *data* — the retired-to-current term map — and the COO owns the *gate* that consumes
+it. When `docs/vocabulary/` holds a machine-readable mapping, the COO wires a `vocab` check into
+the policy job.
 
 ## Decisions made (append as you go)
 
-_Nothing recorded yet by this role._
+- **2026-07-27 — ratified, Option A plus `docs/vocabulary/`.** The COO granted the term-list
+  directory but not `docs/decisions/INDEX.md`: ratification is the COO's to close under
+  ADR-0001, and splitting that authority would defeat the record.
 
 ## Known dead ends
 
-_Nothing recorded yet._
+- **Notion cannot be reached from CI**, and no scheduled cloud run has the connector. Any
+  vocabulary enforcement must therefore read a term list from **git**, not from Notion. That
+  constraint is why `docs/vocabulary/` exists at all.


### PR DESCRIPTION
Closes the Archivist's [ratification row](https://app.notion.com/p/3aa472a5fb6981148ee0fc5dfd3e7f19).

The CEO declared the surface; three structures still said `Provisional / surface not yet declared`. A fresh session reading `ROLES.md` would conclude the role had no surface and skip it — **the exact stale-record failure the registry was built to prevent.** The Archivist filed rather than self-served, which is right: a role writing its own turf entry defeats the point of a registry.

## Adjudication — Option A, plus one path from B, minus the rest

**✅ Granted `docs/vocabulary/`.** Vocabulary lives in *every* role's files, so owning it everywhere would turn each sweep into a turf negotiation — those correctly land as small PRs with review requested, which is how today's sweep ran. But **CI cannot read Notion**, so a term list that lives only there can never be enforced.

That gap is not hypothetical and it cost us today: the Lane A/B naming was retired in favour of **Footage · Sim Replay · Hardware Replay · Concept**, and stale copies were still live in one issue and two role files hours later — invisible to the documentation-drift gate, because that gate watches code↔doc, not vocabulary. A machine-readable term list in git closes it.

**❌ Refused `docs/decisions/INDEX.md`.** Ratification is the COO's to close under ADR-0001. Splitting that authority would defeat the record.

**Division of labour:** the Archivist owns the **data** (retired → current mapping); the COO owns the **gate** that consumes it. A `vocab` check lands in `policy_check.py` once a mapping exists.

## Also

`Provisional → Ratified`, prefix `feat/archive/` — so the turf check stops failing open on that role's branches. That is the same silent hole that was open on Mechanical and Controls until this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
