### PR TITLE
Crate-exclusion boundary: zero ridden-mode motion authority, build-proven

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,14 @@ jobs:
       - name: test
         run: cargo test --workspace
 
+      # ICD §6.3 / DR-MODE-1: board-app-ridden must have zero motion
+      # authority, proven by the dependency graph rather than asserted by a
+      # reviewer. canary-ridden is the positive control -- the gate has to
+      # actually flag it, or the check itself has silently stopped working
+      # (issue #1).
+      - name: crate-exclusion boundary gate
+        run: cargo run -p xtask -- gate
+
   # ---------------------------------------------------------------------
   # Sim-in-the-loop gate. Physics only -- no GL, no rendering, ~2 seconds.
   # Runs on every push and PR, and its failure fails the build.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,25 @@
 version = 4
 
 [[package]]
-name = "board-app"
+name = "board-app-driverless"
+version = "0.1.0"
+dependencies = [
+ "board-types",
+ "control-core",
+ "hal",
+ "hal-actuate",
+ "safety",
+ "sim-backend",
+]
+
+[[package]]
+name = "board-app-ridden"
 version = "0.1.0"
 dependencies = [
  "board-types",
  "control-core",
  "hal",
  "safety",
- "sim-backend",
 ]
 
 [[package]]
@@ -18,6 +29,48 @@ name = "board-types"
 version = "0.1.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "canary-ridden"
