### PR TITLE
ops: tests follow the file they test — test_plant_*.py to Mechanical

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,6 +121,8 @@
 /tests/test_bench_*.py          @MikePaNtZ
 # role: Sr. Mechanical & Systems
 /tests/test_imperfections.py    @MikePaNtZ
+# role: Sr. Mechanical & Systems
+/tests/test_plant_*.py          @MikePaNtZ
 
 # --------------------------------------------------------------------------
 # Renders and published media. This role does NOT own the landing page's


### PR DESCRIPTION
Closes Mechanical's [row](https://app.notion.com/p/3aa472a5fb6981c0a064edd187d25b2b).

`plant.py` moved to Mechanical's ownership (ADR-0002 correction) but its tests did not, so **every test of a file that role owns needed another role's review** — the exact friction the ownership map exists to remove.

**Granted.** A test belongs with the thing it tests; splitting them leaves the owner of a behaviour unable to assert it. `test_imperfections.py` already sits with Mechanical for the same reason, so this is consistency rather than a new boundary.

Worth noting the sequencing: **no `test_plant_*.py` exists yet.** Mechanical asked for the rule *before* writing them rather than after, and filed rather than editing CODEOWNERS itself — correctly reasoning that a path map is a Promise under ADR-0002's own logic. That is the protocol working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
