### PR TITLE
docs: assembly capture plan for Stage 0A

### DIFF
--- a/docs/capture-plan-assembly.md
+++ b/docs/capture-plan-assembly.md
@@ -1,0 +1,49 @@
+# Capture plan — Stage 0A assembly
+
+<!--
+covers:
+  - docs/runbook-stage0a-bench.md
+reconciled: 908f341
+-->
+
+**Assembly happens exactly once.** Everything else on the content roadmap can be redone;
+this cannot. This plan is capture only — no editing, no publishing, no decisions about what
+gets used. That is the marketing line's job, and keeping this to capture is what keeps each
+step under 30 seconds instead of a production.
+
+**One person, alone.** Every step below either needs no hands, or is propped/tripod first,
+record second. If a step needs two hands and a camera, the workaround is stated.
+
+**Failures are the most valuable material, not a thing to hide.** A part that doesn't fit, a
+wrong connector, a motor that won't detect — capture it exactly like a success. This
+project's strongest published artefact so far was a bug write-up.
+
+**Keep the camera on the hardware.** No footage of a person's face/identity — that's a
+separate, explicit decision, not a default here.
+
+**Where footage goes:** a shared Google Drive folder (`Overboard – Raw Capture`, dated
+subfolders), not this repo. Large binaries don't belong in git history, and Drive's phone app
+auto-uploads on wifi with zero extra step at the bench. Digital Content Production pulls raw
+footage from there for editing — this repo never sees it.
+
+---
+
+## The checklist
+
+| Moment (runbook §) | Capture | How | Camera |
+|---|---|---|---|
+| Unboxing / first look (§1) | Stills | 5–6 quick phone photos: unopened boxes, then parts laid out | Handheld, before hands get busy |
+| Kill-path wiring + the 3x switch test (§2) | Video, one continuous clip | Phone **propped against a box**, framed on the switch + controller LED, before you start the three test cycles | Propped — both hands are on the switch |
+| Motor bolted to plate / bracket coming together (§3) | Stills | One photo each: bare plate, motor bolted, disc mounted | Handheld, between steps |
+| First power-on (§5.1–5.3) | Video | Phone propped facing the bench, **recording before** you press precharge; frame the controller LED | Propped — hands on precharge + deadman |
+| First `candump`/`ip link` trace (§5.4) | Screen recording or photo | `⌘+Shift+5` (or phone photo of the laptop screen) showing frames arriving | Handheld/laptop, 10s |
+| **First spin** (§5.5) — the most valuable second in the project | Video | Phone propped/tripod on the disc+motor, **start recording before** running motor detection | Propped — cannot be redone if missed |
+| First `kt` run (§6b) | Screen recording or phone video of the laptop plot | Start the recorder before commanding the current step, stop after the ramp settles | Propped or handheld, whichever is faster to set up |
+
+**Any failure along the way** (wrong hall pinout, disc doesn't clear, connector mismatch,
+detection fails): same rule as above — capture what's in front of you, don't reset first.
+
+---
+
+See `docs/runbook-stage0a-bench.md` for the procedure these moments are attached to; the
+markers there point back here.

--- a/docs/runbook-stage0a-bench.md
+++ b/docs/runbook-stage0a-bench.md
@@ -34,6 +34,9 @@ Pi OS boot is enough.
 
 ---
 
+📷 *Capture plan: `docs/capture-plan-assembly.md`. This is the only assembly — every step
+below marked 📷 is unrepeatable and worth ~15–30s of phone footage.*
+
 ## 1. Parts, and what has to be true before you start
 
 Everything in the **BoM-BENCH-001** view of the
@@ -54,6 +57,8 @@ Everything in the **BoM-BENCH-001** view of the
 **Before you touch anything:** clear the bench, and stand where you are **not** in the plane of
 the disc. A shed set screw leaves along that plane.
 
+📷 **Capture: unboxing / first look** — see capture plan.
+
 ---
 
 ## 2. Build and TEST the kill path — before the motor is ever energised
@@ -71,6 +76,8 @@ motor power, and Stage 0A is the first time that rule becomes physical.
 
 ✅ **Gate: you may not proceed until opening that switch reliably kills controller power.**
 
+📷 **Capture: kill-path wiring + the 3x switch test** — see capture plan.
+
 ---
 
 ## 3. Mechanical assembly
@@ -82,6 +89,8 @@ motor power, and Stage 0A is the first time that rule becomes physical.
 3. Fit the set-screw hub to the shaft, then the disc. **Set screw onto the shaft flat**, not
    onto round stock. Thread-locker.
 4. Rotate by hand: free, no wobble, no contact with anything, full clearance all round.
+
+📷 **Capture: motor bolted to plate / bracket coming together** — see capture plan.
 
 **Record before going further** — these are inputs to the identification, not paperwork:
 
@@ -105,6 +114,9 @@ motor power, and Stage 0A is the first time that rule becomes physical.
 
 ## 5. First power-on
 
+📷 **Capture: first power-on** — phone propped facing the bench, recording before step 2. See
+capture plan.
+
 1. Deadman switch **open**. Confirm it.
 2. Connect the supply. Press and hold precharge 1–2 s.
 3. Close the deadman. Controller LED should come up. **Hands clear of the disc.**
@@ -123,8 +135,13 @@ motor power, and Stage 0A is the first time that rule becomes physical.
 
    You reach the Pi over SSH from the Mac, so you are still working from your own keyboard. The
    Mac never talks to the CAN bus directly.
+
+   📷 **Capture: first `candump` trace on screen** — see capture plan.
 5. Run the VESC motor detection / FOC setup. It will spin the motor briefly. **Stand out of the
    disc plane and keep the deadman within reach.**
+
+   📷 **Capture: first spin — the single most valuable second in the project.** Phone
+   recording **before** you run detection. See capture plan.
 
 ✅ **Gate: motor detection completes and reports hall sensors found.** If halls are not
 detected, stop — it is a pinout or harness fault, and running sensorless would silently change
@@ -144,6 +161,9 @@ the cleaner number.
 
 ### 6b. `kt` — the two-run inertia method
 The measurement Stage 0 exists for, and the reason no load cell was purchased.
+
+📷 **Capture: first `kt` measurement run** — screen/phone recording of the laptop plot,
+started before Run 1. See capture plan.
 
 1. **Run 1 — bare:** commanded current step, log the acceleration ramp.
 2. **Run 2 — with the disc:** *identical* commanded current, log the ramp.


### PR DESCRIPTION
## Summary
- Adds `docs/capture-plan-assembly.md`: a one-page, ruthlessly-short checklist for capturing every unrepeatable moment of Stage 0A assembly (unboxing, kill-path wiring + test, motor-bolted-to-plate, first power-on, first `candump` trace, first spin, first `kt` run), each under ~30s, for one person working alone.
- States the standing content rule explicitly: failures get captured, not hidden.
- Names where footage goes: a shared Google Drive folder, not this repo (no large binaries in git history).
- Adds minimal 📷 inline markers to `docs/runbook-stage0a-bench.md` at each relevant step, pointing back to the capture plan, without restructuring the runbook.
- Carries the ADR-0008 `covers:` manifest, pointed at the runbook it is order-locked to.

## Turf note
`docs/` is COO-owned per CODEOWNERS; this work was assigned to Sr. Mechanical & Systems by the COO on issue #60. `TURF-OVERRIDE` is in the commit message, and `policy_check.py` confirms it clears the turf check.

## Test plan
- [x] `python3 .github/policy_check.py` — all hard checks pass, turf override recognized
- [x] Runbook markers reviewed against actual §1/§2/§3/§5/§6b step numbering

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)