+version = "0.1.0"
+dependencies = [
+ "board-types",
+ "hal",
+ "hal-actuate",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -45,10 +98,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hal-actuate"
+version = "0.1.0"
+dependencies = [
+ "board-types",
+ "hal",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "proc-macro2"
@@ -73,6 +146,16 @@ name = "safety"
 version = "0.1.0"
 dependencies = [
  "board-types",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -106,11 +189,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sim-backend"
 version = "0.1.0"
 dependencies = [
  "board-types",
  "hal",
+ "hal-actuate",
 ]
 
 [[package]]
@@ -125,7 +222,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vesc-tx"
+version = "0.1.0"
+dependencies = [
+ "vesc-wire",
+]
+
+[[package]]
+name = "vesc-wire"
+version = "0.1.0"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "cargo_metadata",
+ "serde_json",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,17 @@ resolver = "2"
 members = [
     "crates/board-types",
     "crates/hal",
+    "crates/hal-actuate",
+    "crates/vesc-wire",
+    "crates/vesc-tx",
     "crates/control-core",
     "crates/safety",
     "crates/sim-backend",
     "crates/control-ffi",
-    "crates/board-app",
+    "crates/board-app-ridden",
+    "crates/board-app-driverless",
+    "crates/canary-ridden",
+    "crates/xtask",
 ]
 
 [workspace.package]
@@ -18,6 +24,9 @@ license = "MIT"
 [workspace.dependencies]
 board-types = { path = "crates/board-types" }
 hal = { path = "crates/hal" }
+hal-actuate = { path = "crates/hal-actuate" }
+vesc-wire = { path = "crates/vesc-wire" }
+vesc-tx = { path = "crates/vesc-tx" }
 control-core = { path = "crates/control-core" }
 safety = { path = "crates/safety" }
 sim-backend = { path = "crates/sim-backend" }

--- a/crates/board-app-driverless/Cargo.toml
+++ b/crates/board-app-driverless/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
-name = "board-app"
+name = "board-app-driverless"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
 [[bin]]
-name = "board-app"
+name = "board-app-driverless"
 path = "src/main.rs"
 
 [dependencies]
 board-types = { workspace = true }
 hal = { workspace = true }
+hal-actuate = { workspace = true }
 control-core = { workspace = true }
 safety = { workspace = true }
 sim-backend = { workspace = true }

--- a/crates/board-app-driverless/README.md
+++ b/crates/board-app-driverless/README.md
@@ -1,0 +1,15 @@
+# board-app-driverless
+
+The binary that wires `control-core` and `safety` to a `hal` + `hal-actuate`
+backend and runs the ICD §5.2 control loop: **observe → compute → clamp →
+apply**, with `wait_observe()` the only call that advances time. Prints a
+periodic heartbeat showing the cycle, IMU batch size, measured current, and
+both clamp stages.
+
+This is the binary with motion authority — it links `hal-actuate` and
+`sim-backend`. The ridden binary is `board-app-ridden`, which links `hal`
+only and cannot actuate; `crates/xtask` gates that at the dependency-graph
+level.
+
+`--backend sim` and `--backend null` both currently resolve to the
+`sim-backend` stub. Run `board-app-driverless --help` for usage.

--- a/crates/board-app-driverless/src/main.rs
+++ b/crates/board-app-driverless/src/main.rs
@@ -1,5 +1,10 @@
-//! `board-app` wires `control-core` + `safety` to a `hal` backend and runs the
-//! ICD §5.2 control loop.
+//! `board-app-driverless` wires `control-core` + `safety` to a `hal` +
+//! `hal-actuate` backend and runs the ICD §5.2 control loop.
+//!
+//! This is the binary with motion authority (ICD §6.3, DR-MODE-1) — it links
+//! `hal-actuate`. Its ridden counterpart is `board-app-ridden`, which cannot
+//! link `hal-actuate` at all; `crates/xtask` gates that at the dependency
+//! graph, not at review time.
 //!
 //! Today both `--backend sim` and `--backend null` map to the same
 //! `sim-backend` stub, which advances a synthetic clock rather than stepping
@@ -10,7 +15,8 @@
 
 use board_types::Params;
 use control_core::Controller;
-use hal::{BoardActuate, BoardObserve};
+use hal::BoardObserve;
+use hal_actuate::BoardActuate;
 use safety::Envelope;
 use sim_backend::SimBackend;
 use std::process::ExitCode;
@@ -23,10 +29,10 @@ struct Args {
 }
 
 fn print_help() {
-    println!("board-app - Overboard control loop runner");
+    println!("board-app-driverless - Overboard control loop runner (motion authority)");
     println!();
     println!("USAGE:");
-    println!("    board-app [OPTIONS]");
+    println!("    board-app-driverless [OPTIONS]");
     println!();
     println!("OPTIONS:");
     println!("    --backend <sim|null>   Board I/O backend to use (default: sim).");
@@ -83,7 +89,7 @@ fn main() -> ExitCode {
     };
 
     println!(
-        "board-app starting: backend={} cycles={}",
+        "board-app-driverless starting: backend={} cycles={}",
         args.backend, args.cycles
     );
 
@@ -165,7 +171,7 @@ fn main() -> ExitCode {
     }
 
     println!(
-        "board-app: completed {} cycles, exiting cleanly",
+        "board-app-driverless: completed {} cycles, exiting cleanly",
         args.cycles
     );
     ExitCode::SUCCESS

--- a/crates/board-app-ridden/Cargo.toml
+++ b/crates/board-app-ridden/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "board-app-ridden"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "board-app-ridden"
+path = "src/main.rs"
+
+# Deliberately short list. No `hal-actuate`, no `sim-backend` (it implements
+# `hal_actuate::BoardActuate` and would pull the crate in transitively), no
+# wire-encoding crate. `crates/xtask`'s gate asserts `hal-actuate` stays
+# unreachable from here.
+[dependencies]
+board-types = { workspace = true }
+hal = { workspace = true }
+control-core = { workspace = true }
+safety = { workspace = true }

--- a/crates/board-app-ridden/README.md
+++ b/crates/board-app-ridden/README.md
@@ -1,0 +1,21 @@
+# board-app-ridden
+
+The binary that must run under a rider: **zero motion authority, and the
+build proves it** (ICD §6.3, DR-MODE-1).
+
+It links `hal` (`BoardObserve`) only — never `hal-actuate`, `sim-backend`, or
+any wire-encoding crate. `crates/xtask`'s gate walks `cargo metadata`'s
+resolve graph from this crate over normal edges (dev- and build-dependencies
+excluded — they don't ship) and fails the build if `hal-actuate` is
+reachable. That is a stronger guarantee than "no one calls `apply()`": the
+binary is not linked against anything that *could*.
+
+There is no rider, no hardware and no real ridden observe backend yet, so
+this binary currently runs its loop against `ShadowBackend`, a local
+placeholder `BoardObserve` implementation that produces synthetic
+observations (see `src/main.rs`). It exists to prove the shadow-mode shape —
+observe, compute, discard — compiles and runs end to end, with no path to
+`apply()` even available to call. Swapping in a real observe-only hardware
+backend is later work; it does not change this crate's dependency shape.
+
+Its driverless counterpart is `board-app-driverless`.

--- a/crates/board-app-ridden/src/main.rs
+++ b/crates/board-app-ridden/src/main.rs
@@ -1,0 +1,230 @@
+//! `board-app-ridden` wires `control-core` + `safety` to a `hal` backend and
+//! runs the observe-half of the ICD §5.2 loop: **observe → compute →
+//! clamp → discard**.
+//!
+//! This binary has zero motion authority, and that is a **build-proven**
+//! property, not an assertion a reviewer has to re-check every time: it does
+//! not link `hal-actuate`, so there is no `apply()` to call even if a future
+//! edit tried to. `crates/xtask`'s gate double-checks the same thing at the
+//! dependency-graph level, so the guarantee survives `cargo build
+//! --all-features` and a transitive dependency, not just a careful diff.
+//!
+//! [`ShadowBackend`] is a placeholder: there is no rider, no hardware and no
+//! real ridden observe backend yet (Track C, procurement-gated). It produces
+//! synthetic observations purely to exercise the loop shape end to end. The
+//! clamp stage runs and its result is printed, then discarded — there is
+//! nowhere in this binary to send it.
+
+use board_types::{IoError, Observation, Params, Profile, RunMetadata, ValidityFlags};
+use control_core::Controller;
+use hal::BoardObserve;
+use safety::Envelope;
+use std::process::ExitCode;
+
+const DEFAULT_CYCLES: u64 = 100;
+/// Nanoseconds per control cycle. 500 Hz, per ICD §11.2.
+const CYCLE_NS: u64 = 2_000_000;
+
+/// Observe-only placeholder. Produces synthetic observations so the shadow
+/// loop has something to run against; not a plant and not a hardware driver.
+#[derive(Debug, Default)]
+struct ShadowBackend {
+    cycle: u64,
+    t_ns: u64,
+    open: bool,
+}
+
+impl BoardObserve for ShadowBackend {
+    fn open(&mut self) -> Result<(), IoError> {
+        self.open = true;
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), IoError> {
+        self.open = false;
+        Ok(())
+    }
+
+    fn wait_observe(&mut self) -> Result<Observation, IoError> {
+        if !self.open {
+            return Err(IoError::ProtocolViolation);
+        }
+        self.cycle += 1;
+        self.t_ns += CYCLE_NS;
+
+        let mut obs = Observation::COLD_START;
+        obs.cycle = self.cycle;
+        obs.t_recv_ns = self.t_ns;
+        obs.validity = ValidityFlags::ALL_FRESH;
+        Ok(obs)
+    }
+
+    fn run_metadata(&self) -> RunMetadata {
+        RunMetadata {
+            icd_version: (0, 3),
+            profile: Profile::Observe,
+            control_rate_hz: 1e9 / CYCLE_NS as f32,
+            params: Params::default(),
+            imu_mounting_rotation: [1.0, 0.0, 0.0, 0.0],
+            r_eff_m: 0.14605,
+            imperfection_profile_id: None,
+            schema_hash: [0; 32],
+            binary_hash: [0; 32],
+            git_sha: [0; 20],
+        }
+    }
+}
+
+struct Args {
+    cycles: u64,
+}
+
+fn print_help() {
+    println!("board-app-ridden - Overboard shadow-mode loop runner (no motion authority)");
+    println!();
+    println!("USAGE:");
+    println!("    board-app-ridden [OPTIONS]");
+    println!();
+    println!("OPTIONS:");
+    println!("    --cycles <N>   Number of fixed-step cycles to run (default: {DEFAULT_CYCLES}).");
+    println!("    -h, --help     Print this help and exit.");
+}
+
+fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<Args, String> {
+    let mut cycles = DEFAULT_CYCLES;
+
+    while let Some(arg) = argv.next() {
+        match arg.as_str() {
+            "--cycles" => {
+                let val = argv
+                    .next()
+                    .ok_or_else(|| "--cycles requires a value".to_string())?;
+                cycles = val
+                    .parse()
+                    .map_err(|_| format!("--cycles: invalid number '{val}'"))?;
+            }
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unrecognized argument '{other}'")),
+        }
+    }
+
+    Ok(Args { cycles })
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args(std::env::args().skip(1)) {
+        Ok(args) => args,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            print_help();
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!(
+        "board-app-ridden starting: cycles={} (no motion authority)",
+        args.cycles
+    );
+
+    let params = Params {
+        max_current_a: 40.0,
+        max_abs_pitch_rad: 0.5,
+        ..Params::default()
+    };
+
+    let mut backend = ShadowBackend::default();
+    let mut controller = Controller::new(params);
+    // Armed so the clamp stage behaves the same as it would on the driverless
+    // path -- there is nothing downstream to send the result to either way.
+    let mut envelope = Envelope::new(params);
+    envelope.arm();
+
+    if let Err(e) = backend.open() {
+        eprintln!("error: backend open failed: {e:?}");
+        return ExitCode::FAILURE;
+    }
+
+    for i in 0..args.cycles {
+        let obs = match backend.wait_observe() {
+            Ok(obs) => obs,
+            Err(board_types::IoError::Transient) => continue,
+            Err(e) => {
+                eprintln!("error: wait_observe failed at cycle {i}: {e:?}");
+                return ExitCode::FAILURE;
+            }
+        };
+
+        let proposed = controller.update(&obs);
+        // Computed and clamped, same as the driverless path -- but there is no
+        // `apply()` in scope to send it to. This binary cannot actuate.
+        let (cmd, saturated) = envelope.apply(proposed, board_types::Faults(obs.fault_word));
+
+        if i % 20 == 0 || i == args.cycles.saturating_sub(1) {
+            println!(
+                "heartbeat: cycle={} t_recv_ns={} would_command={cmd:?} sat={saturated:?} (discarded, no apply() in this binary)",
+                obs.cycle, obs.t_recv_ns,
+            );
+        }
+    }
+
+    if let Err(e) = backend.close() {
+        eprintln!("error: backend close failed: {e:?}");
+        return ExitCode::FAILURE;
+    }
+
+    println!(
+        "board-app-ridden: completed {} cycles, exiting cleanly",
+        args.cycles
+    );
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_defaults() {
+        let args = parse_args(std::iter::empty()).unwrap();
+        assert_eq!(args.cycles, DEFAULT_CYCLES);
+    }
+
+    #[test]
+    fn parse_args_accepts_cycles() {
+        let argv = vec!["--cycles".to_string(), "5".to_string()];
+        let args = parse_args(argv.into_iter()).unwrap();
+        assert_eq!(args.cycles, 5);
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_flag() {
+        let argv = vec!["--backend".to_string(), "sim".to_string()];
+        assert!(parse_args(argv.into_iter()).is_err());
+    }
+
+    #[test]
+    fn shadow_backend_advances_cycle_and_clock() {
+        let mut b = ShadowBackend::default();
+        b.open().unwrap();
+        let o1 = b.wait_observe().unwrap();
+        let o2 = b.wait_observe().unwrap();
+        assert_eq!(o1.cycle, 1);
+        assert_eq!(o2.cycle, 2);
+        assert_eq!(o2.t_recv_ns - o1.t_recv_ns, CYCLE_NS);
+    }
+
+    #[test]
+    fn shadow_backend_refuses_observe_before_open() {
+        let mut b = ShadowBackend::default();
+        assert_eq!(b.wait_observe(), Err(IoError::ProtocolViolation));
+    }
+
+    #[test]
+    fn shadow_backend_reports_observe_only_profile() {
+        let b = ShadowBackend::default();
+        assert_eq!(b.run_metadata().profile, Profile::Observe);
+    }
+}

--- a/crates/board-app/README.md
+++ b/crates/board-app/README.md
@@ -1,9 +1,0 @@
-# board-app
-
-The binary that wires `control-core` and `safety` to a `hal` backend and runs
-the ICD §5.2 control loop: **observe → compute → clamp → apply**, with
-`wait_observe()` the only call that advances time. Prints a periodic heartbeat
-showing the cycle, IMU batch size, measured current, and both clamp stages.
-
-`--backend sim` and `--backend null` both currently resolve to the
-`sim-backend` stub. Run `board-app --help` for usage.

--- a/crates/canary-ridden/Cargo.toml
+++ b/crates/canary-ridden/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "canary-ridden"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "canary-ridden"
+path = "src/main.rs"
+
+# NOT a template to copy. This crate exists to be a mistake --
+# `hal-actuate` should never be a dependency of a ridden-shaped binary --
+# and `crates/xtask`'s gate has to have something real to catch it on.
+[dependencies]
+board-types = { workspace = true }
+hal = { workspace = true }
+hal-actuate = { workspace = true }

--- a/crates/canary-ridden/src/main.rs
+++ b/crates/canary-ridden/src/main.rs
@@ -1,0 +1,84 @@
+//! Positive control for `crates/xtask`'s dependency-graph gate.
+//!
+//! This binary is deliberately shaped like `board-app-ridden` but links
+//! `hal-actuate` anyway — the exact mistake the real crate split exists to
+//! catch (issue #1: a copy-pasted `main.rs` that keeps the `BoardActuate`
+//! import, or a "just for now" dependency that never gets removed). The gate
+//! is required to flag this crate. If it stops flagging `canary-ridden` —
+//! because the marker crate was renamed and the gate wasn't updated, or the
+//! walk logic regressed — that is exactly the silent failure mode this
+//! canary is here to turn loud instead.
+//!
+//! Not built or run as part of the normal loop; `cargo build --workspace`
+//! compiles it (proving the graph edge is real, not just declared and
+//! unused), and `xtask` is what actually inspects it.
+
+use board_types::{Applied, Command, DisarmReason, IoError, Observation, RunMetadata};
+use hal::BoardObserve;
+use hal_actuate::{BoardActuate, Disarm};
+
+struct CanaryDisarm;
+
+impl Disarm for CanaryDisarm {
+    fn disarm(&self, _reason: DisarmReason) -> Result<(), IoError> {
+        Ok(())
+    }
+}
+
+/// A backend that -- wrongly, for anything shaped like the ridden binary --
+/// implements both halves of the seam.
+#[derive(Default)]
+struct CanaryBackend;
+
+impl BoardObserve for CanaryBackend {
+    fn open(&mut self) -> Result<(), IoError> {
+        Ok(())
+    }
+    fn close(&mut self) -> Result<(), IoError> {
+        Ok(())
+    }
+    fn wait_observe(&mut self) -> Result<Observation, IoError> {
+        Ok(Observation::COLD_START)
+    }
+    fn run_metadata(&self) -> RunMetadata {
+        RunMetadata {
+            icd_version: (0, 3),
+            profile: board_types::Profile::DRaw,
+            control_rate_hz: 500.0,
+            params: Default::default(),
+            imu_mounting_rotation: [1.0, 0.0, 0.0, 0.0],
+            r_eff_m: 0.14605,
+            imperfection_profile_id: None,
+            schema_hash: [0; 32],
+            binary_hash: [0; 32],
+            git_sha: [0; 20],
+        }
+    }
+}
+
+impl BoardActuate for CanaryBackend {
+    type Disarm = CanaryDisarm;
+
+    fn arm(&mut self) -> Result<Self::Disarm, IoError> {
+        Ok(CanaryDisarm)
+    }
+
+    fn apply(&mut self, cmd: &Command) -> Result<Applied, IoError> {
+        Ok(Applied {
+            commanded: *cmd,
+            saturated: board_types::Saturation::No,
+            t_apply_ns: 0,
+        })
+    }
+}
+
+fn main() {
+    println!(
+        "canary-ridden: this binary links hal-actuate on purpose -- \
+         the gate in `cargo run -p xtask -- gate` must fail if it does not flag this crate."
+    );
+    let mut backend = CanaryBackend;
+    let _ = backend.open();
+    let _disarm = backend.arm();
+    let _ = backend.apply(&Command::ZERO);
+}

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -9,8 +9,8 @@
 //! value is being singular.
 //!
 //! So the physics calls the controller, not the other way round. That is the
-//! opposite of the eventual hardware arrangement, where `board-app` owns the
-//! loop and calls `BoardActuate` — and that is fine, because **the portable
+//! opposite of the eventual hardware arrangement, where `board-app-driverless`
+//! owns the loop and calls `BoardActuate` — and that is fine, because **the portable
 //! part is [`control_core::PitchRegulator`] and [`safety::Envelope`]**, both of
 //! which are exercised here exactly as they will be on hardware. Only the
 //! direction of the call differs, and switching it later means deleting this

--- a/crates/hal-actuate/Cargo.toml
+++ b/crates/hal-actuate/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sim-backend"
+name = "hal-actuate"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -7,4 +7,3 @@ license.workspace = true
 [dependencies]
 board-types = { workspace = true }
 hal = { workspace = true }
-hal-actuate = { workspace = true }

--- a/crates/hal-actuate/src/lib.rs
+++ b/crates/hal-actuate/src/lib.rs
@@ -1,0 +1,53 @@
+//! Motion authority — the half of the `hal` seam the ridden binary must never
+//! link (BoardIo ICD §6.3, DR-MODE-1).
+//!
+//! [`BoardActuate`] and [`Disarm`] used to live in `hal` itself, split out
+//! only by trait. That is not the property this project needs: a trait split
+//! survives a careful reviewer, but not `cargo build --workspace
+//! --all-features`, not a transitive dependency, not a dev-dependency of a
+//! shared crate. Cargo features are additive and unify across the whole
+//! dependency graph; **absence of a dependency does not unify**, which is why
+//! motion authority lives in its own crate instead.
+//!
+//! `crates/xtask`'s gate walks `cargo metadata`'s resolve graph from
+//! `board-app-ridden` over normal edges (dev- and build-dependencies excluded
+//! on purpose — they don't ship) and fails the build if this crate is
+//! reachable. `crates/canary-ridden` is the positive control: it deliberately
+//! depends on this crate so the gate has something it is required to catch.
+#![no_std]
+
+use board_types::{Applied, Command, DisarmReason, IoError};
+use hal::BoardObserve;
+
+/// A disarm capability that outlives the control thread.
+///
+/// ICD §9.2 requires disarm to be callable from a wedged or panicking loop,
+/// from a watchdog thread, a signal handler or a panic hook. That rules out
+/// `disarm(&mut self)` on the backend — `&mut self` means only the thread that
+/// owns the backend may call it, which is precisely the thread that is stuck.
+///
+/// Realised as an associated type rather than the ICD's concrete struct so each
+/// backend can carry its own pre-opened handle and pre-encoded safe-state
+/// frame. The contract is unchanged.
+///
+/// Implementations **must not** allocate, lock, or block unboundedly —
+/// everything needed is prepared at `arm()` time — and **must** be idempotent,
+/// because several paths may race to call it.
+pub trait Disarm: Send + Sync {
+    fn disarm(&self, reason: DisarmReason) -> Result<(), IoError>;
+}
+
+/// Motion authority. Kept in a separate crate from [`hal::BoardObserve`] so a
+/// binary can be built without ever linking it — DR-MODE-1's shadow-mode
+/// shape, enforced at the dependency graph rather than by a runtime check.
+pub trait BoardActuate: BoardObserve {
+    /// The disarm capability handed out by [`BoardActuate::arm`].
+    type Disarm: Disarm;
+
+    /// Enable motion, returning the disarm handle.
+    fn arm(&mut self) -> Result<Self::Disarm, IoError>;
+
+    /// Enqueue a command. Does **not** advance time. Returns the post-clamp
+    /// value so anti-windup can be driven synchronously (ICD §7.6).
+    fn apply(&mut self, cmd: &Command) -> Result<Applied, IoError>;
+}

--- a/crates/hal/README.md
+++ b/crates/hal/README.md
@@ -2,20 +2,26 @@
 
 The seam between `control-core` and whatever actually drives the wheel.
 
-Two traits, deliberately separate (BoardIo ICD §6.1):
+Observing and actuating are separate **crates**, not just separate traits
+(BoardIo ICD §6.1, §6.3):
 
-- **`BoardObserve`** — `open` / `close` / `wait_observe` / `run_metadata`. The
-  ridden binary links exactly this and nothing more.
-- **`BoardActuate`** — `arm` / `apply`, plus the `Disarm` handle. A binary that
-  never links it *cannot* actuate, so shadow mode is enforced by the compiler
-  rather than by a runtime check.
+- **`hal`** (this crate) — `BoardObserve`: `open` / `close` / `wait_observe` /
+  `run_metadata`. The ridden binary links exactly this and nothing more.
+- **`hal-actuate`** — `BoardActuate`: `arm` / `apply`, plus the `Disarm`
+  handle. The ridden binary must not depend on this crate at all. A trait
+  split alone survives a careful reviewer; it does not survive
+  `cargo build --workspace --all-features` or a transitive dev-dependency,
+  because cargo features unify across the whole graph. Absence of a
+  dependency does not unify — that's the property `crates/xtask`'s gate
+  asserts by walking `cargo metadata`'s resolve graph from `board-app-ridden`
+  and failing if `hal-actuate` is reachable over a normal edge.
 
 `wait_observe()` is the **sole time-advancing call**: in sim it steps physics to
 the next control instant, on hardware it blocks on the IMU. `apply()` enqueues
 and never advances time, so actuation delay stays additive on top of the
 structural loop delay instead of being folded into it. Zero or one `apply()` per
-`wait_observe()` — zero is the shadow-mode shape. `CallSequence` enforces those
-rules for both backends so they cannot drift apart.
+`wait_observe()` — zero is the shadow-mode shape. `CallSequence` (in this
+crate) enforces those rules for both backends so they cannot drift apart.
 
 This replaced a single `cycle(cmd)` call that returned an `Observation`
 (DR-BOARDIO-1, amended). That signature conflated observing with actuating,

--- a/crates/hal/src/lib.rs
+++ b/crates/hal/src/lib.rs
@@ -15,9 +15,9 @@
 //! - [`BoardObserve::wait_observe`] is the **sole** time-advancing call. In sim
 //!   it steps physics to the next control instant; on hardware it blocks on the
 //!   IMU/timer.
-//! - [`BoardActuate::apply`] enqueues and **never** advances time. Actuation
-//!   delay is **additive** on top of the structural loop delay, not inclusive
-//!   of it.
+//! - `hal_actuate::BoardActuate::apply` enqueues and **never** advances time.
+//!   Actuation delay is **additive** on top of the structural loop delay, not
+//!   inclusive of it.
 //! - Zero or one `apply()` per `wait_observe()`. **Zero is legal** — it is the
 //!   shadow-mode loop shape (§6.6).
 //!
@@ -28,21 +28,18 @@
 //!
 //! # Motion authority
 //!
-//! [`BoardObserve`] and [`BoardActuate`] are separate traits so a binary can
-//! link the first without the second: shadow mode then fails to compile if it
-//! ever tries to actuate, rather than being prevented by a runtime check
-//! (DR-MODE-1).
-//!
-//! > **Deferred:** ICD §6.3 requires `BoardActuate` implementations and the
-//! > wire encoders to live in a *separate crate* the ridden binary does not
-//! > depend on, with CI asserting the dependency graph. That is not yet done —
-//! > there is no rider, no hardware and no ridden profile to protect. The trait
-//! > split here is the part that has present value; the crate split must land
-//! > **before the ballasted-dummy bench gate**, and DR-MODE-1 stays unmet until
-//! > it does.
+//! Observing and actuating are separate **crates**, not just separate traits:
+//! `BoardObserve` lives here; `BoardActuate` and `Disarm` live in
+//! `hal-actuate`, which the ridden binary must not depend on (ICD §6.3,
+//! DR-MODE-1). A trait split alone does not survive `cargo build
+//! --all-features` or a transitive dependency — cargo features unify across
+//! the whole graph, but **absence of a dependency does not unify**. The
+//! `xtask` gate asserts `hal-actuate` is unreachable from `board-app-ridden`
+//! by walking `cargo metadata`'s resolve graph over normal edges; see
+//! `crates/xtask`.
 #![no_std]
 
-use board_types::{Applied, Command, DisarmReason, IoError, Observation, RunMetadata};
+use board_types::{IoError, Observation, RunMetadata};
 
 /// Observation and metadata. The ridden binary links exactly this and nothing
 /// more.
@@ -59,38 +56,6 @@ pub trait BoardObserve {
 
     /// Backend-owned run provenance for the MCAP header (ICD §6.2).
     fn run_metadata(&self) -> RunMetadata;
-}
-
-/// A disarm capability that outlives the control thread.
-///
-/// ICD §9.2 requires disarm to be callable from a wedged or panicking loop,
-/// from a watchdog thread, a signal handler or a panic hook. That rules out
-/// `disarm(&mut self)` on the backend — `&mut self` means only the thread that
-/// owns the backend may call it, which is precisely the thread that is stuck.
-///
-/// Realised as an associated type rather than the ICD's concrete struct so each
-/// backend can carry its own pre-opened handle and pre-encoded safe-state
-/// frame. The contract is unchanged.
-///
-/// Implementations **must not** allocate, lock, or block unboundedly —
-/// everything needed is prepared at `arm()` time — and **must** be idempotent,
-/// because several paths may race to call it.
-pub trait Disarm: Send + Sync {
-    fn disarm(&self, reason: DisarmReason) -> Result<(), IoError>;
-}
-
-/// Motion authority. Kept separate from [`BoardObserve`] so it can be left
-/// unlinked entirely.
-pub trait BoardActuate: BoardObserve {
-    /// The disarm capability handed out by [`BoardActuate::arm`].
-    type Disarm: Disarm;
-
-    /// Enable motion, returning the disarm handle.
-    fn arm(&mut self) -> Result<Self::Disarm, IoError>;
-
-    /// Enqueue a command. Does **not** advance time. Returns the post-clamp
-    /// value so anti-windup can be driven synchronously (ICD §7.6).
-    fn apply(&mut self, cmd: &Command) -> Result<Applied, IoError>;
 }
 
 /// Enforces the §5.2 call-sequence rules: zero-or-one `apply()` per

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -20,12 +20,19 @@
 //!   imperfection profile.
 //! - **Cold start reports `Invalid`, not zeros.** A backend presenting zeros as
 //!   measurements before the drive has spoken is non-conforming (§12).
+//!
+//! [`SimBackend`] implements both [`hal::BoardObserve`] and
+//! [`hal_actuate::BoardActuate`], which makes this crate **driverless-only**:
+//! depending on it pulls in `hal-actuate` transitively, so `board-app-ridden`
+//! must not link it. `board-app-ridden` gets its own observe-only backend
+//! instead.
 
 use board_types::{
     Applied, Command, DisarmReason, ImuSample, IoError, Observation, Params, Profile, RunMetadata,
     Saturation, ValidityFlags,
 };
-use hal::{BoardActuate, BoardObserve, CallSequence, Disarm};
+use hal::{BoardObserve, CallSequence};
+use hal_actuate::{BoardActuate, Disarm};
 
 /// Nanoseconds per control cycle. 500 Hz, per ICD §11.2.
 const CYCLE_NS: u64 = 2_000_000;

--- a/crates/vesc-tx/Cargo.toml
+++ b/crates/vesc-tx/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "vesc-tx"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+vesc-wire = { workspace = true }

--- a/crates/vesc-tx/src/lib.rs
+++ b/crates/vesc-tx/src/lib.rs
@@ -1,0 +1,65 @@
+//! VESC CAN wire format — **encoders only**. This is the crate `hal-actuate`
+//! implementations depend on to build actuation frames, and therefore the
+//! crate `board-app-ridden` must never reach.
+//!
+//! ICD §6.3's motion-authority boundary is only as strong as the set of
+//! crates that can *build* an actuation frame — `remote_command_input()`
+//! bypasses every VESC-side config the wire alone cannot see, so the ridden
+//! binary's safety rests entirely on never linking anything that can produce
+//! a `SET_CURRENT` or `COMMAND_REMOTE` frame in the first place (issue #1).
+//! `crates/xtask`'s gate asserts this crate is unreachable from
+//! `board-app-ridden`'s normal dependency edges; `crates/canary-ridden`
+//! deliberately violates that so the gate has something to catch.
+//!
+//! **Byte layouts are not yet transcribed** — see `vesc-wire`'s module docs
+//! for why. This crate exists now, ahead of the hardware that would let a
+//! layout be verified, purely to prove the exclusion boundary before the
+//! first line of real CAN TX code exists (Track C, procurement-gated).
+#![no_std]
+
+use vesc_wire::RawFrame;
+
+/// Why a command could not be encoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodeError {
+    /// The byte layout for this packet has not been transcribed from the ICD
+    /// yet.
+    NotYetImplemented,
+}
+
+/// Encode a `SET_CURRENT` frame — the D-RAW profile's raw-current setpoint.
+///
+/// **Not yet implemented** — see the module docs. Returns
+/// [`EncodeError::NotYetImplemented`] rather than a frame nothing has
+/// verified against real hardware.
+pub fn encode_set_current(_amps: f32) -> Result<RawFrame, EncodeError> {
+    Err(EncodeError::NotYetImplemented)
+}
+
+/// Encode a `COMMAND_REMOTE` frame — the D-REMOTE profile's Refloat setpoint
+/// relay. This is the specific frame issue #1 names as bypassing
+/// `inputtilt_remote_type` entirely, which is exactly why building one is
+/// confined to this crate and this crate alone.
+///
+/// **Not yet implemented** — see the module docs.
+pub fn encode_command_remote(_m_s: f32) -> Result<RawFrame, EncodeError> {
+    Err(EncodeError::NotYetImplemented)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_current_reports_not_yet_implemented_not_a_fabricated_frame() {
+        assert_eq!(encode_set_current(5.0), Err(EncodeError::NotYetImplemented));
+    }
+
+    #[test]
+    fn command_remote_reports_not_yet_implemented_not_a_fabricated_frame() {
+        assert_eq!(
+            encode_command_remote(2.5),
+            Err(EncodeError::NotYetImplemented)
+        );
+    }
+}

--- a/crates/vesc-wire/Cargo.toml
+++ b/crates/vesc-wire/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vesc-wire"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/crates/vesc-wire/src/lib.rs
+++ b/crates/vesc-wire/src/lib.rs
@@ -1,0 +1,91 @@
+//! VESC CAN wire format — constants and **decode only**.
+//!
+//! Deliberately decode-only: an encoder here would hand every crate that
+//! depends on this one — including anything the ridden binary might
+//! link — the raw materials to assemble an actuation frame. Encoders for
+//! `SET_CURRENT` and `COMMAND_REMOTE` live in `vesc-tx`, which the ridden
+//! binary must never depend on (ICD §6.3); this crate carries no such
+//! restriction, because decoding a status frame grants no motion authority.
+//!
+//! **Byte layouts are not yet transcribed.** This crate exists now, ahead of
+//! need, to prove the crate-exclusion boundary can hold (`crates/xtask`'s
+//! gate, `crates/canary-ridden`'s positive control) before the first line of
+//! real CAN code exists — Track C is procurement-gated, and there is no
+//! hardware yet to validate a byte layout against. Filling in the real
+//! packet IDs and field offsets from the ICD is separate, traceable work;
+//! [`decode_motor_current_a`] reports [`DecodeError::NotYetImplemented`]
+//! rather than a fabricated value in the meantime.
+#![no_std]
+
+/// One CAN frame as received from the bus: an arbitration ID and up to 8 data
+/// bytes. The shared shape decode (here) and encode (`vesc-tx`) both operate
+/// on; the two crates do not depend on each other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RawFrame {
+    pub id: u32,
+    pub len: u8,
+    pub data: [u8; 8],
+}
+
+impl RawFrame {
+    /// The populated prefix of `data`. Mirrors
+    /// `Observation::imu_samples`'s "only iterate the populated prefix" rule
+    /// — the backing array is fixed-size, `len` says how much of it is real.
+    pub fn bytes(&self) -> &[u8] {
+        &self.data[..self.len as usize]
+    }
+}
+
+/// Why a frame could not be decoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The frame's length or arbitration ID does not match any packet type
+    /// this crate knows about.
+    Unrecognized,
+    /// The packet type is real but its byte layout has not been transcribed
+    /// from the ICD into this crate yet.
+    NotYetImplemented,
+}
+
+/// Decode a VESC drive-status frame's motor current.
+///
+/// **Not yet implemented** — see the module docs. Returns
+/// [`DecodeError::NotYetImplemented`] for every input rather than a value
+/// nothing has verified.
+pub fn decode_motor_current_a(_frame: RawFrame) -> Result<f32, DecodeError> {
+    Err(DecodeError::NotYetImplemented)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_frame_bytes_exposes_only_the_populated_prefix() {
+        let mut data = [0u8; 8];
+        data[0] = 0xAA;
+        data[1] = 0xBB;
+        let frame = RawFrame {
+            id: 9,
+            len: 2,
+            data,
+        };
+        assert_eq!(frame.bytes(), &[0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn undecoded_layouts_report_not_yet_implemented_not_a_fabricated_value() {
+        // The point of this crate existing before hardware does: it must
+        // never invent a current reading it cannot back with a verified
+        // layout.
+        let frame = RawFrame {
+            id: 0,
+            len: 0,
+            data: [0; 8],
+        };
+        assert_eq!(
+            decode_motor_current_a(frame),
+            Err(DecodeError::NotYetImplemented)
+        );
+    }
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "xtask"
+path = "src/main.rs"
+
+[dependencies]
+cargo_metadata = "0.23"
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,0 +1,301 @@
+//! Dependency-graph gate for issue #1: proves `hal-actuate` (motion
+//! authority) is unreachable from `board-app-ridden` at build time, rather
+//! than trusting a reviewer to notice a stray import.
+//!
+//! `cargo metadata`'s resolve graph already tells us, per edge, whether a
+//! dependency is `Normal`, `Development` (dev-dependency) or `Build`
+//! (build-dependency). Only `Normal` edges ship in the built binary — a
+//! dev-dependency of some crate `board-app-ridden` happens to depend on does
+//! not make it into the linked artifact, so it must not fail the gate
+//! (issue #1's attack-list row 1). The walk below follows normal edges only,
+//! and does so transitively, so `ridden -> shared -> vesc-tx` fails exactly
+//! as `ridden -> vesc-tx` would (row 3).
+//!
+//! Run as `cargo run -p xtask -- gate` (also the default with no
+//! subcommand, so a bare `cargo run -p xtask` in CI does the right thing).
+
+use cargo_metadata::{CargoOpt, DependencyKind, Metadata, MetadataCommand, NodeDep, PackageId};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::process::ExitCode;
+
+const RIDDEN: &str = "board-app-ridden";
+const MARKER: &str = "hal-actuate";
+const CANARY: &str = "canary-ridden";
+
+/// True if at least one target (lib, bin, test, ...) links `dep` normally.
+/// The same package can appear with several `dep_kinds` when different
+/// targets depend on it differently; if *any* of them is `Normal`, the crate
+/// ships, so the edge counts as reachable.
+fn has_normal_edge(dep: &NodeDep) -> bool {
+    dep.dep_kinds
+        .iter()
+        .any(|k| k.kind == DependencyKind::Normal)
+}
+
+/// Adjacency over normal edges only, keyed by the opaque package id string.
+struct Graph {
+    edges: HashMap<String, Vec<String>>,
+}
+
+impl Graph {
+    fn from_metadata(meta: &Metadata) -> Result<Self, String> {
+        let resolve = meta.resolve.as_ref().ok_or_else(|| {
+            "`cargo metadata` returned no resolve graph -- is this workspace missing a lockfile?"
+                .to_string()
+        })?;
+
+        let mut edges = HashMap::new();
+        for node in &resolve.nodes {
+            let normal: Vec<String> = node
+                .deps
+                .iter()
+                .filter(|d| has_normal_edge(d))
+                .map(|d| d.pkg.repr.clone())
+                .collect();
+            edges.insert(node.id.repr.clone(), normal);
+        }
+        Ok(Graph { edges })
+    }
+
+    /// Every package transitively reachable from `start` over normal edges,
+    /// not including `start` itself.
+    fn reachable_from(&self, start: &str) -> HashSet<String> {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<String> = VecDeque::new();
+        queue.push_back(start.to_string());
+        seen.insert(start.to_string());
+
+        while let Some(id) = queue.pop_front() {
+            for dep in self.edges.get(&id).into_iter().flatten() {
+                if seen.insert(dep.clone()) {
+                    queue.push_back(dep.clone());
+                }
+            }
+        }
+        seen.remove(start);
+        seen
+    }
+}
+
+/// Finds a workspace package by name. Deliberately an `Err`, not a silent
+/// "not found -> nothing to check": issue #1's attack list requires the gate
+/// to fail loudly if the marker crate is ever renamed, rather than quietly
+/// passing because it no longer recognises the name it is looking for.
+fn find_package_id(meta: &Metadata, name: &str) -> Result<PackageId, String> {
+    meta.packages
+        .iter()
+        .find(|p| p.name == name)
+        .map(|p| p.id.clone())
+        .ok_or_else(|| {
+            format!(
+                "package '{name}' was not found in `cargo metadata` output -- \
+                 was it renamed or removed? the gate does not know what to check \
+                 and must fail rather than silently pass."
+            )
+        })
+}
+
+/// Runs both halves of the gate against one resolve graph (one feature
+/// configuration): the real check, and its positive control.
+fn check_boundary(meta: &Metadata, config_label: &str) -> Result<(), String> {
+    let graph = Graph::from_metadata(meta)?;
+
+    let ridden = find_package_id(meta, RIDDEN)?;
+    let marker = find_package_id(meta, MARKER)?;
+    let canary = find_package_id(meta, CANARY)?;
+
+    let from_ridden = graph.reachable_from(&ridden.repr);
+    if from_ridden.contains(&marker.repr) {
+        return Err(format!(
+            "[{config_label}] {RIDDEN} can reach {MARKER} over a normal dependency edge. \
+             The ridden binary must have zero motion authority (BoardIo ICD S6.3, DR-MODE-1)."
+        ));
+    }
+
+    // Positive control (issue #1): if `canary-ridden`, which depends on
+    // `hal-actuate` on purpose, is NOT flagged as reaching it, the checker
+    // itself is broken -- e.g. the marker name changed and this file was not
+    // updated -- and that is a worse failure than the boundary itself
+    // breaking, because it fails silently.
+    let from_canary = graph.reachable_from(&canary.repr);
+    if !from_canary.contains(&marker.repr) {
+        return Err(format!(
+            "[{config_label}] positive control failed: {CANARY} does not reach {MARKER}, \
+             but it is supposed to depend on it directly. The gate is not working."
+        ));
+    }
+
+    Ok(())
+}
+
+fn run_gate() -> Result<(), String> {
+    let default_meta = MetadataCommand::new()
+        .exec()
+        .map_err(|e| format!("`cargo metadata` failed: {e}"))?;
+    check_boundary(&default_meta, "default features")?;
+
+    // Attack-list row 2: cargo features are additive and unify across the
+    // whole dependency graph, which is exactly what defeated the earlier
+    // cargo-feature-gated `actuate` approach. Re-running metadata with every
+    // feature enabled is what actually exercises that failure mode, rather
+    // than trusting the default resolve to still hold under
+    // `cargo build --workspace --all-features`.
+    let all_features_meta = MetadataCommand::new()
+        .features(CargoOpt::AllFeatures)
+        .exec()
+        .map_err(|e| format!("`cargo metadata --all-features` failed: {e}"))?;
+    check_boundary(&all_features_meta, "--all-features")?;
+
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        None | Some("gate") => {}
+        Some(other) => {
+            eprintln!("xtask: unknown subcommand '{other}' (expected 'gate' or no argument)");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    match run_gate() {
+        Ok(()) => {
+            println!(
+                "xtask gate: {MARKER} is unreachable from {RIDDEN} \
+                 (checked under default features and --all-features); \
+                 {CANARY} was correctly flagged as reaching it."
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("xtask gate FAILED: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------
+    // Graph reachability -- exercised against synthetic graphs so these
+    // stay fast and do not depend on the real workspace shape.
+    // -----------------------------------------------------------------
+
+    fn graph_from(edges: &[(&str, &str)]) -> Graph {
+        let mut g = Graph {
+            edges: HashMap::new(),
+        };
+        for (from, to) in edges {
+            g.edges
+                .entry(from.to_string())
+                .or_default()
+                .push(to.to_string());
+        }
+        g
+    }
+
+    #[test]
+    fn direct_normal_edge_is_reachable() {
+        let g = graph_from(&[("ridden", "marker")]);
+        assert!(g.reachable_from("ridden").contains("marker"));
+    }
+
+    #[test]
+    fn attack_row_3_transitive_normal_edge_is_reachable() {
+        // "telemetry -> vesc-tx transitively" from issue #1's attack list:
+        // the walk must not stop at the first hop.
+        let g = graph_from(&[("ridden", "telemetry"), ("telemetry", "vesc-tx")]);
+        assert!(g.reachable_from("ridden").contains("vesc-tx"));
+    }
+
+    #[test]
+    fn unrelated_package_is_not_reachable() {
+        let g = graph_from(&[("ridden", "hal"), ("driverless", "marker")]);
+        assert!(!g.reachable_from("ridden").contains("marker"));
+    }
+
+    #[test]
+    fn attack_row_1_dev_only_edge_never_enters_the_graph() {
+        // A dev-dependency edge is filtered out before it reaches `Graph` at
+        // all (see `has_normal_edge`), so a graph built only from that
+        // relationship has no edge for the walk to find -- mirroring "gate
+        // passes" for a vesc-tx dev-dependency of a shared crate.
+        let g = graph_from(&[("ridden", "shared")]); // shared -> vesc-tx omitted: dev-only
+        assert!(!g.reachable_from("ridden").contains("vesc-tx"));
+    }
+
+    #[test]
+    fn a_package_does_not_reach_itself() {
+        let g = graph_from(&[("ridden", "ridden")]);
+        assert!(!g.reachable_from("ridden").contains("ridden"));
+    }
+
+    // -----------------------------------------------------------------
+    // dep_kinds filtering -- exercised against real cargo_metadata types,
+    // deserialized from the same JSON shape `cargo metadata` emits, so this
+    // tests the actual parsing logic rather than a paraphrase of it.
+    // -----------------------------------------------------------------
+
+    fn node_dep(dep_kinds_json: &str) -> NodeDep {
+        let json =
+            format!(r#"{{"name":"x","pkg":"path+file:///x#0.1.0","dep_kinds":{dep_kinds_json}}}"#);
+        serde_json::from_str(&json).expect("fixture JSON must match NodeDep's schema")
+    }
+
+    #[test]
+    fn normal_kind_counts_as_a_normal_edge() {
+        // `cargo metadata` represents the normal kind as a JSON `null`, not
+        // the string "normal".
+        let dep = node_dep(r#"[{"kind":null,"target":null}]"#);
+        assert!(has_normal_edge(&dep));
+    }
+
+    #[test]
+    fn attack_row_1_dev_only_kind_does_not_count_as_a_normal_edge() {
+        let dep = node_dep(r#"[{"kind":"dev","target":null}]"#);
+        assert!(!has_normal_edge(&dep));
+    }
+
+    #[test]
+    fn build_only_kind_does_not_count_as_a_normal_edge() {
+        let dep = node_dep(r#"[{"kind":"build","target":null}]"#);
+        assert!(!has_normal_edge(&dep));
+    }
+
+    #[test]
+    fn attack_row_5_any_normal_kind_among_several_targets_counts() {
+        // The same package can be depended on with different kinds by
+        // different targets (e.g. an optional dep a shared crate's lib
+        // target enables via a feature, alongside a dev-only use in its
+        // tests). One real target linking it normally is enough for it to
+        // ship, regardless of what else is also true about it.
+        let dep = node_dep(r#"[{"kind":"dev","target":null},{"kind":null,"target":null}]"#);
+        assert!(has_normal_edge(&dep));
+    }
+
+    // -----------------------------------------------------------------
+    // Attack-list row 4: a renamed/missing marker crate must fail loudly.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn missing_package_name_is_an_explicit_error_not_a_silent_pass() {
+        let meta_json = r#"{
+            "packages": [],
+            "workspace_members": [],
+            "workspace_default_members": [],
+            "resolve": {"nodes": [], "root": null},
+            "target_directory": "/tmp/target",
+            "workspace_root": "/tmp",
+            "build_directory": null,
+            "version": 1
+        }"#;
+        let meta: Metadata =
+            serde_json::from_str(meta_json).expect("fixture JSON must match Metadata's schema");
+        let err = find_package_id(&meta, "hal-actuate").unwrap_err();
+        assert!(err.contains("hal-actuate"));
+        assert!(err.contains("renamed") || err.contains("removed"));
+    }
+}

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -20,7 +20,23 @@
 
 ## Decisions made (append as you go)
 
-_Nothing recorded yet by this role._
+- **Issue #1, crate-exclusion boundary (PR TBD).** Split `hal` -> `hal` (observe) +
+  `hal-actuate` (motion authority); split `board-app` -> `board-app-ridden` +
+  `board-app-driverless`; added `vesc-wire` (decode-only), `vesc-tx` (encode-only),
+  `canary-ridden` (positive control) and `xtask` (the `cargo metadata`
+  dependency-graph gate). `board-app-ridden` has no observe-only hardware
+  backend yet, so it runs against a local `ShadowBackend` placeholder —
+  intentional, not an oversight; a real one is later, unrelated work.
+  **Deliberately left undone, flagged rather than fixed silently:** `vesc-wire`
+  / `vesc-tx` carry no real VESC byte layouts — there is no hardware yet to
+  verify one against, and fabricating protocol constants from memory into a
+  crate that will gate real actuation was judged worse than leaving them
+  honest stubs. ICD §6.3's "drop symbol scanning" line is a Notion-only edit
+  this session had no Notion access to make. `README.md` still says
+  `cargo run -p board-app` — stale after the split, but `README.md` is CEO
+  turf, not mine to edit.
+
+_Older: nothing recorded before this entry._
 
 ## Known dead ends
 

--- a/sim/scenarios/rust_controller.py
+++ b/sim/scenarios/rust_controller.py
@@ -6,7 +6,8 @@ will eventually run on the Pi -- `control_core::PitchRegulator` behind
 be kept in step with it.
 
 The physics calls the controller here, which is the reverse of the hardware
-arrangement (where `board-app` owns the loop and calls `BoardActuate`). That is
+arrangement (where `board-app-driverless` owns the loop and calls
+`BoardActuate`). That is
 deliberate and cheap to undo: Python owns MuJoCo, the collision geometry, the
 determinism and the metrics, and re-implementing all of that in Rust would buy
 no control knowledge. Only the direction of the call differs; the law and the


### PR DESCRIPTION
## What changed

Splits motion authority out at the **crate** boundary, not just the trait boundary, so "the ridden binary contains no motion-command paths" is something the build proves rather than something a reviewer asserts (issue #1).

- **`hal`** now carries only `BoardObserve` + `CallSequence`.
- **`hal-actuate`** (new) carries `BoardActuate` + `Disarm` — the ridden binary must never depend on this crate.
- **`board-app`** → **`board-app-ridden`** (links `hal` only; runs a placeholder `ShadowBackend` since there's no real observe-only backend yet) + **`board-app-driverless`** (links `hal-actuate` + `sim-backend`, unchanged behavior otherwise).
- **`vesc-wire`** (new, decode-only) and **`vesc-tx`** (new, encode-only) — scaffolding for the future hardware backend. Deliberately carry no real VESC byte layouts yet: there's no hardware to verify a layout against (Track C is procurement-gated), and fabricating protocol constants from memory into a crate that will eventually gate real actuation seemed worse than an honest `NotYetImplemented` stub.
- **`canary-ridden`** (new) — a binary shaped like `board-app-ridden` that deliberately depends on `hal-actuate`. This is the positive control: the gate is required to catch it.
- **`xtask`** (new) — walks `cargo metadata`'s resolve graph over *normal* edges only (dev-/build-dependencies excluded, since they don't ship) and fails if `hal-actuate` is reachable from `board-app-ridden`. Runs the check under both default features and `--all-features`, because cargo features unify across the whole graph — the exact failure mode that killed the earlier `actuate`-feature approach. Fails loudly (not silently) if the marker crate is ever renamed and it can no longer find it. Wired into CI as a new step in the `rust` job: `cargo run -p xtask -- gate`.

## Acceptance criteria (issue #1)

- [x] `hal` → `hal` + `hal-actuate` split
- [x] `vesc-wire` (decode-only) + `vesc-tx` (encoders) added
- [x] `board-app` → `board-app-ridden` + `board-app-driverless` split
- [x] `hal` already conforms to the ICD's `wait_observe()` + `apply()` contract (done in an earlier commit; nothing further needed here)
- [x] `xtask` gate: walks `cargo metadata` resolve nodes from `board-app-ridden`, normal edges only, asserts `hal-actuate` unreachable
- [x] `canary-ridden` positive control: CI asserts the gate passes on the real binary and is required to catch the canary
- [x] Attack list run — as `xtask`'s own unit tests (dev-dependency exclusion, `--all-features` re-resolve, transitive reachability, renamed-marker failure, multi-target dep_kinds), plus the real gate against the live workspace graph in CI
- [ ] Drop symbol scanning from ICD §6.3 — **not done**, flagged below

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace --all-targets`, `cargo test --workspace` (all green, including 10 new `xtask` tests), `cargo run -p xtask -- gate` (passes), `python3 .github/policy_check.py` (all hard checks pass). No Python sim/physics files touched, so the `sim` CI job's behavior is unaffected — this session's sandbox couldn't run the pinned mujoco/numpy pytest suite locally (Python 3.11 vs the 3.12+ the pins require), so that gate is unverified locally but should be green in CI.

## Out of scope / flagged, not fixed

- **ICD §6.3's "drop symbol scanning" line** is a Notion-only edit; this session had no Notion access to make it.
- **`README.md`** still says `cargo run -p board-app` and `crates/board-app` — stale after this split, but `README.md` is CEO turf per CODEOWNERS, not mine to edit.
- **Real VESC wire byte layouts** are still unimplemented in `vesc-wire`/`vesc-tx` — separate, ICD-traced work for when Track C hardware exists to verify against.

Closes #1.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqQ6ESd5H68wGiDUWWtB4W)_