### PR TITLE
feat(controls): Stage-0B bench-test runbook, the Pi-executed procedure

### DIFF
--- a/docs/runbook-stage0b-bench.md
+++ b/docs/runbook-stage0b-bench.md
@@ -1,0 +1,221 @@
+# Runbook — Stage 0B: the procedure the Pi executes, and the data it returns
+
+<!--
+covers:
+  - scripts/stage0b_runbook.py
+  - tests/test_stage0b_runbook.py
+reconciled: 49a2cfc
+-->
+
+**Owned by: Senior Controls** (issue #27 — O4 of the interim roadmap; explicit assignment,
+see "Turf" below). **Executed by: the Pi**, not a human at the bench. Stage 0A
+(`docs/runbook-stage0a-bench.md`) is a checklist a person follows with a multimeter and a
+kill switch. This is its Stage 0B counterpart: the Pi image (O3, issues #51/#52) is the
+vehicle, and this is the payload it runs once it exists — an ordered, machine-executed
+procedure that produces one log per run instead of one person's notes.
+
+**Same physical rig as Stage 0A** — the 6374 bench motor, CANable, and the Pi as the Linux
+host. Stage 0A proves the rig can spin and be measured by hand; this procedure is what the Pi
+runs automatically once it can, and it adds the one measurement Stage 0A cannot make:
+command→actuation latency, gated by real-time scheduling this rig does not yet have running.
+
+---
+
+## Why a procedure, not a script dump
+
+Each step below states three things:
+
+- **Purpose** — what the step is trying to establish.
+- **Falsifies** — the specific observation that would prove the step did NOT establish it.
+  A step with no falsifying observation is theatre, not a test.
+- **Pass / fail** — the numeric or boolean condition evaluated against the step's result.
+
+Steps run in the stated order because each one is a precondition for the next: there is no
+value in measuring current-step response through a CAN link that has not been proven to
+round-trip a frame, and no value in doing that unpowered check on wiring that has not passed
+continuity.
+
+---
+
+## ⚠️ Abort criteria — stated here, before step 4 (the first powered step)
+
+Per the project safety rule (hardware deadman in series with motor power), the following abort
+the run **immediately**, regardless of which step is in progress:
+
+- The deadman is opened, at any point, by anyone. This is a hardware interrupt, not a
+  procedure step, and it pre-empts everything below.
+- Step 1 (continuity/insulation) fails. Powering a shorted or leaky circuit is not
+  diagnosable from software.
+- Step 2 (unpowered CAN round-trip) fails. A bus that cannot be trusted unpowered cannot be
+  trusted with a motor attached.
+- Motor detection (Stage 0A §5) has not previously completed with halls found on this exact
+  hardware assembly. This procedure does not re-run detection; it assumes Stage 0A's gate
+  already passed and refuses to proceed if the log for that gate is missing.
+- Any commanded current step produces a measured current that does not settle within
+  `2 × current_loop_tau_s` of commanding zero. An actuator that will not release the disc on
+  command is the one failure this project cannot tolerate quietly.
+
+An aborted run is still **logged** (see §Log schema) with `"aborted_at_step"` set — a run that
+stopped is data, and silently discarding it hides exactly the failure the abort exists to
+catch.
+
+---
+
+## The procedure
+
+### Step 1 — Continuity and insulation check
+**Purpose:** confirm the assembly matches Stage 0A §4 (no phase-to-phase or phase-to-frame
+short) before any power is applied.
+**Falsifies:** measured resistance below the insulation-tester's fault threshold on any
+phase-to-phase or phase-to-frame pair.
+**Pass/fail:** pass iff every pair reads open circuit (phase-to-phase) or above the tester's
+insulation-fault threshold (phase-to-frame).
+**Hardware-only** — no sim equivalent. A simulated harness has no frame to short against.
+
+### Step 2 — Unpowered CAN round-trip
+**Purpose:** confirm the CAN transport (CANable, wiring, termination) carries a frame
+correctly before anything downstream depends on it.
+**Falsifies:** a frame sent is not received, or is received corrupted (wrong ID, wrong DLC,
+wrong payload bytes).
+**Pass/fail:** pass iff a loopback frame round-trips byte-identical.
+**Covered separately, not re-derived here:** the round-trip fidelity claim (including sign
+and scaling survival) is the acceptance target of the `can-harness` crate (issue #52), which
+proves it on a virtual CAN bus with no hardware required. This step is that same check, run
+against the real bus. This runbook does not re-implement it — it depends on `can-harness`
+passing first, once merged.
+
+### ⚠️ Abort gate — see "Abort criteria" above. Do not proceed past this line without it read.
+
+### Step 3 — First powered spin (deadman in hand)
+**Purpose:** confirm the assembly survives being powered and commanded at all, before trusting
+any measurement it produces.
+**Falsifies:** controller does not power up on deadman-close, does not respond to a CAN
+command, or does not die on deadman-open (re-run of Stage 0A §2's three-cycle test, because a
+harness change since 0A invalidates that gate).
+**Pass/fail:** pass iff power-up, command-response and deadman-kill all confirm.
+**Hardware-only.**
+
+### Step 4 — Current-step response
+**Purpose:** characterise the current loop's step response — first-order lag time constant —
+against the sim's prediction, on the real drive.
+**Falsifies:** measured current does not settle monotonically toward the commanded value, or
+settles to a time constant more than 3× the sim's `current_loop_tau_s` prediction (a gross
+mismatch means the sim's imperfection profile is not representative, which is exactly the
+kind of gap this runbook exists to catch before it reaches the board).
+**Pass/fail:** pass iff settle time is within the stated band at each of three commanded
+amplitudes, both directions (mirrors Stage 0A §6c).
+**Dry-runnable against the sim** — see §Dry run.
+
+### Step 5 — Coast-down
+**Purpose:** measure bearing/seal/cogging friction via speed decay, as an independent check
+that nothing changed mechanically since Stage 0A.
+**Falsifies:** decay parameters (`b`, `tau_c`) drift by more than the Stage 0A measurement's
+stated fit uncertainty — a drift means something in the assembly moved or degraded between
+sessions.
+**Pass/fail:** pass iff fit `R²` clears the Stage 0A acceptance threshold and both fitted
+parameters fall within tolerance of the Stage 0A baseline.
+**Dry-runnable against the sim** — see §Dry run.
+
+### Step 6 — Command→actuation latency measurement (the Stage-0 go/no-go)
+**Purpose:** the reason Stage 0B exists — measure the time from a CAN command frame leaving
+the Pi to the drive actually changing current, under representative CPU and network load.
+**Falsifies:** p99.9 latency exceeding 1 ms, or any single sample exceeding 2 ms, over the
+pre-registered ≥10⁵-cycle run.
+**Pass/fail:** this project's own AC-6 (`docs/design-pi-image-stage0b.md`, §"Numeric
+acceptance criteria"), reused verbatim here rather than re-derived: **Go** if p99.9 ≤ 1 ms
+*and* max ≤ 2 ms over ≥10⁵ cycles under representative load; any max > 2 ms escalates as an
+architecture finding rather than being tuned away.
+**Hardware measurement — a real jitter distribution needs a real RT kernel and a real bus.**
+**Dry-runnable against the sim only as a determinism/schema check** — see §Dry run for exactly
+what that does and does not prove.
+
+---
+
+## Log schema
+
+One JSON document per run, uploaded and traceable to the exact code that produced it. Fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schema_version` | int | `1`. Bump on any incompatible field change. |
+| `stage` | string | `"0B"`. |
+| `git_sha` | string | Short SHA of the tree that produced the run, `-dirty` suffixed if uncommitted changes were present — same convention as `scripts/experiment.py`. |
+| `mode` | string | `"hardware"` or `"dry_run"`. A dry run against the sim must never be mistaken for a hardware result downstream. |
+| `aborted_at_step` | string \| null | Step name if the run aborted, else `null`. |
+| `steps` | array | One entry per step actually run, in order. |
+
+Each entry in `steps`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string | e.g. `"current_step_response"`. |
+| `purpose` | string | One-line restatement, for a log read without this doc open. |
+| `result` | string | `"pass"`, `"fail"`, or `"skipped"` (skipped = hardware-only step, not run in `dry_run` mode). |
+| `measured` | object | Step-specific numeric results (e.g. `{"tau_s": 0.00098}`). |
+| `falsified_by` | string \| null | If `result == "fail"`, which falsifying condition fired. |
+
+This schema is deliberately small. It is the shape a log needs to be re-derivable and
+attributable to code, not a full telemetry format — the high-rate signal (current, speed,
+CAN frames) belongs in the project's MCAP log per the engineering conventions, referenced by
+run ID from this document, not duplicated into it.
+
+---
+
+## Dry run against the sim
+
+`scripts/stage0b_runbook.py` runs steps 4, 5 and 6 against the sim so the procedure — the
+step ordering, the schema, the pass/fail evaluation — is debugged before any hardware exists,
+per the acceptance criterion. It reuses the Stage 0A bench-rig identification code
+(`sim.scenarios.bench_spinup.identify` / `.spindown`, Sr. Mechanical & Systems' turf — read
+only, no changes made here) rather than re-deriving the physics, and the Stage 0B
+imperfection profile (`sim.scenarios.imperfections.STAGE0_PLACEHOLDER`) for the latency
+proxy.
+
+**What the dry run does NOT prove:** step 6's sim proxy finds the first instant current departs
+from zero after a step command, under `STAGE0_PLACEHOLDER`'s `actuation_delay_s` (a pure
+transport delay, no jitter source). It is a schema/plumbing check — does the pass/fail logic
+correctly evaluate a `(p99.9, max)` pair against AC-6's thresholds — and explicitly not a
+substitute for a real jitter distribution, which needs a real RT scheduler, a real bus and a
+real load generator. `STAGE0_PLACEHOLDER`'s own docstring already carries this caveat: its
+delay and current-loop-lag constants are marked `PROVISIONAL`, no Stage-0A current-loop data
+exists yet to fit them against. The dry run inherits that honesty rather than hiding it.
+
+**Finding, flagged rather than fixed here:** step 5's dry run runs the `IDEAL` profile, not
+`STAGE0_PLACEHOLDER`. `bench_spinup.spindown()` (Sr. Mechanical & Systems' turf) fits its
+decay window starting the instant current is commanded to zero, with no equivalent of
+`identify()`'s data-driven `settle_time_s` to skip the actuation-delay + current-loop-lag
+transient at the start of the decay. Under `STAGE0_PLACEHOLDER` that transient corrupts the
+least-squares fit across the whole window (R² collapsed to ~0.002 in testing — noise, not a
+curve). `IDEAL` is the only profile `spindown()` is actually validated against today
+(`tests/test_bench_spinup.py::test_spindown_recovers_friction_terms_on_ideal_run`, R² > 0.999).
+
+Steps 1–3 are hardware-only and report `"skipped"` with no falsifying claim in dry-run mode.
+
+```sh
+python3 scripts/stage0b_runbook.py --dry-run --out sim/out/stage0b/dry-run.json
+```
+
+Determinism: like every scenario run in this project, no wall clock is read for the numeric
+result — the sim steps are seeded and reproducible bit-for-bit (`tests/test_stage0b_runbook.py`
+pins this). The JSON's `git_sha` field is the one piece of real-world state the dry run
+records, exactly as `scripts/experiment.py` does.
+
+---
+
+## Turf
+
+`docs/` is COO turf (`CODEOWNERS`). Issue #27 explicitly assigns this runbook to Senior
+Controls ("Owner: Senior Controls", "Dispatch: cron OK") — same shape as issue #32's override
+for `docs/design-pi-image-stage0b.md`.
+
+TURF-OVERRIDE: docs/ is COO turf; issue #27 assigns this runbook to Senior Controls.
+
+## What this runbook does NOT establish
+
+Same discipline as Stage 0A §7: this is the **bench** motor's current loop and the **bench**
+rig's friction, not the board's. What transfers to the board is the imperfection profile
+(actuation delay, current-loop lag) and the CAN transport's proven behaviour — properties of
+the shared controller + CAN + host path, not of the machine at either end.
+
+**Next:** once AC-6 passes on real hardware under this procedure, Stage 0B's architecture
+go/no-go is decided — see `docs/design-pi-image-stage0b.md`.

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -56,6 +56,26 @@
   `cargo run -p board-app` — stale after the split, but `README.md` is CEO
   turf, not mine to edit.
 
+- **Issue #27, O4 — Stage-0B bench-test runbook (`docs/runbook-stage0b-bench.md`).** The
+  Pi-executed counterpart to Stage 0A's human checklist: ordered steps with purpose/falsifies/
+  pass-fail, abort criteria stated before the first powered step, a small JSON log schema
+  traceable to `git_sha`, and a sim dry run (`scripts/stage0b_runbook.py`,
+  `tests/test_stage0b_runbook.py`) exercising the sim-representable steps (current-step
+  response, coast-down, command→actuation latency) before hardware exists. AC-6's thresholds
+  (p99.9 ≤ 1 ms, max ≤ 2 ms, ≥10⁵ cycles) are reused verbatim from the ratified
+  `docs/design-pi-image-stage0b.md`, not re-derived.
+  **Finding, flagged rather than fixed:** `bench_spinup.spindown()` (Sr. Mechanical & Systems'
+  turf) has no equivalent of `identify()`'s data-driven `settle_time_s` windowing, so fitting
+  its decay under `STAGE0_PLACEHOLDER` runs the least-squares fit straight through the
+  actuation-delay + current-loop-lag transient at the start of the decay — R² collapsed to
+  ~0.002 (noise, not a curve) in testing here. The coast-down dry run uses `IDEAL` instead,
+  the only profile `spindown()` is actually validated against today.
+  **Deliberately left out:** the CAN round-trip step (2) is not re-implemented — it depends on
+  `can-harness` (issue #52, PR #53, not yet merged) and is documented as covered there rather
+  than duplicated. No `--hardware` mode exists; there is no Pi image yet to run it against
+  (O3, issues #51/#52 still open), and a stub with nothing to execute it would be exactly the
+  unverifiable code this project rules out.
+
 _Older: nothing recorded before this entry._
 
 ## Known dead ends

--- a/scripts/stage0b_runbook.py
+++ b/scripts/stage0b_runbook.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Stage 0B bench-test runbook driver -- docs/runbook-stage0b-bench.md.
+
+Runs the ordered procedure the runbook defines and emits one JSON log
+conforming to the runbook's "Log schema" section.
+
+Only `--dry-run` exists. There is no hardware mode yet: no Pi image exists to
+run this against (O3, issues #51/#52 are still open), so wiring a hardware
+path now would be code with nothing to execute it -- exactly the kind of
+unverifiable addition this project rules out. `run(dry_run=False, ...)`
+raises rather than pretending.
+
+The dry run exercises steps 4-6 (the sim-representable ones) against the
+Stage 0A bench-rig identification code (Sr. Mechanical & Systems' turf,
+imported read-only, never modified here) and the Stage 0B imperfection
+profile. Steps 1-3 are hardware-only and are reported "skipped".
+
+    python3 scripts/stage0b_runbook.py --dry-run --out sim/out/stage0b/dry-run.json
+
+Determinism: no wall clock is read for any numeric result -- the sim steps
+are seeded (ImperfectionProfile.seed) and reproducible bit-for-bit, exactly
+like every other scenario in this project. `git_sha()` is the one piece of
+real-world state recorded, matching `scripts/experiment.py`'s convention.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from sim.scenarios.bench_spinup import (  # noqa: E402
+    IdentifyParams,
+    SpindownParams,
+    identify,
+    load_model,
+    spindown,
+)
+from sim.scenarios.imperfections import (  # noqa: E402
+    IDEAL,
+    STAGE0_PLACEHOLDER,
+    ImperfectionProfile,
+    ImperfectionState,
+)
+
+SCHEMA_VERSION = 1
+
+# Reused verbatim from docs/design-pi-image-stage0b.md's AC-6 -- the
+# pre-registered go/no-go -- not re-derived here.
+AC6_P999_MAX_S = 0.001
+AC6_MAX_MAX_S = 0.002
+AC6_MIN_CYCLES = 100_000
+
+#: Reused from tests/test_bench_spinup.py's own acceptance bar for a fit run
+#: under the STAGE0_PLACEHOLDER imperfection profile (not IDEAL, which pins a
+#: tighter 0.999) -- not invented for this script.
+R2_ACCEPT = 0.95
+
+OUT_DIR = REPO / "sim" / "out" / "stage0b"
+
+
+def git_sha() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=REPO,
+            capture_output=True, text=True, check=True,
+        )
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain"], cwd=REPO,
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip() + ("-dirty" if dirty.stdout.strip() else "")
+    except Exception:
+        return "unknown"
+
+
+def _skipped(name: str, purpose: str) -> dict:
+    return {"name": name, "purpose": purpose, "result": "skipped", "measured": {}, "falsified_by": None}
+
+
+def step_current_response(profile: ImperfectionProfile = STAGE0_PLACEHOLDER) -> dict:
+    """Step 4 dry run -- reuses `bench_spinup.identify`'s own fit-quality
+    diagnostic as the stand-in for "does the current loop step and settle
+    the way the sim predicts"."""
+    result = identify(IdentifyParams(), profile=profile)
+    m = result.metrics
+    passed = m.r2_bare > R2_ACCEPT and m.r2_loaded > R2_ACCEPT
+    return {
+        "name": "current_step_response",
+        "purpose": "characterise the current loop's step response against the sim's prediction",
+        "result": "pass" if passed else "fail",
+        "measured": {
+            "r2_bare": m.r2_bare,
+            "r2_loaded": m.r2_loaded,
+            "fit_start_s": m.fit_start_s,
+        },
+        "falsified_by": None if passed else (
+            f"r2_bare={m.r2_bare:.4f} or r2_loaded={m.r2_loaded:.4f} <= {R2_ACCEPT}"
+        ),
+    }
+
+
+def step_coast_down(profile: ImperfectionProfile = IDEAL) -> dict:
+    """Step 5 dry run -- reuses `bench_spinup.spindown`'s own fit quality.
+
+    Runs against `IDEAL`, not `STAGE0_PLACEHOLDER`, and that is a finding,
+    not a style choice: unlike `identify()`, `spindown()` fits its decay
+    window starting the instant current is commanded to zero, with no
+    equivalent of `identify()`'s data-driven `settle_time_s` to skip the
+    actuation-delay + current-loop-lag transient at the start of the decay.
+    Under `STAGE0_PLACEHOLDER` that transient corrupts the least-squares fit
+    across the whole window (R^2 ~ 0.002 in testing here, not a curve, noise).
+    `spindown()` is Sr. Mechanical & Systems' turf (`sim/scenarios/bench_*.py`
+    per CODEOWNERS) -- flagged in the PR and in CONTEXT.md, not fixed here.
+    `IDEAL` is the one profile this function is actually validated against
+    (`tests/test_bench_spinup.py::test_spindown_recovers_friction_terms_on_ideal_run`,
+    R^2 > 0.999).
+    """
+    result = spindown(SpindownParams(), profile=profile)
+    m = result.metrics
+    passed = m.r2 > R2_ACCEPT
+    return {
+        "name": "coast_down",
+        "purpose": "measure friction decay as an independent consistency check",
+        "result": "pass" if passed else "fail",
+        "measured": {
+            "r2": m.r2,
+            "b_fit_nm_s_per_rad": m.b_fit_nm_s_per_rad,
+            "tau_c_fit_nm": m.tau_c_fit_nm,
+        },
+        "falsified_by": None if passed else f"r2={m.r2:.4f} <= {R2_ACCEPT}",
+    }
+
+
+def step_latency_proxy(profile: ImperfectionProfile = STAGE0_PLACEHOLDER) -> dict:
+    """Step 6 dry run -- a SCHEMA/PLUMBING CHECK ONLY, not a hardware
+    measurement.
+
+    AC-6 is "command leaves the Pi -> drive actually changing current" --
+    the transport/processing delay, not the current loop's full settle time
+    (that is a separate, already-modelled quantity, `current_loop_tau_s`).
+    So this measures the FIRST departure from zero after a step command, at
+    the bench rig's own physics timestep (`bench_spinup.load_model().opt.
+    timestep`, not invented here) so the delay is resolved rather than
+    aliased by a coarse discretisation.
+
+    The sim has no jitter source, so one deterministic first-response time
+    stands in for both p99.9 and max -- this proves the pass/fail evaluator
+    correctly reads a (p999, max) pair against AC-6, and nothing about real
+    hardware jitter. See docs/runbook-stage0b-bench.md, "What the dry run
+    does NOT prove."
+    """
+    dt_s = float(load_model().opt.timestep)
+    imp = ImperfectionState(profile=profile, dt_s=dt_s)
+    commanded_a = 20.0
+    threshold_a = 0.01 * commanded_a
+    window_s = 0.02  # comfortably past AC-6's 2 ms ceiling
+    n_cycles = int(round(window_s / dt_s))
+    t = np.arange(n_cycles) * dt_s
+    measured = np.array([imp.apply_current(commanded_a) for _ in range(n_cycles)])
+
+    above = np.flatnonzero(measured > threshold_a)
+    if above.size == 0:
+        raise ValueError(
+            f"current never departed from zero within the {window_s * 1e3:.0f} ms "
+            "window -- profile has no delay, or the window is too short"
+        )
+    first_response_s = float(t[int(above[0])])
+
+    p999_s = first_response_s
+    max_s = first_response_s
+    passed = p999_s <= AC6_P999_MAX_S and max_s <= AC6_MAX_MAX_S
+    return {
+        "name": "command_actuation_latency",
+        "purpose": "AC-6 schema/plumbing dry run -- NOT a hardware jitter measurement",
+        "result": "pass" if passed else "fail",
+        "measured": {
+            "first_response_s": first_response_s,
+            "p999_s": p999_s,
+            "max_s": max_s,
+            "cycles": 1,
+        },
+        "falsified_by": None if passed else f"p999_s={p999_s:.6f} or max_s={max_s:.6f} exceeds AC-6",
+    }
+
+
+def run(dry_run: bool, profile: ImperfectionProfile = STAGE0_PLACEHOLDER) -> dict:
+    if not dry_run:
+        raise NotImplementedError(
+            "no hardware mode yet -- no Pi image exists to run this against "
+            "(O3, issues #51/#52 are still open). A --hardware path with nothing "
+            "to execute it against would be unverifiable, which this project "
+            "rules out explicitly."
+        )
+    steps = [
+        _skipped("continuity_insulation", "confirm wiring matches Stage 0A assembly"),
+        _skipped("unpowered_can_roundtrip", "confirm CAN transport carries a frame correctly"),
+        _skipped("first_powered_spin", "confirm the assembly survives being powered and commanded"),
+        step_current_response(profile),
+        step_coast_down(),  # always IDEAL -- see step_coast_down's docstring
+        step_latency_proxy(profile),
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "stage": "0B",
+        "git_sha": git_sha(),
+        "mode": "dry_run",
+        "aborted_at_step": None,
+        "steps": steps,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", required=True,
+                         help="run the sim-representable steps; the only mode implemented")
+    parser.add_argument("--out", type=Path, default=None,
+                         help="write the log JSON here; defaults to stdout")
+    args = parser.parse_args(argv)
+
+    log = run(dry_run=args.dry_run)
+    text = json.dumps(log, indent=2, sort_keys=True)
+
+    if args.out is None:
+        print(text)
+    else:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n")
+        print(f"wrote {args.out}", file=sys.stderr)
+
+    failed = [s["name"] for s in log["steps"] if s["result"] == "fail"]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage0b_runbook.py
+++ b/tests/test_stage0b_runbook.py
@@ -1,0 +1,117 @@
+"""Acceptance gate for the Stage 0B bench-test runbook driver.
+
+docs/runbook-stage0b-bench.md's dry-run acceptance criterion is that the
+procedure -- step ordering, schema, pass/fail evaluation -- is debugged
+against the sim before hardware exists. These tests pin the schema shape and
+the determinism the doc promises, not the physical numbers themselves (those
+are pinned in tests/test_bench_spinup.py and tests/test_imperfections.py,
+whose functions this driver reuses read-only).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from stage0b_runbook import (  # noqa: E402
+    AC6_MAX_MAX_S,
+    AC6_P999_MAX_S,
+    run,
+    step_coast_down,
+    step_current_response,
+    step_latency_proxy,
+)
+
+HARDWARE_ONLY_STEPS = ("continuity_insulation", "unpowered_can_roundtrip", "first_powered_spin")
+SIM_STEPS = ("current_step_response", "coast_down", "command_actuation_latency")
+
+
+def test_hardware_only_mode_is_not_implemented():
+    """No Pi image exists yet (O3, issues #51/#52 are open) -- a --hardware
+    path with nothing to execute it against would be unverifiable."""
+    with pytest.raises(NotImplementedError):
+        run(dry_run=False)
+
+
+def test_dry_run_reports_all_six_steps_in_order():
+    log = run(dry_run=True)
+    names = [s["name"] for s in log["steps"]]
+    assert names == [
+        "continuity_insulation",
+        "unpowered_can_roundtrip",
+        "first_powered_spin",
+        "current_step_response",
+        "coast_down",
+        "command_actuation_latency",
+    ]
+
+
+def test_hardware_only_steps_are_skipped_not_evaluated():
+    log = run(dry_run=True)
+    by_name = {s["name"]: s for s in log["steps"]}
+    for name in HARDWARE_ONLY_STEPS:
+        assert by_name[name]["result"] == "skipped"
+        assert by_name[name]["falsified_by"] is None
+
+
+def test_sim_representable_steps_pass_on_the_committed_defaults():
+    """The whole point of a dry run: it should be green against the repo's
+    own defaults before anyone points it at hardware."""
+    log = run(dry_run=True)
+    by_name = {s["name"]: s for s in log["steps"]}
+    for name in SIM_STEPS:
+        assert by_name[name]["result"] == "pass", by_name[name]
+        assert by_name[name]["falsified_by"] is None
+
+
+def test_every_step_conforms_to_the_log_schema():
+    log = run(dry_run=True)
+    assert log["schema_version"] == 1
+    assert log["stage"] == "0B"
+    assert log["mode"] == "dry_run"
+    assert isinstance(log["git_sha"], str) and log["git_sha"]
+    for step in log["steps"]:
+        assert set(step) == {"name", "purpose", "result", "measured", "falsified_by"}
+        assert step["result"] in {"pass", "fail", "skipped"}
+        assert isinstance(step["measured"], dict)
+
+
+def test_dry_run_is_deterministic():
+    """No wall clock feeds any numeric result -- two runs produce identical
+    step results (git_sha aside, which is real-world state by design)."""
+    a = run(dry_run=True)
+    b = run(dry_run=True)
+    assert a["steps"] == b["steps"]
+
+
+def test_current_response_step_reuses_the_stage0_placeholder_profile():
+    """Same acceptance bar as bench_spinup's own STAGE0_PLACEHOLDER test
+    (tests/test_bench_spinup.py::test_the_r2_diagnostic_is_asserted_and_not_merely_reported,
+    R^2 > 0.95) -- not re-derived here."""
+    step = step_current_response()
+    assert step["measured"]["r2_bare"] > 0.95
+    assert step["measured"]["r2_loaded"] > 0.95
+
+
+def test_coast_down_step_defaults_to_ideal_not_stage0_placeholder():
+    """spindown() has no equivalent of identify()'s settle-time windowing,
+    so STAGE0_PLACEHOLDER corrupts its fit -- see the step's docstring and
+    docs/runbook-stage0b-bench.md's flagged finding. IDEAL is the only
+    profile it is actually validated against
+    (test_bench_spinup.py::test_spindown_recovers_friction_terms_on_ideal_run)."""
+    step = step_coast_down()
+    assert step["measured"]["r2"] > 0.999
+
+
+def test_latency_proxy_step_measures_first_departure_from_zero():
+    """AC-6 is command-leaves-the-Pi to actuation-starts-changing, not the
+    current loop's full settle time -- a full-settle version of this check
+    would fail against AC-6's 1 ms / 2 ms thresholds even though the model's
+    own actuation_delay_s (1 ms, PROVISIONAL) is right at the boundary."""
+    step = step_latency_proxy()
+    assert step["measured"]["first_response_s"] == pytest.approx(0.001, abs=2e-4)
+    assert step["measured"]["p999_s"] <= AC6_P999_MAX_S
+    assert step["measured"]["max_s"] <= AC6_MAX_MAX_S


### PR DESCRIPTION
## What changed and why

`docs/runbook-stage0b-bench.md` is the Stage-0B counterpart to Stage 0A's human checklist
(`docs/runbook-stage0a-bench.md`): an ordered procedure **the Pi runs**, not a person with a
multimeter. Objective 4 of the interim roadmap — the Pi image (O3, issues #51/#52) is the
vehicle, this is the payload.

Each step states its **purpose**, what would **falsify** it, and a **pass/fail** condition.
Abort criteria are stated before the first powered step, not after. Step 6's threshold —
p99.9 ≤ 1 ms, max ≤ 2 ms, ≥10⁵ cycles — is **AC-6, reused verbatim** from the already-ratified
`docs/design-pi-image-stage0b.md`, not re-derived.

`scripts/stage0b_runbook.py` is the dry-run driver the acceptance criteria ask for: it
exercises the sim-representable steps (current-step response, coast-down, command→actuation
latency) against the sim before any hardware exists, and emits the runbook's log schema
(`schema_version`, `git_sha`, `mode`, per-step pass/fail) so the procedure — ordering, schema,
evaluation logic — is debugged in software first, matching `scripts/experiment.py`'s
git-SHA-traceability convention. `tests/test_stage0b_runbook.py` (9 tests) pins the schema
shape, step ordering, and determinism.

## Acceptance criteria (issue #27)

- [x] Written, ordered procedure with a stated purpose and pass/fail per step.
- [x] Covers continuity/insulation, unpowered CAN round-trip, first powered spin, current-step
      response, coast-down, and command→actuation latency.
- [x] Every step names what is being identified and what would falsify it.
- [x] Abort criteria stated before the first powered step.
- [x] One documented log schema per run, traceable to the git SHA of the code that produced it.
- [x] Dry-runnable against the sim, so the procedure is debugged before hardware exists.

## A finding, flagged rather than fixed

`bench_spinup.spindown()` (Sr. Mechanical & Systems' turf) has no equivalent of `identify()`'s
data-driven `settle_time_s` windowing. Fitting its decay under `STAGE0_PLACEHOLDER` runs the
least-squares fit straight through the actuation-delay + current-loop-lag transient at the
start of the decay — R² collapsed to ~0.002 (noise, not a curve) in testing here. The
coast-down dry run uses `IDEAL` instead, the only profile `spindown()` is actually validated
against today (`tests/test_bench_spinup.py::test_spindown_recovers_friction_terms_on_ideal_run`).
Logged in `roles/senior-controls/CONTEXT.md` for whoever picks up the real fix — it's Mechanical's
file, not mine to edit.

## What I deliberately left out

- **No `--hardware` mode.** No Pi image exists yet to run it against (O3, issues #51/#52 are
  still open); a stub with nothing to execute it against would be exactly the unverifiable code
  this project rules out.
- **Step 2 (unpowered CAN round-trip) is not re-implemented.** It is the acceptance target of
  `can-harness` (issue #52, PR #53, not yet merged) — this runbook depends on that passing
  rather than duplicating it.
- **Step 6's sim proxy is a schema/plumbing check, not a real jitter measurement.** It finds
  first departure from zero under `STAGE0_PLACEHOLDER`'s `actuation_delay_s`, deterministically —
  a real p99.9/max distribution needs a real RT scheduler, a real bus, and a real load generator.
  Stated explicitly in both the doc and the script's docstrings.

## Turf

`docs/` is COO turf (CODEOWNERS). Issue #27 explicitly assigns this runbook to Senior Controls
("Owner: Senior Controls", "Dispatch: cron OK") — same shape as issue #32's override for
`docs/design-pi-image-stage0b.md`.

TURF-OVERRIDE: docs/ is COO turf; issue #27 assigns this runbook to Senior Controls.

## Verification

- `.venv/bin/python3 -m pytest tests/` → 202 passed, 2 xfailed (after `cargo build --release -p control-ffi`, required for the pre-existing closed-loop/terrain/shuttle/hill gates — confirmed those failures are pre-existing and unrelated to this change, not introduced by it)
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (no Rust code touched)
- `python3 .github/policy_check.py` ✅ all hard checks pass (turf override honored, doc-drift clean)

No `sim/models/`, `sim/scenarios/plant.py`, `sim/scenarios/imperfections.py`, or
`sim/scenarios/bench_*.py` touched — Mechanical's identification code is imported read-only.

Closes #27


---
_Generated by [Claude Code](https://claude.ai/code/session_01XUprySCvQgiTXtV9LYGVVJ)_