### PR TITLE
fix(controls): target-gate can-harness's socketcan dep for macOS

### DIFF
--- a/crates/can-harness/Cargo.toml
+++ b/crates/can-harness/Cargo.toml
@@ -6,6 +6,12 @@ license.workspace = true
 
 [dependencies]
 vesc-wire = { workspace = true }
+
+# socketcan binds Linux-specific socket constants (AF_CAN, PF_CAN) and does
+# not build on macOS/Windows. Target-gated here so `cargo build --workspace`
+# succeeds on those platforms; src/lib.rs cfg-gates the code that uses it to
+# match (issue #62). Do not move this back to an unconditional dependency.
+[target.'cfg(target_os = "linux")'.dependencies]
 socketcan = { workspace = true }
 
 [dev-dependencies]

--- a/crates/can-harness/src/lib.rs
+++ b/crates/can-harness/src/lib.rs
@@ -17,11 +17,20 @@
 //! top of: [`RawFrame`] in, over a real Linux CAN socket, [`RawFrame`] out,
 //! byte-for-byte, including the sign and scaling bits a fabricated constant
 //! could not be trusted to get right anyway.
+//!
+//! **Linux-only.** `socketcan` and `vcan` are both Linux kernel facilities,
+//! so everything here is `#[cfg(target_os = "linux")]`-gated (issue #62):
+//! on another platform this crate compiles to an empty, harmless no-op
+//! rather than failing `cargo build --workspace`.
 
+#[cfg(target_os = "linux")]
 pub mod responder;
+#[cfg(target_os = "linux")]
 pub mod vcan;
 
+#[cfg(target_os = "linux")]
 use socketcan::{CanDataFrame, EmbeddedFrame, Frame as SocketCanFrame};
+#[cfg(target_os = "linux")]
 use vesc_wire::RawFrame;
 
 /// Converts a [`RawFrame`] to the frame type `socketcan` sends on the wire.
@@ -29,12 +38,14 @@ use vesc_wire::RawFrame;
 /// `RawFrame::id`'s magnitude picks standard (11-bit) vs extended (29-bit)
 /// automatically, the same convention `ip link`/`candump` use -- callers
 /// don't choose a frame flavour, the id's range does.
+#[cfg(target_os = "linux")]
 pub fn to_can_frame(frame: RawFrame) -> Option<CanDataFrame> {
     CanDataFrame::from_raw_id(frame.id, frame.bytes())
 }
 
 /// Converts a received `socketcan` frame back to the shape `vesc-wire` and
 /// `vesc-tx` share.
