### PR TITLE
fix(mech): give bench_spinup.spindown() a data-driven settle window

### DIFF
--- a/roles/sr-mechanical-systems/CONTEXT.md
+++ b/roles/sr-mechanical-systems/CONTEXT.md
@@ -73,6 +73,23 @@ now cross-check: free-roll agreement 0.24–1.78% to 20% grade, bit-identical on
 asymmetry Controls measured falls out of geometry, because a board resting flat on a slope is
 already at world pitch −φ. PR #18.
 
+**2026-07-28 — `spindown()` gets the same settle window `identify()` got, mirrored for a decay.**
+Flagged by Senior Controls (#68) while dry-running the Stage-0B runbook: unlike `identify()`,
+`spindown()` had no data-driven settle window, so its friction fit ran straight through the
+actuation-delay + current-loop-lag transient at the START of the coast-down. Under the default
+profile that collapsed R² to ~0.002 — noise, not a curve — because the friction regression's
+design matrix (`[w, sign(w)]`) has no column to absorb the transient's torque, unlike `identify()`
+where the same transient only ever scaled a slope. Fix: `decay_settle_time_s`, the decay-side twin
+of `settle_time_s`, waits for the *measured* current to decay to within `settle_fraction` of zero
+and stay there before either the two-term or the lumped-fit diagnostic runs. Needed a tighter
+`settle_fraction` than `identify()`'s 0.99 (0.9999) because there is no current column to absorb
+residual bias here — 0.99 still left R²=0.635; 0.9999 gives R²=0.9999, b/tau_c error <0.05%, at a
+window-open time (12.5 ms) that costs nothing against a 2 s decay. No published friction figure
+had ever been derived through the STAGE0 path — only `IDEAL` was ever asserted — so nothing
+downstream needed correcting, only the `scripts/stage0b_runbook.py::step_coast_down` `IDEAL`
+workaround needs removing now, which is Senior Controls' file. PR: TBD (branch
+`feat/mech/spindown-settle-window`), closes #68.
+
 ## Known dead ends
 
 - **Do not lift the board clear of the ground to isolate accelerometer geometry.** A free-floating

--- a/roles/sr-mechanical-systems/CONTEXT.md
+++ b/roles/sr-mechanical-systems/CONTEXT.md
@@ -87,8 +87,7 @@ residual bias here — 0.99 still left R²=0.635; 0.9999 gives R²=0.9999, b/tau
 window-open time (12.5 ms) that costs nothing against a 2 s decay. No published friction figure
 had ever been derived through the STAGE0 path — only `IDEAL` was ever asserted — so nothing
 downstream needed correcting, only the `scripts/stage0b_runbook.py::step_coast_down` `IDEAL`
-workaround needs removing now, which is Senior Controls' file. PR: TBD (branch
-`feat/mech/spindown-settle-window`), closes #68.
+workaround needs removing now, which is Senior Controls' file. PR #70.
 
 ## Known dead ends
 

--- a/sim/scenarios/bench_spinup.py
+++ b/sim/scenarios/bench_spinup.py
@@ -116,6 +116,41 @@ acceleration directly against `[w, sign(w)]`:
 `J` is read directly off the compiled model (`_joint_inertia`) rather than
 re-derived here -- that is mode 1's job, not this one's.
 
