### PR TITLE
feat(controls): map the closed-loop disturbance-rejection envelope

### DIFF
--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -16,14 +16,15 @@
   loosened blindly: `test_there_is_large_margin_on_actuation_delay` was pinned at 6.80 deg
   (truth pitch) and is now 9.71 deg (the honest number) — still clear of the 18.57 deg strike
   angle, re-baselined to `< 10.5`.
-  **Still open — issue #24's other four ACs, deliberately not attempted in the same PR:**
-  disturbance-rejection **envelope** (currently one fixed magnitude, `NOMINAL_IMPULSE_NS = 20`,
-  not a sweep to a recovery boundary); the `r_eff` tyre-ground justification (geometry is
-  Mechanical's turf — this role can investigate and report, not edit `sim/models/`); confirming
-  every scenario already emits bit-identical metrics JSON (spot-checked true for impulse and
-  closed-loop via existing determinism tests, not re-verified for hill/terrain/shuttle); and an
-  audit marking every acceptance number in the scenario docs as measured vs. assumed. Each is
-  its own well-scoped increment, not a blocker for this one.
+  **AC2 also now cleared (PR TBD):** the disturbance-rejection envelope is mapped, not one
+  fixed magnitude — see the decision-log entry below. **Still open — issue #24's other three
+  ACs, deliberately not attempted in the same PR:** the `r_eff` tyre-ground justification
+  (geometry is Mechanical's turf — this role can investigate and report, not edit
+  `sim/models/`); confirming every scenario already emits bit-identical metrics JSON
+  (spot-checked true for impulse and closed-loop via existing determinism tests, not
+  re-verified for hill/terrain/shuttle); and an audit marking every acceptance number in the
+  scenario docs as measured vs. assumed. Each is its own well-scoped increment, not a blocker
+  for this one.
 - Closed-loop control is in sim; the estimator now closes the loop on the driverless impulse gate
   and the ridden cascade too, not only the shuttle.
 
@@ -35,6 +36,23 @@
 - `.github/workflows/ci.yml` is yours. `.github/policy_check.py` and `CODEOWNERS` are the COO's.
 
 ## Decisions made (append as you go)
+
+- **Issue #24, AC2 — disturbance-rejection envelope (PR TBD).** Added
+  `sim/scenarios/disturbance_envelope.py` (`sweep_closed_loop`, `EnvelopeResult`),
+  `tests/test_disturbance_envelope.py`, and `scripts/disturbance_envelope.py`. A grid sweep
+  (20 N*s steps, `NOMINAL_IMPULSE_NS` to 320 N*s) on the driverless closed-loop board, not a
+  bisection to the exact recovery point: measured directly that `nose_strike` is **not
+  monotonic** in impulse magnitude near the 18.57 deg strike angle (280 and 300 N*s struck,
+  290 and 320 did not — `peak_abs_pitch_deg` sits within ~1 deg of the strike angle across
+  that whole band), so a bisection would converge on an arbitrary knife's-edge crossing that
+  moves with any small upstream change without the controller's real margin having changed. The
+  pinned number is the honest measured one: recovery boundary **260 N*s**, first sampled
+  failure **280 N*s** — 13x `NOMINAL_IMPULSE_NS`. Re-run twice to confirm the sweep itself is
+  deterministic before pinning.
+  **Deliberately left out:** the ridden/cascade plant (issue #24 only asked about the
+  driverless gate here — `test_closed_loop.py`'s ridden section is a separate, larger
+  configuration space); the `r_eff` justification, determinism audit and assumption audit are
+  issue #24's other three ACs, each its own increment.
 
 - **Issue #32, Stage-0B Pi image design (`docs/design-pi-image-stage0b.md`).** Design only, no
   implementation. Repo boundary: a `pi/` directory **in this repo**, argued on the *runtime

--- a/scripts/disturbance_envelope.py
+++ b/scripts/disturbance_envelope.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Report the closed-loop disturbance-rejection envelope (issue #24, AC2).
+
+Sweeps a grid of impulse magnitudes against the driverless closed-loop
+board, prints the per-magnitude table, and writes the same data as JSON so
+it is archived rather than left in a terminal scrollback -- the same
+git-SHA-traceability convention `scripts/experiment.py` uses.
+
+    cargo build --release -p control-ffi
+    .venv/bin/python scripts/disturbance_envelope.py
+
+Requires the control-ffi library to be built (see `sim/scenarios/rust_controller.py`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from sim.scenarios.disturbance_envelope import sweep_closed_loop  # noqa: E402
+from sim.scenarios.impulse_response import NOMINAL_IMPULSE_NS, load_model  # noqa: E402
+from sim.scenarios.rust_controller import RustController  # noqa: E402
+
+OUT_DIR = REPO / "sim" / "out"
+
+
+def git_sha() -> str:
+    try:
+        out = subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=REPO,
+                             capture_output=True, text=True, check=True)
+        dirty = subprocess.run(["git", "status", "--porcelain"], cwd=REPO,
+                               capture_output=True, text=True, check=True)
+        return out.stdout.strip() + ("-dirty" if dirty.stdout.strip() else "")
+    except Exception:
+        return "unknown"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--low", type=float, default=NOMINAL_IMPULSE_NS, help="N*s, sweep start")
+    ap.add_argument("--high", type=float, default=320.0, help="N*s, sweep end (inclusive)")
+    ap.add_argument("--step", type=float, default=20.0, help="N*s, grid spacing")
+    ap.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    args = ap.parse_args()
+
+    magnitudes = []
+    m = args.low
+    while m <= args.high + 1e-9:
+        magnitudes.append(m)
+        m += args.step
+
+    model = load_model()
+    result = sweep_closed_loop(model, RustController, magnitudes)
+
+    print(f"{'magnitude (N*s)':>16}  {'nose strike':>11}  {'peak |pitch| (deg)':>18}")
+    for p in result.points:
+        print(f"{p.magnitude_ns:16.1f}  {str(p.nose_strike):>11}  {p.peak_abs_pitch_deg:18.2f}")
+
+    print(f"\nfirst failure       {result.first_failure_ns} N*s")
+    print(f"recovery boundary   {result.recovery_boundary_ns} N*s")
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.out_dir / "disturbance_envelope_metrics.json"
+    out_path.write_text(
+        json.dumps({"git_sha": git_sha(), **result.to_json_dict()}, indent=2) + "\n"
+    )
+    print(f"\nwrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sim/scenarios/disturbance_envelope.py
+++ b/sim/scenarios/disturbance_envelope.py
@@ -1,0 +1,117 @@
+"""Disturbance-rejection ENVELOPE for the closed-loop controller.
+
+GitHub #24, AC2: the impulse gate (`tests/test_closed_loop.py`) only proves
+the controller survives one fixed magnitude, `NOMINAL_IMPULSE_NS`. That is a
+single point on a curve, not the curve -- it says nothing about how much
+margin is left, or where the controller actually stops coping.
+
+WHY A GRID SWEEP, NOT A BISECTION TO THE EXACT CROSSING
+---------------------------------------------------------
+`nose_strike` is a real bumper-vs-ground contact (see `impulse_response.py`),
+decided against a geometric collision boundary. Close to the strike angle
+(18.57 deg, `nose_strike_angle_deg`) the boolean outcome is NOT monotonic in
+impulse magnitude -- measured directly: at 20 N*s steps from 260 to 320 N*s
+the closed-loop driverless board struck at 280 and 300 N*s but *not* at 290
+or 320 (`peak_abs_pitch_deg` sits within ~1 deg of the strike angle across
+that whole band, so which side of it a run lands on is sensitive to exactly
+where the trajectory is at the moment of closest approach). A bisection
+search would converge on one of those knife-edge crossings and report a
+number that moves with any small upstream change (gains, estimator state,
+even float rounding) without the controller's actual margin having changed.
+
+A coarse grid sweep instead reports a genuine ENVELOPE: every sampled
+magnitude survived or it did not, in order, and the "recovery boundary" is
+the last grid point *before* the first sampled failure -- a number with a
+full grid step of headroom, not a coin-flip on the exact contact frame.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .impulse_response import ImpulseParams, run
+
+
+@dataclass(frozen=True)
+class EnvelopePoint:
+    """One sampled magnitude and what happened."""
+
+    magnitude_ns: float
+    nose_strike: bool
+    peak_abs_pitch_deg: float
+
+
+@dataclass(frozen=True)
+class EnvelopeResult:
+    """The swept envelope, points in ascending magnitude order."""
+
+    points: tuple[EnvelopePoint, ...]
+
+    @property
+    def first_failure_ns(self) -> float | None:
+        """Smallest swept magnitude that struck, or None if nothing did."""
+        return next((p.magnitude_ns for p in self.points if p.nose_strike), None)
+
+    @property
+    def recovery_boundary_ns(self) -> float:
+        """Largest swept magnitude confirmed survivable.
+
+        One grid step below the first sampled failure, or the top of the
+        sweep if nothing in it failed. Raises rather than guessing if the
+        sweep cannot show a boundary at all (nothing survived, or the
+        smallest magnitude sampled already struck).
+        """
+        failure = self.first_failure_ns
+        survived = [p.magnitude_ns for p in self.points if not p.nose_strike]
+        if failure is None:
+            if not survived:
+                raise ValueError("no sampled magnitude survived -- sweep starts too high")
+            return max(survived)
+        below = [m for m in survived if m < failure]
+        if not below:
+            raise ValueError(
+                f"the smallest sampled magnitude ({self.points[0].magnitude_ns} N*s) "
+                "already struck -- sweep starts too high to show a boundary"
+            )
+        return max(below)
+
+    def to_json_dict(self) -> dict:
+        return {
+            "points": [
+                {
+                    "magnitude_ns": p.magnitude_ns,
+                    "nose_strike": p.nose_strike,
+                    "peak_abs_pitch_deg": p.peak_abs_pitch_deg,
+                }
+                for p in self.points
+            ],
+            "first_failure_ns": self.first_failure_ns,
+            "recovery_boundary_ns": self.recovery_boundary_ns,
+        }
+
+
+def sweep_closed_loop(model, controller_factory, magnitudes_ns, sim_seconds=8.0) -> EnvelopeResult:
+    """Run the closed-loop impulse scenario at each magnitude in
+    `magnitudes_ns` (ascending) and report what happened at each.
+
+    `controller_factory` is called once per magnitude and used as a context
+    manager -- the same "fresh controller per run" pattern
+    `tests/test_closed_loop.py` uses, so no run carries hidden state between
+    magnitudes.
+    """
+    points = []
+    for magnitude in magnitudes_ns:
+        with controller_factory() as controller:
+            result = run(
+                ImpulseParams(magnitude_ns=magnitude, sim_seconds=sim_seconds),
+                model=model,
+                controller=controller,
+            )
+        points.append(
+            EnvelopePoint(
+                magnitude_ns=magnitude,
+                nose_strike=result.metrics.nose_strike,
+                peak_abs_pitch_deg=result.metrics.peak_abs_pitch_deg,
+            )
+        )
+    return EnvelopeResult(tuple(points))

--- a/tests/test_disturbance_envelope.py
+++ b/tests/test_disturbance_envelope.py
@@ -1,0 +1,116 @@
+"""Disturbance-rejection ENVELOPE gate (issue #24, AC2).
+
+`tests/test_closed_loop.py` proves the controller survives one fixed
+impulse, `NOMINAL_IMPULSE_NS`. That is a single point. This file sweeps a
+grid of magnitudes on the same driverless closed-loop configuration and
+pins the recovery boundary the sweep actually measures -- see
+`sim/scenarios/disturbance_envelope.py` for why the sweep is a coarse grid
+rather than a bisection to the exact knife's edge.
+
+THE LIBRARY MUST BE BUILT, same as `test_closed_loop.py`:
+
+    cargo build --release -p control-ffi
+"""
+
+import pytest
+
+from sim.scenarios.disturbance_envelope import EnvelopePoint, EnvelopeResult, sweep_closed_loop
+from sim.scenarios.impulse_response import NOMINAL_IMPULSE_NS, load_model
+from sim.scenarios.rust_controller import RustController, library_path
+
+
+@pytest.fixture(scope="module")
+def model():
+    return load_model()
+
+
+def test_the_control_library_is_actually_built():
+    """Fails loudly rather than letting the rest of the file skip."""
+    assert library_path() is not None, (
+        "control-ffi is not built, so the envelope gate would be vacuous. "
+        "Run: cargo build --release -p control-ffi"
+    )
+
+
+# --------------------------------------------------------------------------
+# EnvelopeResult -- the arithmetic, tested against constructed points so it
+# does not need a sim run to check its edge cases.
+# --------------------------------------------------------------------------
+
+def _points(*pairs):
+    """`(magnitude_ns, nose_strike)` pairs -> a tuple of EnvelopePoint."""
+    return tuple(
+        EnvelopePoint(magnitude_ns=m, nose_strike=s, peak_abs_pitch_deg=0.0) for m, s in pairs
+    )
+
+
+def test_recovery_boundary_is_one_grid_step_below_first_failure():
+    result = EnvelopeResult(_points((20, False), (40, False), (60, True), (80, True)))
+    assert result.first_failure_ns == 60
+    assert result.recovery_boundary_ns == 40
+
+
+def test_recovery_boundary_is_the_top_of_the_sweep_if_nothing_failed():
+    result = EnvelopeResult(_points((20, False), (40, False), (60, False)))
+    assert result.first_failure_ns is None
+    assert result.recovery_boundary_ns == 60
+
+
+def test_recovery_boundary_raises_if_the_sweep_starts_too_high():
+    """The smallest sampled magnitude already struck -- there is no
+    survivable point in this sweep to report a boundary from, and guessing
+    one (e.g. zero) would be worse than an explicit failure."""
+    result = EnvelopeResult(_points((60, True), (80, True)))
+    with pytest.raises(ValueError):
+        result.recovery_boundary_ns
+
+
+def test_recovery_boundary_ignores_a_later_reversion_to_survival():
+    """A magnitude past the first failure that happens to survive again
+    (the knife's-edge non-monotonicity documented in the module) must not
+    be picked as "the" boundary -- it would overstate the margin."""
+    result = EnvelopeResult(_points((20, False), (40, False), (60, True), (80, False)))
+    assert result.first_failure_ns == 60
+    assert result.recovery_boundary_ns == 40
+
+
+# --------------------------------------------------------------------------
+# The actual sweep, against the real closed-loop driverless board.
+# --------------------------------------------------------------------------
+
+#: 20 N*s steps from the existing nominal point up to comfortably past where
+#: the controller was measured to first fail. Coarse deliberately -- see
+#: `sim/scenarios/disturbance_envelope.py` for why finer steps chase a
+#: knife's edge rather than mapping a margin.
+SWEEP_MAGNITUDES_NS = tuple(range(int(NOMINAL_IMPULSE_NS), 321, 20))
+
+
+def test_the_envelope_is_mapped_not_a_single_point(model):
+    result = sweep_closed_loop(model, RustController, SWEEP_MAGNITUDES_NS)
+    assert len(result.points) > 2, "a sweep of one or two points is not an envelope"
+    assert [p.magnitude_ns for p in result.points] == sorted(p.magnitude_ns for p in result.points)
+
+
+def test_the_envelope_sweep_is_deterministic(model):
+    """Same property every other scenario gate asserts: same inputs, same
+    trace, so a controller carrying hidden state across runs would be
+    caught."""
+    first = sweep_closed_loop(model, RustController, SWEEP_MAGNITUDES_NS[:3])
+    second = sweep_closed_loop(model, RustController, SWEEP_MAGNITUDES_NS[:3])
+    assert first.to_json_dict() == second.to_json_dict()
+
+
+def test_recovery_boundary_has_large_margin_over_the_nominal_impulse(model):
+    """Measured, not assumed -- re-baseline deliberately if the physics or
+    gains change, the same convention `NOMINAL_IMPULSE_NS` and
+    `EXPECTED_STRIKE_ANGLE_DEG` already use.
+
+    260 N*s is 13x `NOMINAL_IMPULSE_NS` (20 N*s), which is itself already
+    ~60% clear of the open-loop topple threshold -- so the closed-loop
+    controller carries a large, now-measured margin rather than an assumed
+    one.
+    """
+    result = sweep_closed_loop(model, RustController, SWEEP_MAGNITUDES_NS)
+    assert result.first_failure_ns == 280.0
+    assert result.recovery_boundary_ns == 260.0
+    assert result.recovery_boundary_ns > 10 * NOMINAL_IMPULSE_NS


### PR DESCRIPTION
## What changed and why

Issue #24 (AC2): the driverless closed-loop gate (`tests/test_closed_loop.py`) only proves the
controller survives one fixed impulse, `NOMINAL_IMPULSE_NS = 20 N*s`. That is a single point, not
the envelope the acceptance criterion asks for: *"Disturbance-rejection envelope mapped, not a
single point: sweep impulse magnitude and report the recovery boundary."*

- `sim/scenarios/disturbance_envelope.py` — `sweep_closed_loop()` runs the closed-loop impulse
  scenario across a grid of magnitudes; `EnvelopeResult` derives `first_failure_ns` and
  `recovery_boundary_ns` from the sampled points.
- `tests/test_disturbance_envelope.py` — CI gate. Unit tests on the boundary arithmetic against
  constructed points (fast, no sim), plus the real sweep against the driverless closed-loop board,
  pinning the measured recovery boundary.
- `scripts/disturbance_envelope.py` — CLI to print the table and archive the JSON, mirroring
  `scripts/experiment.py`'s conventions (git-SHA-stamped, `sim/out/` which is gitignored).

**Why a grid sweep, not a bisection to the exact recovery point.** I measured this directly rather
than assuming it: at 20 N*s steps from 260–320 N*s, the closed-loop board struck at 280 and 300 N*s
but *not* at 290 or 320 — `peak_abs_pitch_deg` sits within ~1 deg of the 18.57 deg strike angle
across that whole band, so `nose_strike` is not monotonic in impulse magnitude that close to the
geometric collision threshold. A bisection would converge on one of those knife-edge crossings and
report a number that moves with any small upstream change (gains, estimator, float rounding)
without the controller's actual margin having changed. The coarse grid instead reports a genuine
envelope, and the pinned "recovery boundary" is the last grid point *before* the first sampled
failure — a full grid step of headroom, not a coin flip.

**Measured, not assumed:** recovery boundary **260 N*s**, first sampled failure **280 N*s** — 13x
`NOMINAL_IMPULSE_NS` (itself already ~60% clear of the open-loop topple threshold). Re-ran the
sweep twice to confirm it is deterministic before pinning either number.

## Acceptance criteria (issue #24, AC2 only)

- [x] Disturbance-rejection envelope mapped, not a single point: sweep impulse magnitude and
      report the recovery boundary.

Issue #24 has three other ACs (`r_eff` tyre-ground justification, a determinism audit across all
four scenarios, and an assumed-vs-measured audit of every acceptance number). Each is its own
well-scoped increment per the role's standing convention — not attempted here, and the issue stays
open for them. Not closing #24 in this PR.

## What I deliberately left out

- **The ridden/cascade plant.** Issue #24's AC2 language matches the driverless gate's existing
  single-point test (`test_closed_loop_prevents_the_nose_strike`); the ridden cascade is a larger
  configuration space (inner + outer loop gains, ballast mass) and its own increment.
- **The other three ACs of #24** — see above.

## Turf

`sim/scenarios/disturbance_envelope.py` — mine (`/sim/` minus `plant.py`/`imperfections.py`).
`tests/`, `scripts/`, `roles/senior-controls/CONTEXT.md` — mine outright. Confirmed with
`python3 .github/policy_check.py --who <path>` for each new file.

## Verification

- `.venv/bin/python3 -m pytest tests/` → 201 passed, 2 xfailed (up from 193 passed on master; no
  regressions), after `cargo build --release -p control-ffi`
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅ (no Rust touched)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo run -p xtask -- gate` ✅ (unaffected — no crate dependency changes)
- `python3 .github/policy_check.py` ✅ all hard checks pass

No `sim/models/`, `sim/scenarios/plant.py`, or `sim/scenarios/imperfections.py` touched —
Mechanical's fidelity contract is imported read-only, nothing in it changed.

Closes: none (see above — partial AC on issue #24)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdatY4Rw5ivKfSTjybo5a1)_