### PR TITLE
docs(vocabulary): land the retired→current mapping the vocab gate needs

### DIFF
--- a/docs/vocabulary/README.md
+++ b/docs/vocabulary/README.md
@@ -32,5 +32,19 @@ mechanical, so the gate stays cheap and the human-readable version stays single-
 
 ## Status
 
-**Empty by design.** The COO wires a `vocab` check into `.github/policy_check.py` once a
-mapping lands here — this role owns the data, the COO owns the gate.
+**Populated 2026-07-27 — `retired-terms.json` is the mapping.** Eight terms, seven at `error`
+and one (`bare-replay`) at `warn` because it is a heuristic that will produce false positives.
+Over to the COO to wire the `vocab` check into `.github/policy_check.py`: this role owns the
+data, the COO owns the gate.
+
+Two things in the file are worth knowing before writing that check, because both come from
+mistakes made during the sweep it was built from:
+
+- **Word boundaries are not optional.** Every pattern is anchored. An unanchored `lane` matches
+  `plane`, which cost a false positive on `overboard-viz#5` during the first sweep.
+- **A term may appear if the same line links canonical** (`exempt_line_regex`). This is the
+  duplication rule enforcing itself: the only legal way to name a retired term is to also say
+  where the current definition lives. Checking per *line* rather than per *page* is deliberate —
+  four documents were scored "handled" on the strength of a banner at the top while still
+  restating the retired definition further down, and two of those restatements had already
+  gone false.

--- a/docs/vocabulary/retired-terms.json
+++ b/docs/vocabulary/retired-terms.json
@@ -1,0 +1,107 @@
+{
+  "version": 1,
+  "owner": "Archivist",
+  "canonical_definitions": "https://app.notion.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b",
+
+  "_comment": [
+    "Machine-readable retired -> current mapping. Data only: no definitions, no rationale.",
+    "Those live in the Notion page named above, which is the single place any of these terms",
+    "is defined. This file exists because CI cannot read Notion.",
+    "",
+    "Consumed by the `vocab` check in .github/policy_check.py (COO owns the gate,",
+    "Archivist owns this data). Adding a term here is a records fix, not a decision.",
+    "",
+    "The gate is expected to scan the WORKING TREE only. Git history, merged pull requests",
+    "and closed issues keep the old terms on purpose -- the record of how we got here is an",
+    "asset for a project whose thesis is building in public. Never rewrite history to match",
+    "current vocabulary."
+  ],
+
+  "escape": {
+    "commit_marker": "VOCAB-OK:",
+    "_note": "Mirrors ADR-0008's `DOC-OK:`. A commit carrying `VOCAB-OK: <reason>` bypasses this check, so an emergency is never blocked by a naming rule."
+  },
+
+  "exempt_paths": [
+    "docs/vocabulary/**",
+    "docs/decisions/ADR-*.md",
+    ".github/policy_check.py"
+  ],
+  "_exempt_paths_note": "ADRs are the immutable record of a decision at the time it was made; an ADR is superseded, never edited. This directory necessarily contains the retired terms themselves.",
+
+  "exempt_line_regex": "app\\.notion\\.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b",
+  "_exempt_line_note": [
+    "A line may name a retired term if it ALSO links the canonical page. That is deliberately",
+    "the same rule this vocabulary exists to enforce -- do not restate a definition, link to it.",
+    "It makes the only legal way to mention a retired term the one that also tells the reader",
+    "where the current definition lives.",
+    "",
+    "Learned the hard way on 2026-07-27: four documents were marked 'handled' because they",
+    "carried a pointer banner, while still RESTATING the old definition further down. Two of",
+    "those restatements had already gone false -- both said Lane A 'carries no signature',",
+    "which stopped being true the moment a Sim Replay gained a SIM tag. A banner at the top of",
+    "a page does not make the page correct. Checking per line does."
+  ],
+
+  "terms": [
+    {
+      "id": "lane-a",
+      "pattern": "\\bLane[ _-]?A\\b",
+      "replacement": "Sim Replay",
+      "severity": "error",
+      "note": "Ambiguous on purpose: a Replay always names its source, so the correct replacement is `Sim Replay` OR `Hardware Replay`. Default to Sim Replay -- no hardware telemetry exists yet. Do not auto-fix; a human picks the source."
+    },
+    {
+      "id": "lane-b",
+      "pattern": "\\bLane[ _-]?B\\b",
+      "replacement": "Concept",
+      "severity": "error",
+      "note": "Unambiguous. Safe to auto-fix."
+    },
+    {
+      "id": "lane-declaration",
+      "pattern": "\\blane declaration\\b",
+      "replacement": "category declaration",
+      "severity": "error",
+      "flags": "i"
+    },
+    {
+      "id": "lane-directories",
+      "pattern": "\\blane_[ab]\\b",
+      "replacement": "replay/ or concept/",
+      "severity": "error",
+      "note": "In overboard-viz the directory IS the category declaration, so a retired directory name is the mechanism rather than cosmetics. Renamed in overboard-viz PR #3."
+    },
+    {
+      "id": "two-lane",
+      "pattern": "\\btwo-lane\\b",
+      "replacement": "four categories",
+      "severity": "error",
+      "flags": "i",
+      "note": "The count changed, not just the names. There are four categories: Footage, Sim Replay, Hardware Replay, Concept."
+    },
+    {
+      "id": "simulation-burn-in",
+      "pattern": "burned-in `?SIMULATION`? mark",
+      "severity": "error",
+      "flags": "i",
+      "replacement": "the per-category on-frame mark (SIM / HARDWARE / CONCEPT)",
+      "note": "Retired with the lane vocabulary. `SIMULATION` read as a disclaimer and started an argument about watermarks."
+    },
+    {
+      "id": "watermark",
+      "pattern": "\\bwatermark",
+      "replacement": "signature",
+      "severity": "error",
+      "flags": "i",
+      "note": "Banned in overboard-viz/CLAUDE.md by its own rule: the word imports a defensive, anti-piracy framing that is wrong for what the mark does. Studios sign concept work."
+    },
+    {
+      "id": "bare-replay",
+      "pattern": "(?<!Sim )(?<!Hardware )\\bReplay\\b",
+      "replacement": "Sim Replay or Hardware Replay",
+      "severity": "warn",
+      "note": "ADVISORY, and expected to produce false positives -- it cannot tell prose about the concept from a category label. There is no bare `Replay`: the qualifier is what tells a viewer whether they are looking at physics or at a real board. Kept at warn so it informs without blocking; promote to error only if it proves precise in practice."
+    }
+  ]
+}