+SPIN-DOWN HAD THE SAME WINDOWING BUG AS identify(), AND IT WAS WORSE (#68)
+---------------------------------------------------------------------------
+`identify()` opens its fit window once the measured current has settled INTO
+a step (`settle_time_s`). Until this fix, `spindown()` had no equivalent for
+the mirror-image transient: the command drops to zero, but under
+`STAGE0_PLACEHOLDER` the actuation delay and current-loop lag mean the
+current actually delivered decays away from `spin_up_current_a` rather than
+vanishing instantly. For the first few milliseconds of the "decay", the shaft
+is still seeing several amps -- and unlike `identify()`'s ramp, which is
+merely suppressed by a roughly constant factor, this puts a torque transient
+an order of magnitude larger than the genuine friction deceleration straight
+into a regression whose design matrix (`[w, sign(w)]`) has no column to
+absorb it. Measured result: R^2 ~ 0.002 under the default profile -- noise,
+not a curve (issue #68, raised by Senior Controls while dry-running the
+Stage-0B runbook, `spindown()` being this role's file).
+
+The fix is the same shape as `identify()`'s, mirrored for a falling rather
+than a rising current: `decay_settle_time_s` waits for the measured current
+to decay to within `settle_fraction` of zero and STAY there, data-driven off
+the current trace exactly like `settle_time_s` -- there is no profile object
+on real hardware, only a current sensor, and this rig's whole job is to
+characterise that signal path. Both the two-term and the lumped-fit
+diagnostic now run over the post-settle window only. On `IDEAL` the window
+opens at the very first sample (nothing to wait for) so behaviour there is
+unchanged; `test_spindown_recovers_friction_terms_under_the_stage0_profile`
+pins the STAGE0 recovery so this cannot regress silently the way the original
+bug did.
+
+No published friction figure was ever derived through the STAGE0 path: the
+only spindown assertions in this suite ran on `IDEAL`, and the Stage-0B
+runbook dry run (`scripts/stage0b_runbook.py::step_coast_down`) used `IDEAL`
+as an explicit, documented workaround pending this fix. There is nothing to
+correct downstream -- only the workaround to remove, which is Senior
+Controls' file to change.
+
 CATEGORY ERROR GUARD
 ---------------------
 This bench motor's kt is ~0.05 N*m/A (a 190 kv 6374). The onewheel hub
@@ -307,6 +342,45 @@ def settle_time_s(
         raise ValueError(
             "measured current settles only at the very last sample -- no ramp "
             "left to fit. Increase IdentifyParams.sim_seconds."
+        )
+    return float(t[idx])
+
+
+def decay_settle_time_s(
+    t: np.ndarray, i_measured: np.ndarray, initial_current_a: float, fraction: float,
+) -> float:
+    """First instant after which the measured current, released from
+    `initial_current_a` when the command drops to zero, STAYS within
+    `1 - fraction` of zero.
+
+    The decay-side twin of `settle_time_s` (see #68): that one waits for
+    current to rise INTO a held command; this one waits for it to fall AWAY
+    from one, because the actuation delay and current-loop lag delay the
+    fall exactly as they delay the rise. Same "stays within" search from the
+    end for the same reason -- a staircased or noisy current can cross the
+    threshold once on the way down and bounce back before it has genuinely
+    settled, and the LAST crossing is what bounds the transient.
+
+    Data-driven on purpose, exactly like `settle_time_s`: on hardware there
+    is no profile object to consult for how long the current loop takes to
+    unwind, only a current sensor, and characterising that signal path is
+    this rig's job.
+    """
+    threshold = (1.0 - fraction) * abs(initial_current_a)
+    ok = np.abs(np.asarray(i_measured)) <= threshold
+    if not ok.any():
+        raise ValueError(
+            f"measured current never decayed within {1.0 - fraction:.0%} of "
+            f"{initial_current_a} A of zero. Either the current-loop lag "
+            "exceeds SpindownParams.decay_s or the run is too short to "
+            "contain a settled decay."
+        )
+    violations = np.flatnonzero(~ok)
+    idx = 0 if violations.size == 0 else int(violations[-1]) + 1
+    if idx >= len(t):
+        raise ValueError(
+            "measured current settles only at the very last sample -- no "
+            "decay left to fit friction against. Increase SpindownParams.decay_s."
         )
     return float(t[idx])
 
@@ -561,6 +635,34 @@ class SpindownParams:
     constant is ~18 s, so the decay is nowhere near complete, but the speed
     swept is still wide enough to separate the two friction terms)."""
 
+    settle_fraction: float = 0.9999
+    """Fraction of the way from `spin_up_current_a` to zero the measured
+    current must decay -- and stay -- before the friction-fit window opens.
+
+    Mirrors `IdentifyParams.settle_fraction` (see #68), but tighter, and for
+    a reason specific to this fit: the friction regression's design matrix is
+    `[w, sign(w)]`, with no column for a current term, so ANY residual
+    current-loop torque left in the window is pure unmodelled signal, not a
+    small bias the way Coulomb is for `identify()`'s kt. `identify()` can
+    afford 0.99 because its 14 ms window is itself tiny; this decay runs for
+    `decay_s` (2 s by default), so there is no cost to waiting for the
+    transient to genuinely die out.
+
+    Measured on the default profile (fraction -> window opens at / R^2 /
+    b error / tau_c error):
+
+        0.99     ->  7.0 ms  /  R^2=0.635   /  4.51%   /  1.95%
+        0.999    -> 10.0 ms  /  R^2=0.996   /  0.389%  /  0.165%
+        0.9999   -> 12.5 ms  /  R^2=0.9999  /  0.043%  /  0.015%
+        0.99999  -> 15.5 ms  /  R^2=0.99999 /  0.0049% /  0.0058%
+
+    0.99 is what `identify()` uses and is not nearly tight enough here --
+    0.2 A of residual current (1% of the 20 A spin-up) still produces ~5.4
+    rad/s^2 of unmodelled torque, comparable to the friction deceleration
+    itself. 0.9999 clears the same R^2 > 0.999 bar the ideal run holds, with
+    a wide margin still visible in the 0.99999 row; going tighter buys very
+    little further and starts trading away decay data for no real gain."""
+
 
 @dataclass
 class SpindownMetrics:
@@ -570,6 +672,15 @@ class SpindownMetrics:
     b_fit_nm_s_per_rad: float = 0.0
     tau_c_fit_nm: float = 0.0
     r2: float = 0.0
+
+    #: Where the friction-fit window actually started, seconds from current-cut
+    #: (t=0 of the decay). DERIVED FROM THE DATA (`decay_settle_time_s`), not a
+    #: parameter -- reported for the same reason `identify()` reports
+    #: `fit_start_s`: a fit is not reproducible unless the window it used is
+    #: stated alongside it. On `IDEAL` this is ~0 (nothing to wait for); under
+    #: `STAGE0_PLACEHOLDER` it is the time the current-loop transient took to
+    #: unwind. See #68.
+    fit_start_s: float = 0.0
 
     #: What the model was actually built with -- read off the compiled model
     #: rather than hardcoded, so a change to bench_rig.xml's placeholders
@@ -628,7 +739,7 @@ def spindown(
 
     n_decay = int(round(params.decay_s / dt))
     t0 = float(data.time)
-    ts, ws, accs = [], [], []
+    ts, ws, accs, i_meas = [], [], [], []
     for _ in range(n_decay):
         current = imp.apply_current(0.0)
         data.ctrl[0] = current * NAMEPLATE_KT_NM_PER_A
@@ -636,27 +747,41 @@ def spindown(
         ts.append(float(data.time) - t0)
         ws.append(imp.wheel_rate(float(data.qvel[0]), float(data.time)))
         accs.append(float(data.qacc[0]))
+        i_meas.append(current)
 
     t = np.asarray(ts)
     w = np.asarray(ws)
     acc = np.asarray(accs)
+    i_dec = np.asarray(i_meas)
     j = _joint_inertia(model)
 
-    # Two-term fit: qacc = -(b/J)*w - (tau_c/J)*sign(w).
-    sgn = np.sign(w)
-    design = np.vstack([w, sgn]).T
-    (c1, c2), *_ = np.linalg.lstsq(design, acc, rcond=None)
+    # The friction fit must not see the current-loop's own unwind -- see the
+    # module docstring (#68). Data-driven, exactly like identify()'s settle
+    # window: wait for the MEASURED current, not the profile, to say the
+    # transient is over.
+    t_start = decay_settle_time_s(t, i_dec, params.spin_up_current_a, params.settle_fraction)
+    fit_mask = t >= t_start
+    w_fit = w[fit_mask]
+    acc_fit = acc[fit_mask]
+
+    # Two-term fit: qacc = -(b/J)*w - (tau_c/J)*sign(w), over the settled
+    # window only.
+    sgn = np.sign(w_fit)
+    design = np.vstack([w_fit, sgn]).T
+    (c1, c2), *_ = np.linalg.lstsq(design, acc_fit, rcond=None)
     b_fit = -c1 * j
     tau_c_fit = -c2 * j
     pred = design @ np.array([c1, c2])
-    ss_res = float(np.sum((acc - pred) ** 2))
-    ss_tot = float(np.sum((acc - acc.mean()) ** 2))
+    ss_res = float(np.sum((acc_fit - pred) ** 2))
+    ss_tot = float(np.sum((acc_fit - acc_fit.mean()) ** 2))
     r2 = 1.0 - ss_res / ss_tot if ss_tot > 0.0 else 1.0
 
-    # Lumped (viscous-only) fit -- the defect the two-term fit replaces.
-    b_lump = -float(np.dot(w, acc) / np.dot(w, w))
-    resid_lump = acc - (-b_lump * w)
-    order = np.argsort(w)
+    # Lumped (viscous-only) fit -- the defect the two-term fit replaces. Same
+    # settled window, so the diagnostic is a fair comparison against the
+    # two-term fit above rather than against a different slice of the data.
+    b_lump = -float(np.dot(w_fit, acc_fit) / np.dot(w_fit, w_fit))
+    resid_lump = acc_fit - (-b_lump * w_fit)
+    order = np.argsort(w_fit)
     k = max(1, len(order) // 20)  # slowest / fastest 5% of the logged speeds
     resid_lo = float(resid_lump[order[:k]].mean())
     resid_hi = float(resid_lump[order[-k:]].mean())
@@ -670,6 +795,7 @@ def spindown(
         b_fit_nm_s_per_rad=b_fit,
         tau_c_fit_nm=tau_c_fit,
         r2=r2,
+        fit_start_s=t_start,
         b_placeholder_nm_s_per_rad=b_true,
         tau_c_placeholder_nm=tau_c_true,
         b_error_pct=abs(b_fit - b_true) / b_true * 100.0 if b_true else 0.0,
@@ -853,6 +979,8 @@ def main() -> int:
         result = spindown(params, profile=profile)
         m = result.metrics
         print(f"=== bench spindown  [profile={m.imperfection_profile_id}]")
+        print(f"  fit window opens at {m.fit_start_s*1e3:.2f} ms "
+              "(current-loop transient excluded)")
         print(f"  speed swept     {m.w0_rad_s:.2f} -> {m.w_end_rad_s:.2f} rad/s")
         print(f"  b fit           {m.b_fit_nm_s_per_rad:.6e} N*m*s/rad "
               f"(placeholder {m.b_placeholder_nm_s_per_rad:.2e}, {m.b_error_pct:.3f}% off)")

--- a/tests/test_bench_spinup.py
+++ b/tests/test_bench_spinup.py
@@ -38,6 +38,7 @@ from sim.scenarios.bench_spinup import (
     IdentifyParams,
     SpindownParams,
     build_bare_model,
+    decay_settle_time_s,
     known_disc_inertia_kg_m2,
     load_model,
     replay,
@@ -270,6 +271,107 @@ def test_spindown_lumped_fit_residual_changes_sign(loaded_model):
     assert m.lumped_residual_changes_sign, (
         f"lo={m.lumped_residual_low_speed_rad_s2}, hi={m.lumped_residual_high_speed_rad_s2}"
     )
+
+
+def test_spindown_recovers_friction_terms_under_the_stage0_profile(loaded_model):
+    """**The assertion whose absence let R^2 collapse to ~0.002 ship green** (#68).
+
+    Before the fix, `spindown()` had no settle window: the least-squares fit
+    ran from the instant current was commanded to zero, straight through the
+    actuation-delay + current-loop-lag transient while real current was still
+    decaying off the shaft. Under the default profile that produced an R^2 of
+    ~0.002 -- noise, not a curve -- yet nothing asserted it, so the only
+    spindown test in this suite (on `IDEAL`, where there is no transient to
+    hide) stayed green regardless.
+
+    Tolerances match the ideal run's (1%) because after the fix there is no
+    reason STAGE0 should be worse: both profiles now fit over a settled
+    window, and the only thing STAGE0 adds is a longer wait for the transient
+    to clear, not a bias in the result.
+    """
+    m = spindown(SpindownParams(), model=loaded_model, profile=STAGE0_PLACEHOLDER).metrics
+    assert m.r2 > 0.999, (
+        f"R^2={m.r2:.4f} -- if this is near zero the fit window is back inside "
+        "the current-loop's unwind transient"
+    )
+    assert m.b_fit_nm_s_per_rad == pytest.approx(m.b_placeholder_nm_s_per_rad, rel=0.01)
+    assert m.tau_c_fit_nm == pytest.approx(m.tau_c_placeholder_nm, rel=0.01)
+
+
+def test_the_spindown_fit_window_opens_after_the_current_has_decayed(loaded_model):
+    """The mechanism, pinned so it cannot regress back to fitting from t=0.
+
+    Under Stage-0 there is 1 ms of actuation delay plus a 1 ms current-loop
+    time constant on the way DOWN to zero, just as there is on the way up in
+    `identify()`, so a settled window cannot start at t=0. On IDEAL there is
+    nothing to wait for, so it must start immediately. Both directions are
+    asserted, exactly mirroring
+    `test_the_fit_window_opens_after_the_current_has_settled` for `identify()`.
+    """
+    stage0 = spindown(SpindownParams(), model=loaded_model, profile=STAGE0_PLACEHOLDER).metrics
+    ideal = spindown(SpindownParams(), model=loaded_model, profile=IDEAL).metrics
+
+    assert stage0.fit_start_s > 0.005, (
+        f"window opened at {stage0.fit_start_s*1e3:.1f} ms -- too early to have "
+        "cleared the current-loop's unwind transient"
+    )
+    assert ideal.fit_start_s < 0.002, (
+        f"window opened at {ideal.fit_start_s*1e3:.1f} ms on a profile with no "
+        "delay and no lag -- the settle detector is not data-driven"
+    )
+
+
+def test_spindown_fitting_from_zero_reproduces_the_r2_collapse(loaded_model):
+    """The counterfactual, so the reason for the window is measured and not
+    just asserted in a docstring -- mirrors
+    `test_fitting_from_zero_reproduces_the_original_50_percent_error` for
+    `identify()`.
+
+    `settle_fraction=0.0` reconstructs the pre-fix behaviour (window opens at
+    the first sample, i.e. fits straight through the transient) without
+    duplicating `spindown()`'s internals. If this stops reproducing a
+    near-zero R^2, the current-loop model has changed and the windowing
+    rationale needs revisiting rather than being trusted.
+    """
+    m = spindown(
+        SpindownParams(settle_fraction=0.0), model=loaded_model, profile=STAGE0_PLACEHOLDER,
+    ).metrics
+    assert m.r2 < 0.1, (
+        f"R^2={m.r2:.4f} fitting from t=0 -- expected a collapse close to the "
+        "~0.002 reported in #68; the current-loop model may have changed"
+    )
+    assert m.b_error_pct > 20.0 and m.tau_c_error_pct > 20.0, (
+        "expected the from-zero fit to badly mis-recover both friction terms, "
+        f"got b_error={m.b_error_pct:.2f}%, tau_c_error={m.tau_c_error_pct:.2f}%"
+    )
+
+
+# --------------------------------------------------------------------------
+# decay_settle_time_s -- unit-level, no sim
+# --------------------------------------------------------------------------
+
+def test_decay_settle_time_s_waits_for_the_last_violation():
+    """"Stays within", not "first reaches": a current that dips under the
+    threshold and bounces back out must not open the window early."""
+    t = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+    i_measured = np.array([20.0, 0.05, 5.0, 0.05, 0.02, 0.01])  # dip at t=1, then back up at t=2
+    t_start = decay_settle_time_s(t, i_measured, initial_current_a=20.0, fraction=0.99)
+    assert t_start == pytest.approx(3.0), (
+        "must skip past the t=2 bounce-back, not stop at the first dip under threshold"
+    )
+
+
+def test_decay_settle_time_s_opens_immediately_when_already_settled():
+    t = np.array([0.0, 1.0, 2.0])
+    i_measured = np.array([0.0, 0.0, 0.0])
+    assert decay_settle_time_s(t, i_measured, initial_current_a=20.0, fraction=0.99) == 0.0
+
+
+def test_decay_settle_time_s_raises_if_current_never_decays():
+    t = np.array([0.0, 1.0, 2.0])
+    i_measured = np.array([20.0, 19.0, 18.0])
+    with pytest.raises(ValueError, match="never decayed"):
+        decay_settle_time_s(t, i_measured, initial_current_a=20.0, fraction=0.99)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What changed and why

Issue #68 (found by Senior Controls while dry-running the Stage-0B runbook, flagged rather
than fixed since `bench_spinup.py` is Mechanical's turf): `identify()` has a data-driven
`settle_time_s` window before its ramp fit opens; `spindown()` had no equivalent. So its
two-term friction fit (`qacc = -(b/J)*w - (tau_c/J)*sign(w)`) ran from the instant current was
commanded to zero, straight through the actuation-delay + current-loop-lag transient while real
current was still decaying off the shaft. Measured: **R² collapsed to ~0.002** under the default
profile — noise, not a curve — reproduced exactly in this PR's regression test.

Why this one was worse than `identify()`'s equivalent bug (#13, 50.4% kt error): `identify()`'s
transient only ever *scaled* a slope, so the fit stayed a line, just the wrong line. The friction
regression's design matrix, `[w, sign(w)]`, has no column for a current term at all, so the
leftover transient torque is pure unmodelled signal — it doesn't bias the fit, it destroys it.

- `sim/scenarios/bench_spinup.py` — `decay_settle_time_s`, the decay-side twin of
  `settle_time_s`: waits for the *measured* current to decay to within `settle_fraction` of
  zero and stay there (searching from the end, so a noisy dip-and-bounce doesn't open the
  window early) before either the two-term fit or the lumped-fit diagnostic runs. Data-driven
  off the current trace, not the profile — same reason as `identify()`: hardware has a current
  sensor, not a profile object.
- `SpindownParams.settle_fraction` (new, default `0.9999`) — tighter than `identify()`'s `0.99`
  on purpose, and the docstring records the sensitivity sweep that justifies it: 0.99 still left
  R²=0.635 (0.2 A of residual current is ~5.4 rad/s² of unmodelled torque, comparable to the
  friction deceleration itself); 0.9999 gives R²=0.9999, b/tau_c error <0.05%, opening the window
  at 12.5 ms — negligible against a 2 s decay.
- `SpindownMetrics.fit_start_s` (new) — reported, mirroring `identify()`'s `fit_start_s`, so the
  window a fit used is stated alongside it rather than implied.
- `tests/test_bench_spinup.py` — new STAGE0 recovery test (R² > 0.999, b/tau_c error < 1%,
  same tolerance as the ideal run), a settle-window mechanism test mirroring `identify()`'s, a
  counterfactual reproducing the ~0.002 collapse (`settle_fraction=0.0`), and unit tests for
  `decay_settle_time_s` itself (dip-and-bounce, already-settled, never-settles).

**Measured, not assumed:** R² 0.002 → 0.9999, b error 650% → 0.043%, tau_c error 278% → 0.015%,
on the default `STAGE0_PLACEHOLDER` profile. `IDEAL` behaviour is unchanged (window still opens
at the first sample — nothing to wait for).

## Acceptance criteria (issue #68)

- [x] `spindown()` gets a settle window equivalent to `identify()`'s — data-driven, not a
      hardcoded constant.
- [x] Fit quality is reported (`fit_start_s`, already-existing `r2`), not just the fitted value.
- [x] A test that fails if the fit degrades below a stated R² threshold (`r2 > 0.999`) on the
      default (known-good) profile.
- [x] Works under `STAGE0_PLACEHOLDER`, not only `IDEAL`.
- [x] Whether a published friction figure was derived through this path: **no.** The only
      spindown assertion in this suite ever ran on `IDEAL`
      (`test_spindown_recovers_friction_terms_on_ideal_run`), and the Stage-0B runbook dry run
      (`scripts/stage0b_runbook.py::step_coast_down`) used `IDEAL` as an explicit, documented
      workaround pending this fix. Nothing downstream needs correcting.

## Out of scope / for Senior Controls

`scripts/stage0b_runbook.py::step_coast_down` hardcodes `profile: ImperfectionProfile = IDEAL`
as that documented workaround, with a docstring pointing at this same defect. Per the issue's
own note ("once this lands, that workaround should be removed"), removing it is a one-line
change — but `scripts/` is Senior Controls' turf, not mine, so it's called out here rather than
touched. `docs/runbook-stage0b-bench.md` (COO turf) has matching prose that would need the same
update.

## Turf

`sim/scenarios/bench_spinup.py`, `tests/test_bench_spinup.py`, `roles/sr-mechanical-systems/` —
all mine per `.github/policy_check.py --who`. No `<sensor>`/`<actuator>` elements or `plant.py`/
`imperfections.py` touched. No bench-fitted constant written into a board model.

## Verification

- `.venv (py3.13)/bin/python3 -m pytest tests/` → 208 passed, 2 xfailed (up from 201 passed on
  `master`; no regressions), after `cargo build --release -p control-ffi`
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅ (no Rust touched)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `python3 .github/policy_check.py` ✅ all hard checks pass

Closes #68

---
_Generated by [Claude Code](https://claude.ai/code/session_01D31m5eD8B5JZd546ouyXtm)_