### PR TITLE
feat(controls): virtual CAN harness proving the CAN stack with no hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "board-app-driverless"
 version = "0.1.0"
 dependencies = [
@@ -32,12 +44,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "camino"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "can-harness"
+version = "0.1.0"
+dependencies = [
+ "socketcan",
+ "vesc-tx",
+ "vesc-wire",
 ]
 
 [[package]]
@@ -74,6 +101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "control-core"
 version = "0.1.0"
 dependencies = [
@@ -88,6 +127,21 @@ dependencies = [
  "board-types",
  "control-core",
  "safety",
+]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "embedded-can"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
+dependencies = [
+ "nb",
 ]
 
 [[package]]
@@ -106,10 +160,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -118,10 +193,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "neli"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -185,7 +319,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -208,6 +342,46 @@ dependencies = [
  "board-types",
  "hal",
  "hal-actuate",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "socketcan"
+version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea24328be148eea05f36bc3991b1c174c586853e04d1480b92429b2df6aea865"
+dependencies = [
+ "bitflags",
+ "embedded-can",
+ "hex",
+ "itertools",
+ "libc",
+ "log",
+ "nb",
+ "neli",
+ "nix",
+ "socket2",
+ "thiserror",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -238,7 +412,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -257,6 +431,79 @@ dependencies = [
 [[package]]
 name = "vesc-wire"
 version = "0.1.0"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/board-app-ridden",
     "crates/board-app-driverless",
     "crates/canary-ridden",
+    "crates/can-harness",
     "crates/xtask",
 ]
 
@@ -31,3 +32,4 @@ control-core = { path = "crates/control-core" }
 safety = { path = "crates/safety" }
 sim-backend = { path = "crates/sim-backend" }
 serde = { version = "1", default-features = false, features = ["derive"] }
+socketcan = "3.6"

--- a/crates/can-harness/Cargo.toml
+++ b/crates/can-harness/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "can-harness"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+vesc-wire = { workspace = true }
+socketcan = { workspace = true }
+
+[dev-dependencies]
+vesc-tx = { workspace = true }

--- a/crates/can-harness/src/lib.rs
+++ b/crates/can-harness/src/lib.rs
@@ -1,0 +1,66 @@
+//! Std-only CAN test infrastructure: a self-managed virtual CAN (`vcan`)
+//! interface and a simulated VESC-shaped responder, so the CAN stack --
+//! frame transport, the encode/decode seam, timeout handling -- can be
+//! proven end to end with zero hardware (issue #52).
+//!
+//! Deliberately `std`, unlike `vesc-wire`/`vesc-tx`: sockets, threads and a
+//! kernel network interface have no `no_std` story. Nothing in this crate is
+//! linked by `board-app-ridden` or `board-app-driverless`; it exists only
+//! under `cargo test`.
+//!
+//! **No real VESC packet IDs live here.** `vesc-wire::decode_motor_current_a`
+//! and `vesc-tx::encode_set_current` are still `NotYetImplemented` stubs --
+//! see their module docs for why a real byte layout has not been transcribed
+//! (no hardware exists yet to verify one against, and this project has
+//! already ruled that a plausible-but-wrong constant is worse than a blank).
+//! This crate proves the transport those functions will eventually sit on
+//! top of: [`RawFrame`] in, over a real Linux CAN socket, [`RawFrame`] out,
+//! byte-for-byte, including the sign and scaling bits a fabricated constant
+//! could not be trusted to get right anyway.
+
+pub mod responder;
+pub mod vcan;
+
+use socketcan::{CanDataFrame, EmbeddedFrame, Frame as SocketCanFrame};
+use vesc_wire::RawFrame;
+
+/// Converts a [`RawFrame`] to the frame type `socketcan` sends on the wire.
+///
+/// `RawFrame::id`'s magnitude picks standard (11-bit) vs extended (29-bit)
+/// automatically, the same convention `ip link`/`candump` use -- callers
+/// don't choose a frame flavour, the id's range does.
+pub fn to_can_frame(frame: RawFrame) -> Option<CanDataFrame> {
+    CanDataFrame::from_raw_id(frame.id, frame.bytes())
+}
+
+/// Converts a received `socketcan` frame back to the shape `vesc-wire` and
+/// `vesc-tx` share.
+pub fn from_can_frame(frame: &CanDataFrame) -> RawFrame {
+    let bytes = frame.data();
+    let mut data = [0u8; 8];
+    data[..bytes.len()].copy_from_slice(bytes);
+    RawFrame {
+        id: frame.raw_id(),
+        len: bytes.len() as u8,
+        data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_frame_survives_the_can_data_frame_shape_alone() {
+        // Pure conversion, no vcan involved -- the transport round trip is
+        // covered separately in tests/vcan_stack.rs, which needs a real
+        // interface and may skip.
+        let original = RawFrame {
+            id: 0x123,
+            len: 3,
+            data: [0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0],
+        };
+        let can_frame = to_can_frame(original).expect("valid frame");
+        assert_eq!(from_can_frame(&can_frame), original);
+    }
+}

--- a/crates/can-harness/src/responder.rs
+++ b/crates/can-harness/src/responder.rs
@@ -1,0 +1,76 @@
+//! A simulated VESC-shaped responder: answers a command frame with a status
+//! frame on a background thread, the way a real controller would, so the
+//! stack above the transport (timeouts, decode, retry) can be tested without
+//! one (issue #52 AC2).
+//!
+//! Arbitration IDs are chosen by the caller and are test-local placeholders,
+//! not real VESC packet IDs -- see `crate` docs for why.
+
+use crate::{from_can_frame, to_can_frame};
+use socketcan::{CanFrame, ShouldRetry, Socket};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+use vesc_wire::RawFrame;
+
+/// How often the background thread checks for shutdown between reads. Short
+/// enough that dropping a [`SimResponder`] at the end of a test doesn't
+/// stall it, long enough not to busy-loop.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Runs on a background thread until dropped: reads frames from a vcan
+/// interface and, for each one, writes back whatever `respond` returns on
+/// the same bus. Returning `None` from `respond` simulates silence --
+/// callers building the "responder never answers" case (AC4) just always
+/// return `None`, no separate variant needed.
+pub struct SimResponder {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SimResponder {
+    /// Spawns the responder against an already-up vcan interface named
+    /// `ifname`.
+    pub fn spawn(
+        ifname: &str,
+        respond: impl Fn(RawFrame) -> Option<RawFrame> + Send + 'static,
+    ) -> std::io::Result<Self> {
+        let socket = socketcan::CanSocket::open(ifname)?;
+        socket.set_read_timeout(POLL_INTERVAL)?;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = stop.clone();
+
+        let handle = thread::spawn(move || {
+            while !stop_thread.load(Ordering::Relaxed) {
+                let frame = match socket.read_frame() {
+                    Ok(CanFrame::Data(frame)) => frame,
+                    Ok(_) => continue,
+                    Err(e) if e.should_retry() => continue,
+                    Err(_) => continue,
+                };
+                let Some(reply) = respond(from_can_frame(&frame)) else {
+                    continue;
+                };
+                if let Some(reply_frame) = to_can_frame(reply) {
+                    let _ = socket.write_frame(&reply_frame);
+                }
+            }
+        });
+
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for SimResponder {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/crates/can-harness/src/vcan.rs
+++ b/crates/can-harness/src/vcan.rs
@@ -1,0 +1,88 @@
+//! Bring up and tear down a virtual CAN interface without a manual `ip
+//! link` step (issue #52 AC1) -- the same rtnetlink calls `ip link add ...
+//! type vcan` issues itself, driven directly from Rust via `socketcan`'s
+//! `netlink` feature.
+
+use socketcan::{CanInterface, CanSocket, Socket};
+use std::fmt;
+
+/// Why a vcan interface could not be brought up here.
+///
+/// Not a hard failure for a caller to propagate. The expected case is an
+/// unprivileged `cargo test --workspace` run (no `CAP_NET_ADMIN`) or a
+/// kernel with no `vcan` module loaded -- callers should treat this as
+/// "skip this test with a clear message," per AC1, via [`up_or_skip`].
+#[derive(Debug)]
+pub struct VcanUnavailable(String);
+
+impl fmt::Display for VcanUnavailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for VcanUnavailable {}
+
+/// A vcan interface this process created. Torn down automatically on drop --
+/// the other half of AC1's "no manual step."
+pub struct VcanFixture {
+    interface: Option<CanInterface>,
+    name: String,
+}
+
+impl VcanFixture {
+    /// Creates and brings up a fresh vcan interface named `name`.
+    ///
+    /// `name` should be unique per test (e.g. include the test name) --
+    /// tests may run concurrently, and creating an interface name already in
+    /// use fails.
+    pub fn up(name: &str) -> Result<Self, VcanUnavailable> {
+        let interface = CanInterface::create_vcan(name, None).map_err(|e| {
+            VcanUnavailable(format!(
+                "could not create vcan interface '{name}' ({e}) -- likely missing \
+                 CAP_NET_ADMIN or the kernel has no vcan module loaded"
+            ))
+        })?;
+        interface.bring_up().map_err(|e| {
+            VcanUnavailable(format!("created '{name}' but could not bring it up: {e}"))
+        })?;
+        Ok(Self {
+            interface: Some(interface),
+            name: name.to_string(),
+        })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Opens a raw CAN socket bound to this interface.
+    pub fn socket(&self) -> std::io::Result<CanSocket> {
+        CanSocket::open(&self.name)
+    }
+}
+
+impl Drop for VcanFixture {
+    fn drop(&mut self) {
+        // Best-effort: if the interface is already gone -- another cleanup
+        // raced us, or this fixture is unwinding after a partial failure --
+        // that is not this destructor's problem to report.
+        if let Some(interface) = self.interface.take() {
+            let _ = interface.delete();
+        }
+    }
+}
+
+/// Brings up a vcan fixture, or prints why it can't and returns `None` so
+/// the caller can return early instead of failing a test on infrastructure
+/// it doesn't control. This is the "skipped with a clear message" half of
+/// AC1 -- run it, read the SKIP line in the test output.
+pub fn up_or_skip(name: &str) -> Option<VcanFixture> {
+    match VcanFixture::up(name) {
+        Ok(fixture) => Some(fixture),
+        Err(e) => {
+            eprintln!("SKIP {name}: {e}");
+            None
+        }
+    }
+}

--- a/crates/can-harness/tests/vcan_stack.rs
+++ b/crates/can-harness/tests/vcan_stack.rs
@@ -1,0 +1,184 @@
+//! Issue #52: prove the CAN stack -- transport, a simulated responder,
+//! round-trip byte fidelity and timeout behaviour -- end to end against a
+//! real Linux `vcan` interface, with zero hardware.
+//!
+//! Every test here goes through [`can_harness::vcan::up_or_skip`] first and
+//! returns early with a printed `SKIP` line if `vcan` is unavailable (no
+//! `CAP_NET_ADMIN`, no `vcan` kernel module) -- AC1's "skipped with a clear
+//! message rather than failing." This crate runs as an ordinary member of
+//! the existing `cargo test --workspace` step, which is unprivileged, so a
+//! SKIP on every test is the expected, honest outcome there -- see this
+//! issue's PR description for why turning that into a live run needs a
+//! deliberate, separate CI change this PR does not make.
+//!
+//! Each test uses its own interface name so they can run concurrently
+//! without colliding.
+
+use can_harness::responder::SimResponder;
+use can_harness::vcan::up_or_skip;
+use can_harness::{from_can_frame, to_can_frame};
+use socketcan::Socket;
+use std::time::{Duration, Instant};
+use vesc_wire::RawFrame;
+
+#[test]
+fn vcan_lifecycle_is_self_managed() {
+    let Some(fixture) = up_or_skip("vh52lifecyc") else {
+        return;
+    };
+    // If we got this far, up() succeeded with no manual `ip link` step.
+    // Opening a socket against the freshly-created interface proves it's
+    // actually there, not just that create_vcan() returned Ok on paper.
+    fixture.socket().expect("interface exists and is up");
+    drop(fixture);
+    // Teardown happened in Drop; a second bring-up under the same name
+    // would fail if it hadn't, which the next test (different name) can't
+    // catch, so re-create the same name here to prove the delete landed.
+    let second = can_harness::vcan::VcanFixture::up("vh52lifecyc");
+    assert!(
+        second.is_ok(),
+        "teardown of the first fixture did not actually remove the interface"
+    );
+}
+
+#[test]
+fn simulated_responder_answers_command_with_status() {
+    let Some(fixture) = up_or_skip("vh52responder") else {
+        return;
+    };
+
+    const COMMAND_ID: u32 = 0x100; // test-local placeholder, not a real VESC packet ID
+    const STATUS_ID: u32 = 0x101;
+
+    let _responder = SimResponder::spawn(fixture.name(), move |req| {
+        if req.id != COMMAND_ID {
+            return None;
+        }
+        Some(RawFrame {
+            id: STATUS_ID,
+            len: req.len,
+            data: req.data,
+        })
+    })
+    .expect("responder spawns against a live interface");
+
+    let socket = fixture.socket().expect("socket opens");
+    socket
+        .set_read_timeout(Duration::from_secs(2))
+        .expect("timeout sets");
+
+    let command = RawFrame {
+        id: COMMAND_ID,
+        len: 2,
+        data: [0xAB, 0xCD, 0, 0, 0, 0, 0, 0],
+    };
+    let frame = to_can_frame(command).expect("valid frame");
+    socket.write_frame(&frame).expect("command sends");
+
+    let reply = socket.read_frame().expect("responder answers in time");
+    let socketcan::CanFrame::Data(reply) = reply else {
+        panic!("expected a data frame back");
+    };
+    let reply = from_can_frame(&reply);
+    assert_eq!(reply.id, STATUS_ID);
+    assert_eq!(reply.bytes(), command.bytes());
+}
+
+/// AC3: encode -> vcan -> decode must return exactly what went in,
+/// including sign and scaling.
+///
+/// `vesc_wire::decode_motor_current_a` / `vesc_tx::encode_set_current` are
+/// still `NotYetImplemented` stubs (no hardware exists yet to verify a real
+/// VESC byte layout against -- see their module docs), so this proves the
+/// layer they will sit on: the transport itself does not corrupt a signed,
+/// scaled value's bytes. The #12 IMU frame-reflection bug was exactly this
+/// class of defect, just on a different bus.
+#[test]
+fn round_trip_preserves_sign_and_scaling() {
+    let Some(fixture) = up_or_skip("vh52roundtrip") else {
+        return;
+    };
+
+    // A test-local convention -- not vesc-wire's layout -- of two big-endian
+    // i16 fields: a negative value at offset 0, a scaled positive value
+    // (x10) at offset 2. Chosen to exercise sign (negative) and scaling
+    // (divide-by-10) the same way a real current/duty-cycle field would.
+    let raw_amps = -1234_i16; // would decode to -123.4 A at a /10 scale
+    let raw_duty = 5678_i16; // would decode to 567.8 at a /10 scale
+
+    let mut data = [0u8; 8];
+    data[0..2].copy_from_slice(&raw_amps.to_be_bytes());
+    data[2..4].copy_from_slice(&raw_duty.to_be_bytes());
+    let sent = RawFrame {
+        id: 0x102,
+        len: 4,
+        data,
+    };
+
+    // Two independent sockets, like two nodes on a real bus -- a socket does
+    // not receive its own transmitted frames by default (CAN_RAW_RECV_OWN_MSGS
+    // is off), so a single socket here would prove nothing about the
+    // transport and everything about that unrelated default.
+    let tx = fixture.socket().expect("tx socket opens");
+    let rx = fixture.socket().expect("rx socket opens");
+    rx.set_read_timeout(Duration::from_secs(2))
+        .expect("timeout sets");
+
+    let frame = to_can_frame(sent).expect("valid frame");
+    tx.write_frame(&frame).expect("frame sends");
+
+    let received = rx
+        .read_frame()
+        .expect("vcan carries the frame to the other socket");
+    let socketcan::CanFrame::Data(received) = received else {
+        panic!("expected a data frame back");
+    };
+    let received = from_can_frame(&received);
+
+    assert_eq!(received, sent, "transport must not alter the frame at all");
+
+    let decoded_amps = i16::from_be_bytes(received.data[0..2].try_into().unwrap());
+    let decoded_duty = i16::from_be_bytes(received.data[2..4].try_into().unwrap());
+    assert_eq!(decoded_amps, raw_amps, "sign must survive the round trip");
+    assert_eq!(decoded_duty, raw_duty, "scaling field must survive intact");
+    assert!(
+        decoded_amps < 0 && decoded_duty > 0,
+        "sanity: fixture actually exercises both signs"
+    );
+}
+
+/// AC4: what the stack does when nothing answers. This is the failure that
+/// matters at a bench and cannot be tested later on hardware without a
+/// motor attached.
+#[test]
+fn silence_produces_a_bounded_timeout_not_a_hang() {
+    let Some(fixture) = up_or_skip("vh52silence") else {
+        return;
+    };
+
+    // Deliberately no SimResponder -- nobody answers.
+    let socket = fixture.socket().expect("socket opens");
+    let timeout = Duration::from_millis(300);
+
+    let request = RawFrame {
+        id: 0x100,
+        len: 1,
+        data: [0x01, 0, 0, 0, 0, 0, 0, 0],
+    };
+    let frame = to_can_frame(request).expect("valid frame");
+    socket.write_frame(&frame).expect("request sends");
+
+    let started = Instant::now();
+    let result = socket.read_frame_timeout(timeout);
+    let elapsed = started.elapsed();
+
+    assert!(
+        result.is_err(),
+        "no responder is running; a frame arriving would mean the vcan bus echoed \
+         the request back as if from a peer, which is not what this test sets up"
+    );
+    assert!(
+        elapsed < timeout * 3,
+        "timeout took {elapsed:?} for a {timeout:?} budget -- looks like a hang, not a timeout"
+    );
+}

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -36,8 +36,38 @@
   `cargo run -p board-app` — stale after the split, but `README.md` is CEO
   turf, not mine to edit.
 
-_Older: nothing recorded before this entry._
+- **Issue #52, virtual CAN harness (PR TBD).** New crate `can-harness`: a
+  self-managed `vcan` bring-up/teardown (via `socketcan`'s netlink API, no
+  `ip link` shell-out), a simulated VESC-shaped responder on a background
+  thread, and transport-level round-trip + timeout tests. **Deliberately did
+  not fill in `vesc-wire`/`vesc-tx`'s real byte layouts.** Tried to source
+  them from the official (non-firmware) "VESC 6 CAN Formats" PDF at
+  vesc-project.com — every fetch of that site 403'd from this session, for
+  every page on the domain, not just that one file, so I could not confirm
+  it either way. Left the stubs as they were and tested the transport layer
+  (sign/scale byte fidelity through a real vcan round trip) instead, per the
+  issue's own fallback instruction.
+  **Deliberately left undone:** did not add a privileged CI step to make the
+  vcan tests run for real. This sandbox returns `Operation not supported`
+  for `vcan` interface creation even under `sudo` — looks like the container
+  kernel has no `vcan` support at all, not just a permissions gap — so I had
+  no way to verify a privileged step would actually work on the GH-hosted
+  runner, and didn't want to gamble a required check on an unverified guess.
+  The crate rides the existing unprivileged `cargo test --workspace` step,
+  where every vcan test is expected to print `SKIP` and pass — which is
+  itself the acceptance criterion for "vcan unavailable." Turning that into
+  a live run on `ubuntu-latest` (it likely needs `CAP_NET_ADMIN`, which a
+  plain job step doesn't have either) is flagged, not fixed, here.
+
+_Older entries collapsed above this line as the log grows; nothing predates the crate-exclusion entry._
 
 ## Known dead ends
 
-_Nothing recorded yet._
+- **Fetching vesc-project.com for the VESC 6 CAN Formats PDF (2026-07-28).**
+  `WebFetch` returned HTTP 403 for every URL tried on that domain (the PDF
+  itself, and two different documentation pages) — looked like the fetcher
+  was being blocked outright rather than any one page being gated. Did not
+  find a working alternative source for real, non-GPL-firmware VESC CAN
+  byte layouts in the time this session had. Next session: worth trying a
+  different fetch path (cache, a mirror, or asking Mike for a manual pull)
+  before assuming the constants are simply unobtainable.


### PR DESCRIPTION
First implementation increment of the Stage-0B Pi image (design #51, not yet ratified — this doesn't touch anything #51 is still discussing).

New crate `can-harness`, std-only, not linked by `board-app-ridden` or `board-app-driverless` — it exists purely under `cargo test`.

## What it does

- **`vcan::VcanFixture`** — creates and tears down a virtual CAN interface via `socketcan`'s netlink API. No manual `ip link` step: this is the same rtnetlink call `ip link add ... type vcan` itself makes, done directly from Rust, RAII-torn-down on drop.
- **`vcan::up_or_skip`** — the AC1 "skipped with a clear message where vcan is unavailable" path. Prints `SKIP <name>: <reason>` and returns `None` instead of failing a test on infrastructure it doesn't control (no `CAP_NET_ADMIN`, no `vcan` kernel module).
- **`responder::SimResponder`** — a background thread that reads frames off a vcan interface and answers a configurable "command" arbitration ID with a "status" frame, the way a real controller would (AC2).
- **`tests/vcan_stack.rs`** — four behavioural tests:
  - interface lifecycle (create → use → drop → re-create proves teardown actually happened)
  - simulated responder answers a command with a status frame
  - round-trip byte fidelity through a real vcan send/receive, including a negative and a scaled value, using **two independent sockets** (a socket doesn't receive its own frames by default — a single-socket version would have proven nothing)
  - silence: no responder running, `read_frame_timeout` returns a bounded error instead of hanging (AC4 — the failure that can't be tested later without a motor attached)

## No invented VESC protocol constants

`vesc-wire::decode_motor_current_a` / `vesc-tx::encode_set_current` are untouched — still `NotYetImplemented` stubs. I looked for the official (non-firmware) "VESC 6 CAN Formats" PDF at vesc-project.com to fill them in properly, but every fetch on that domain came back `403` this session — looked like the fetcher was blocked outright, not one page being gated — so I couldn't confirm a real byte layout either way and left it there rather than guess. Logged as a known dead end in `roles/senior-controls/CONTEXT.md` for whoever picks this up next.

Because of that, the round-trip test exercises **transport fidelity** (sign + scale bits survive `RawFrame → socketcan → vcan → socketcan → RawFrame` unmangled) using an explicit test-local byte convention, clearly commented as not a real VESC layout. Once real constants land, this same harness slots them in with minimal changes.

## What I deliberately left out

- **No privileged CI step.** This sandbox returns `Operation not supported` creating a vcan interface even under `sudo` — the container kernel looks like it has no vcan support at all, not just a permissions gap — so I had no way to verify a `sudo`-wrapped test step would actually work on `ubuntu-latest` before gambling a required check on it. The crate rides the existing unprivileged `cargo test --workspace` step in `rust`, where every vcan test is expected to print `SKIP` and pass — itself the literal AC1 acceptance behavior. Making it run live on CI is flagged, not fixed, in the role's decision log.
- **No changes to `vesc-wire`/`vesc-tx`** — see above.
- Out of scope per the issue: the `mcp251xfd` HAT, real SPI, latency measurement, the image build.

## Verification

- `cargo build --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (can-harness's vcan tests print `SKIP` in this environment and this is expected — see above)
- `cargo run -p xtask -- gate` ✅ (unaffected — nothing depends on `can-harness`)
- `python3 .github/policy_check.py` ✅ all hard checks pass

Closes #52


---
_Generated by [Claude Code](https://claude.ai/code/session_01HK7sfFWjzzqnM6qxa9C4Px)_