+#[cfg(target_os = "linux")]
 pub fn from_can_frame(frame: &CanDataFrame) -> RawFrame {
     let bytes = frame.data();
     let mut data = [0u8; 8];
@@ -46,7 +57,7 @@ pub fn from_can_frame(frame: &CanDataFrame) -> RawFrame {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
 

--- a/crates/can-harness/tests/vcan_stack.rs
+++ b/crates/can-harness/tests/vcan_stack.rs
@@ -13,6 +13,13 @@
 //!
 //! Each test uses its own interface name so they can run concurrently
 //! without colliding.
+//!
+//! Gated on `target_os = "linux"` (issue #62): `can_harness` compiles to a
+//! no-op on other platforms, so this whole file would fail to compile
+//! against it there. On a non-Linux `cargo test --workspace` this binary
+//! builds with zero tests, which is the correct outcome, not a weakening --
+//! `vcan`/`socketcan` do not exist to skip against off Linux.
+#![cfg(target_os = "linux")]
 
 use can_harness::responder::SimResponder;
 use can_harness::vcan::up_or_skip;

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -128,6 +128,21 @@
   (O3, issues #51/#52 still open), and a stub with nothing to execute it would be exactly the
   unverifiable code this project rules out.
 
+- **Issue #62, target-gate `can-harness`'s `socketcan` dependency (PR TBD).** Follow-up from
+  #53: `socketcan` was an unconditional workspace dependency, so `cargo build --workspace` failed
+  on macOS (the CEO's machine). Moved `socketcan` to a
+  `[target.'cfg(target_os = "linux")'.dependencies]` table in `crates/can-harness/Cargo.toml` and
+  `#[cfg(target_os = "linux")]`-gated every item in `src/lib.rs` that touches it (`responder`,
+  `vcan`, `to_can_frame`/`from_can_frame`, their unit test); `tests/vcan_stack.rs` gets
+  `#![cfg(target_os = "linux")]` so it compiles to zero tests off Linux instead of failing to
+  compile against a crate with no socketcan items. **Verified for real, not assumed:** this
+  sandbox has no macOS runner, so verification used `rustup target add x86_64-apple-darwin` and
+  `cargo check`/`cargo clippy --workspace --all-targets --target x86_64-apple-darwin -- -D
+  warnings` — both clean, and `can-harness` compiles to an empty crate on that target as
+  intended. Linux side re-verified unchanged: `cargo test -p can-harness` still runs all four
+  vcan tests and prints `SKIP` for each (no `CAP_NET_ADMIN`/`vcan` module in this sandbox, the
+  expected unprivileged outcome), `cargo run -p xtask -- gate` still passes.
+
 _Older entries collapsed above this line as the log grows; nothing predates the crate-exclusion entry._
 
 ## Known dead ends


### PR DESCRIPTION
## What changed and why

Issue #62 (follow-up from #53, merged deliberately rather than blocked on this): `socketcan =
"3.6"` was an **unconditional** workspace dependency, and `crates/can-harness` depended on it
unconditionally. `socketcan` binds Linux-specific socket constants (`AF_CAN`, `PF_CAN`) and does
not build on macOS, so `cargo build --workspace` failed on the CEO's machine. CI is Linux-only
(`ubuntu-latest`) so it stayed green throughout — this was a dev-experience bug, not a
correctness one.

- `crates/can-harness/Cargo.toml` — moved `socketcan` out of `[dependencies]` into a
  `[target.'cfg(target_os = "linux")'.dependencies]` table, with a comment stating why so it
  doesn't get moved back.
- `crates/can-harness/src/lib.rs` — `#[cfg(target_os = "linux")]` on the `responder`/`vcan`
  module declarations, the `socketcan`/`vesc_wire` imports, `to_can_frame`/`from_can_frame`, and
  their unit test. Off Linux, the crate compiles to an empty, harmless no-op instead of failing.
- `crates/can-harness/tests/vcan_stack.rs` — `#[cfg(target_os = "linux")]` at the top, so off
  Linux the integration test binary compiles with zero tests instead of failing to compile
  against a crate that no longer exports the items it uses.

## Acceptance criteria (issue #62)

- [x] `cargo build --workspace`/`cargo test --workspace` succeed on macOS (skipping the harness).
- [x] On Linux, everything still builds and the vcan tests still run — nothing weakened.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` stays clean on both.
- [x] The mechanism (target-gated dependency + matching `cfg` in code) is stated in a comment.

## Verification

This sandbox has no macOS runner, so I did not fabricate a "verified on macOS" claim — instead
used a real cross-target compiler check via `rustup target add x86_64-apple-darwin`:

- `cargo check --workspace --all-targets --target x86_64-apple-darwin` ✅ — `can-harness`
  compiles to an empty crate on that target as intended, rest of the workspace unaffected.
- `cargo clippy --workspace --all-targets --target x86_64-apple-darwin -- -D warnings` ✅ clean.
- Linux side re-verified unchanged: `cargo test -p can-harness` → all 4 `vcan_stack` tests still
  run and print `SKIP` (no `CAP_NET_ADMIN`/`vcan` module in this sandbox — the expected
  unprivileged outcome per #52), unit test still passes.
- `cargo build --workspace --all-targets` ✅ (native Linux)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (native Linux)
- `cargo run -p xtask -- gate` ✅ (unaffected)
- `python3 .github/policy_check.py` ✅ all hard checks pass

## What I deliberately left out

Nothing beyond the issue's own scope — this is a 3-file, single-concern dependency/cfg fix.
Did not touch the root `Cargo.toml`'s `socketcan = "3.6"` line under `[workspace.dependencies]`;
it's inert there (only pulled into a build when a member references it via `{ workspace = true }`)
and `can-harness` is now the only such reference, itself target-gated.

## Turf

`crates/can-harness/`, `roles/senior-controls/CONTEXT.md` — mine per `.github/policy_check.py
--who` for each touched path. No `sim/models/`, `plant.py`, or `imperfections.py` touched.

Closes #62

---
_Generated by [Claude Code](https://claude.ai/code/session_014Gk3VqrWAopjbVo5kAnW8d)_