### PR DESCRIPTION
Closes the **data half** of the Archivist ratification ([Escalations row](https://app.notion.com/p/3aa472a5fb6981148ee0fc5dfd3e7f19), ratified same-day via #45). Division agreed there: **this role owns the DATA, the COO owns the GATE.** `docs/vocabulary/README.md` was seeded by the COO and says the `vocab` check gets wired into `.github/policy_check.py` once a mapping lands. This is that mapping.

## Why this exists

CI cannot read Notion, so a term list that lives only there can never be enforced. On 2026-07-27 "Lane A / Lane B" was retired for **Footage · Sim Replay · Hardware Replay · Concept**, and stale copies were still live in issues and docs hours later — invisible to the ADR-0008 drift gate, because that gate watches code↔doc, not vocabulary.

## What is in it

Eight terms — seven `error`, one (`bare-replay`) `warn`, because it is a heuristic that will produce false positives and should not block a build until it proves precise.

## Two design points, both from mistakes made during the sweep this came from

- **Every pattern is word-anchored.** An unanchored `lane` matches `plane` — that produced a false positive on `overboard-viz#5` in the first sweep.
- **`exempt_line_regex` lets a line name a retired term if the same line links the canonical page.** That is the duplication rule enforcing itself: the only legal way to mention a retired term is to also say where the current definition lives. Per **line**, not per page, and deliberately — four docs were scored "handled" on the strength of a banner at the top while still restating the old definition further down. Two of those restatements had already gone false: both claimed Lane A "carries no signature", which stopped being true the moment a Sim Replay gained a `SIM` tag.

## Scope and escape

- Escape is `VOCAB-OK:` in a commit, mirroring ADR-0008's `DOC-OK:`, so a naming rule can never block an emergency.
- Git history, merged PRs and closed issues are **out of scope by design** — the record of how we got here is the asset.
- `docs/vocabulary/**` and `docs/decisions/ADR-*.md` are exempt: the first necessarily contains the retired terms, and an ADR is superseded, never edited.

## Verification

- `policy` passes locally — 8 roles, 38 ownership rules, all hard checks green.
- All 8 regexes compile; both failure modes asserted by hand (`"tilted plane a bit"` → no match, `"must be Lane A"` → match).
- `--who` confirms `docs/vocabulary/retired-terms.json` → **Archivist [Ratified]**, CODEOWNERS:177.

**No acceptance criteria moved.** Data only — no gate, no behaviour change, until the COO wires the check.

/cc COO — this unblocks your side.