### PR TITLE
fix(sim): run the attitude estimator by default, not ground truth

### DIFF
--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -5,11 +5,27 @@
 - **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
 
 ## Current sub-goals
-- **Blocking the first public announcement:** re-run the sim with the imperfect-sensor profile.
-  Every number marketing would publish today comes from a sim that knows its own tilt perfectly.
-  The numbers will get worse; we must publish the honest ones first. Nobody told this role it
-  was holding up a launch — that silence is the actual defect.
-- Closed-loop control is in sim; the estimator closes the loop on the shuttle.
+- **Was blocking the first public announcement, now partly cleared (PR TBD, issue #24 AC1):**
+  `RustController`'s `use_estimator` default flipped `False` → `True`, so the driverless
+  disturbance-rejection gate (`tests/test_closed_loop.py`), the ridden cascade gate, and
+  `scripts/render_scenario.py --compare` — the exact script that produces the artifact CI
+  publishes to `sim-latest` — now all run on the attitude **estimate**, not ground truth, by
+  default. hill.py/terrain.py/shuttle_run.py already did this; the driverless impulse gate,
+  which is what the published render and its `impulse_closed_loop_metrics.json` actually show,
+  did not. One pinned regression threshold moved with it and was re-measured rather than
+  loosened blindly: `test_there_is_large_margin_on_actuation_delay` was pinned at 6.80 deg
+  (truth pitch) and is now 9.71 deg (the honest number) — still clear of the 18.57 deg strike
+  angle, re-baselined to `< 10.5`.
+  **Still open — issue #24's other four ACs, deliberately not attempted in the same PR:**
+  disturbance-rejection **envelope** (currently one fixed magnitude, `NOMINAL_IMPULSE_NS = 20`,
+  not a sweep to a recovery boundary); the `r_eff` tyre-ground justification (geometry is
+  Mechanical's turf — this role can investigate and report, not edit `sim/models/`); confirming
+  every scenario already emits bit-identical metrics JSON (spot-checked true for impulse and
+  closed-loop via existing determinism tests, not re-verified for hill/terrain/shuttle); and an
+  audit marking every acceptance number in the scenario docs as measured vs. assumed. Each is
+  its own well-scoped increment, not a blocker for this one.
+- Closed-loop control is in sim; the estimator now closes the loop on the driverless impulse gate
+  and the ridden cascade too, not only the shuttle.
 
 ## Turf notes
 - Owns `crates/`, `tests/`, `scripts/`, most of `sim/` — but **not** `sim/models/`,

--- a/sim/scenarios/rust_controller.py
+++ b/sim/scenarios/rust_controller.py
@@ -153,7 +153,7 @@ class RustController:
         v_ref_fn=None,
         r_eff_m: float = DEFAULT_R_EFF_M,
         com_above_axle: bool = True,
-        use_estimator=False,
+        use_estimator=True,
         estimator_tau_s: float = 1.0,
         estimator_accel_aiding: int = 1,
         wheel_accel_tau_s: float = 0.05,

--- a/tests/test_imperfections.py
+++ b/tests/test_imperfections.py
@@ -193,10 +193,18 @@ def test_there_is_large_margin_on_actuation_delay(ridden):
     times the estimate -- because at ~12 rad/s bandwidth a millisecond costs
     almost no phase. Measured, so the claim is not an assertion about a Bode
     plot nobody drew.
+
+    Re-baselined for the honest number: `RustController` now runs the
+    estimator by default (issue #24 AC1 -- every headline number was
+    previously measured against ground-truth pitch, which no real IMU has).
+    Fusing the estimate costs real margin here: 6.80 deg on truth pitch,
+    9.71 deg on the estimate. Both are well clear of the 18.57 deg strike
+    angle, so "unbothered" still holds -- but the number moved, which is
+    exactly the point of measuring it honestly instead of on truth.
     """
     r = _impulse(ridden, STAGE0_PLACEHOLDER, delay_s=0.020)
     assert not r.metrics.nose_strike
-    assert r.metrics.peak_abs_pitch_deg < 9.0
+    assert r.metrics.peak_abs_pitch_deg < 10.5
 
 
 def test_enough_delay_does_break_it(ridden):


### PR DESCRIPTION
## What changed and why

`RustController.use_estimator` defaulted to `False`. That meant the driverless
disturbance-rejection gate (`tests/test_closed_loop.py`), the ridden cascade
gate, and `scripts/render_scenario.py --compare` — the script that produces
the artifact CI publishes to `sim-latest` and the numbers that end up in the
metrics JSON — all fed the controller MuJoCo's exact pitch instead of the
fused attitude estimate. `hill.py`, `terrain.py` and `shuttle_run.py` already
defaulted to the estimator; the driverless impulse scenario, which is what
the published render and its `impulse_closed_loop_metrics.json` actually
show, did not.

This is the CONTEXT.md-flagged blocker on the first public announcement:
"every number marketing would publish today comes from a sim that knows its
own tilt perfectly." One line — the default — was the actual gap.

**One pinned regression threshold moved with the honest number, and was
re-measured rather than loosened blindly:**
`test_there_is_large_margin_on_actuation_delay` measured 6.80 deg on truth
pitch and **9.71 deg on the estimate**, same 20 ms actuation delay, same
profile. Still well clear of the 18.57 deg strike angle — the "unbothered at
20 ms" claim holds — but the margin is thinner than the old, dishonest
number suggested, which is exactly why AC1 exists. Re-baselined to `< 10.5`
deg (measured value + margin), not the old `< 9.0`.

## Acceptance criteria (issue #24, AC1 only — see below)

- [x] Estimator in the loop by default for the driverless impulse gate and
      the ridden cascade gate (they were the two headline scenarios still on
      truth pitch; hill/terrain/shuttle already defaulted correctly).
- [x] The published render path (`render_scenario.py --compare`) now
      produces the honest, estimator-in-the-loop closed-loop numbers.
- [x] No regression thresholds silently loosened — the one that moved was
      re-measured and the new number is stated in the test docstring and in
      `roles/senior-controls/CONTEXT.md`.

## What I deliberately left out

Issue #24 has five acceptance criteria; this PR lands AC1 only, as the
smallest correct increment, and does **not** close the issue.

- **AC2, disturbance-rejection envelope.** The impulse scenario still runs a
  single fixed magnitude (`NOMINAL_IMPULSE_NS = 20.0`), not a sweep to a
  recovery boundary. Real work, deserves its own PR.
- **AC3, tyre–ground contact / `r_eff`.** `r_eff` derives from an enclosure
  clearance gap per the existing comments in the model. Mass, inertia,
  geometry and contact in `sim/models/` are Sr. Mechanical & Systems' turf,
  not mine to fix — at most I can investigate and report.
- **AC4, bit-identical metrics JSON for every scenario.** Spot-checked true
  for the impulse and closed-loop gates via the existing determinism tests
  (`test_repeat_runs_are_bit_identical`, `test_closed_loop_runs_are_deterministic`,
  `test_runs_with_the_profile_are_deterministic`); not re-verified for
  hill/terrain/shuttle in this pass.
- **AC5, marking every scenario-doc acceptance number as measured vs.
  assumed.** A documentation audit across all four scenarios' docs — broad
  enough to be its own increment.

Full rationale for scoping to AC1 alone is in `roles/senior-controls/CONTEXT.md`.

## Verification

- `source .venv/bin/activate && python3 -m pytest tests/` → 193 passed, 2 xfailed (same 2 as before this change)
- `cargo build --workspace --all-targets` ✅
- `cargo test --workspace` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo run -p xtask -- gate` ✅ (unaffected — no crate-graph change)
- `python3 .github/policy_check.py` ✅ all hard checks pass

No `sim/models/` or Rust code touched — only the Python default and one
Python test threshold.

Refs #24 (AC1 of 5 — issue stays open for AC2–AC5).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKRnUve43Y8ag5kv1TdKJC)_