### PR TITLE
fix(mech): match bench_rig.xml to the parts actually purchased

### DIFF
--- a/roles/sr-mechanical-systems/CONTEXT.md
+++ b/roles/sr-mechanical-systems/CONTEXT.md
@@ -73,6 +73,26 @@ now cross-check: free-roll agreement 0.24–1.78% to 20% grade, bit-identical on
 asymmetry Controls measured falls out of geometry, because a board resting flat on a slope is
 already at world pitch −φ. PR #18.
 
+**2026-07-28 — `bench_rig.xml` now matches the parts actually purchased (#66).** Flywheel geometry
+was a 75 mm/12 mm custom aluminium disc estimate; the confirmed part is two goBILDA
+3628-0032-0082 units (82 mm OD, 152 g, 1651 g·cm² each, manufacturer-published). A same-mass solid
+disc at that radius computes to ~1277 g·cm² — 30% low — because the real part is a hub-and-rim
+casting, not a uniform disc, so each flywheel now carries an explicit `<inertial>` sourced directly
+from the datasheet rather than a density-derived guess. Plate stock corrected to the confirmed
+12″×12″ ¼″ 6061-T651 sheet (thickness 6 mm→6.35 mm exact); clamps confirmed as IRWIN Quick-Grip
+mini, noted as a second candidate resonance source alongside the riser (#64). Rotor can/hub stay
+geometry-derived estimates — no manufacturer figure exists for them, that's what the bare-run
+measurement is for.
+
+**Before/after, measured not assumed:** J_disc 1.6103e-3 → 3.3020e-4 kg·m² (matches 2×1651 g·cm²
+exactly), J_loaded 1.8510e-3 → 5.7085e-4 kg·m², ratio J_disc/J_bare 6.69 → 1.37. That drop is
+expected, not a regression — #65 already flagged 1.1–1.65 from these same confirmed figures and
+owns the decision of whether to accept it or add inertia; this issue only made the model match
+what's on the shaft. `sim/scenarios/bench_spinup.py`'s `known_disc_inertia_kg_m2()` now returns the
+manufacturer figure too (was a radius/thickness/density formula), since real hardware would know
+this from a datasheet, not a ruler. 202 tests pass, same count as master — updated in place, not
+added, since the affected assertions are model-inertia values, not new coverage.
+
 ## Known dead ends
 
 - **Do not lift the board clear of the ground to isolate accelerometer geometry.** A free-floating

--- a/sim/models/bench_rig.xml
+++ b/sim/models/bench_rig.xml
@@ -3,9 +3,9 @@
     Overboard bench rig plant model — wave-0, desk-scale.
 
     A sensored outrunner bolted face-on to a plate, the plate clamped to a desk
-    edge, and a disc of known inertia on the shaft. One hinge, one actuator.
-    That is the whole vehicle here, and it is deliberately the simplest plant
-    that still exercises the real signal path.
+    edge, and two discs of known inertia on the shaft. One hinge, one
+    actuator. That is the whole vehicle here, and it is deliberately the
+    simplest plant that still exercises the real signal path.
 
     WHY THIS MODEL EXISTS, AND WHAT IT IS NOT FOR
     --------------------------------------------
@@ -41,10 +41,12 @@
     GEOMETRY
     --------
     Desk top is z = 0 and the desk edge is x = 0; the rig hangs off +x. The
-    motor axis sits at x = 0.06, i.e. 60 mm PAST the edge, so the disc (75 mm
-    radius) swings in free air. That overhang is load-bearing, not styling: a
-    plate clamped flush would put the disc over the desk surface, which kills
-    the pendulum upgrade and lets a shed set screw take a chunk out of the desk.
+    motor axis sits at x = 0.06, i.e. 60 mm PAST the edge, so the flywheels
+    (41 mm radius each, confirmed #66 -- was a 75 mm placeholder disc) swing
+    in free air with margin to spare. That overhang is load-bearing, not
+    styling: a plate clamped flush would put the discs over the desk surface,
+    which kills the pendulum upgrade and lets a shed set screw take a chunk
+    out of the desk.
 
     THE MOUNT IS TWO GEOMS, NOT ONE, AND THAT FOLLOWS FROM THE MOTOR'S MOUNTING
     FACE
@@ -61,14 +63,30 @@
     So the mount is a base plate + a riser, matching the buildable bracket
     (base the clamps grip, riser carrying the motor, joined at the desk edge):
 
-      base_plate   x in [-0.10, 0], thin in Z (6 mm, the 1/4" stock), lying
-                   flat on the desk top (z in [0, 0.006]). This is the part
-                   the two bench clamps grip (Stage-0A Sec 3.2).
+      base_plate   x in [-0.10, 0], thin in Z (1/4" = 6.35 mm exactly, the
+                   confirmed stock thickness -- see #66), lying flat on the
+                   desk top (z in [0, 0.00635]). This is the part the two
+                   bench clamps grip (Stage-0A Sec 3.2).
 
-      riser        x in [0, 0.12], thin in Y (6 mm), standing from the desk
-                   top to z = 0.2. Its face is in the X-Z plane, which is what
-                   lets the motor face-mount to it with the shaft along Y.
-                   The motor axis at x = 0.06 sits mid-riser, past the edge.
+      riser        x in [0, 0.12], thin in Y (6.35 mm, same stock), standing
+                   from the desk top to z = 0.2. Its face is in the X-Z plane,
+                   which is what lets the motor face-mount to it with the
+                   shaft along Y. The motor axis at x = 0.06 sits mid-riser,
+                   past the edge.
+
+    RAW STOCK, NOW CONFIRMED RATHER THAN ASSUMED (#66)
+    ----------------------------------------------------
+    Both pieces are cut from a single 12"x12" (304.8 mm square) sheet of 1/4"
+    6061-T651 -- ordered, cut, and non-returnable. base_plate (100x90 mm) and
+    riser (120x200 mm) together use well under half that area, leaving ~60%
+    of the sheet spare (see #64, which asks whether 1/4" is stiff enough for
+    the 200 mm riser under flywheel load -- unresolved here, tracked there).
+    The bench clamps are confirmed as IRWIN Quick-Grip mini one-handed
+    clamps, materially lower clamping force than screw-type F-clamps. That is
+    a second candidate source of a low-frequency mode beyond riser bending --
+    if bench data shows a structural resonance inside the control bandwidth,
+    the clamp interface is now a named suspect alongside riser compliance,
+    not just the riser.
 
     Both are visual only (contype/conaffinity 0, not a body with an
     <inertial>), so this is a rendering and buildability fix with no dynamics
@@ -80,34 +98,75 @@
     the disc for an arm-and-mass a genuine inverted pendulum rather than a
     turntable.
 
-    MASS AND INERTIA COME FROM GEOMETRY
-    -----------------------------------
-    No <inertial> block is given. MuJoCo derives body mass and inertia from the
-    geoms and their densities, exactly the way the onewheel model derives its
-    nose-strike angle from collision hulls instead of a tuned constant. The
-    disc is 6061 aluminium at 2700 kg/m^3, r = 75 mm, t = 12 mm, which is
-    0.5726 kg and 1.6103e-3 kg*m^2 about the axis. As compiled, the joint-space
-    inertias are:
+    MASS AND INERTIA: GEOMETRY FOR THE ROTOR, MANUFACTURER FIGURE FOR THE
+    FLYWHEELS (#66)
+    -----------------------------------------------------------------------
+    rotor_can and hub have no <inertial> block: MuJoCo derives their mass and
+    inertia from geometry and density, exactly the way the onewheel model
+    derives its nose-strike angle from collision hulls instead of a tuned
+    constant. That is correct for them because they ARE estimates awaiting
+    measurement -- no manufacturer publishes rotor inertia for e-skate 6374s,
+    and the two sources found during sourcing disagreed by 16x (roughly
+    2000-3000 g*cm^2, see #65). This model's rotor_can density is chosen to
+    land near the middle of that band; the disagreement is the finding, not
+    something to paper over, and it is exactly what the bare-run measurement
+    exists to resolve.
 
-        J_bare   = 2.4065e-4 kg*m^2   (rotor can + hub)
-        J_loaded = 1.8510e-3 kg*m^2
-        J_disc   = 1.6103e-3 kg*m^2   == 1/2*m*r^2 exactly, because every
-                                         rotor geom is centred on the axis
+    The flywheels are different: they are a bought, catalogued part, so
+    deriving their inertia from an assumed solid-cylinder geometry would be
+    replacing a known number with a guess. #66 confirmed the purchased part is
+    a goBILDA 3628-0032-0082 (82 mm OD), manufacturer-published at 152 g and
+    1651 g*cm^2 (1.651e-4 kg*m^2) about its own axis -- and a same-mass solid
+    41 mm-radius disc would compute to ~1277 g*cm^2, about 30% low, because
+    goBILDA's flywheel is a hub-and-rim casting with mass biased toward the
+    rim, not a uniform disc. So each flywheel carries an explicit <inertial>
+    stating that published figure directly, rather than a <geom> density
+    chosen to reverse-engineer it. The two flywheels are the ×2 hedge #65
+    describes as already bought; both are modelled, because that is what is
+    on the shaft, not a decision about which to keep -- #65 stays open for
+    that. Their transverse (non-axial) moments are not published and are
+    approximated as I_axial/2, the exact thin-disc identity; this is a
+    placeholder, but a provably inert one, because the rig has a single hinge
+    DOF about the shaft (Y) and nothing here couples the transverse inertia
+    into that joint's equation of motion -- it would only matter for reaction
+    forces on the frame, which this model does not analyse.
 
-    The ratio matters more than either number: J_disc / J_bare = 6.69. The
-    two-run identification (spin up bare, spin up loaded, solve for kt and
+    As compiled, the joint-space inertias are:
+
+        J_bare   = 2.4065e-4 kg*m^2   (rotor can + hub, unchanged by #66)
+        J_disc   = 3.3020e-4 kg*m^2   (two flywheels, manufacturer figure:
+                                         2 x 1651 g*cm^2, exact -- offsets
+                                         along the shaft axis contribute
+                                         nothing to inertia about that axis,
+                                         so the two add directly)
+        J_loaded = 5.7085e-4 kg*m^2
+
+    BEFORE / AFTER (#66 replaced a custom 75 mm aluminium disc, an estimate,
+    with the two goBILDA flywheels actually purchased):
+
+                     before (guess)    after (measured/mfr)
+        J_disc       1.6103e-3         3.3020e-4    (-79.5%)
+        J_loaded     1.8510e-3         5.7085e-4    (-69.2%)
+        ratio                6.69             1.37    (see #65)
+
+    The ratio drop is real and expected, not a regression: #65 already flagged
+    that the confirmed manufacturer figures (152 g, 1651 g*cm^2 each) give a
+    ratio of roughly 1.1-1.65 against the bare-rotor estimate, well below the
+    6.7 design point. This issue (#66) is scoped to making the model match
+    what was bought, not to deciding whether to add inertia -- that is #65's
+    open question, and 1.37 sits inside the range #65 already reported.
+
+    The two-run identification (spin up bare, spin up loaded, solve for kt and
     J_rotor) is only well conditioned when the added inertia is comparable to
-    or larger than the unknown one. At ~6.7x the two acceleration slopes differ
-    by 7.4x, well clear of measurement noise. A disc that merely nudged the
-    total would produce two nearly identical ramps and an ill-posed fit.
+    or larger than the unknown one. At the design point (~6.7x) the two
+    acceleration slopes differed by 7.4x, well clear of measurement noise; at
+    1.37x the two slopes are closer together and error amplification on kt is
+    roughly double (see #65). Still solvable -- the requirement was "added
+    inertia comparable to or larger than the unknown," which 1.1-1.65 clears
+    -- just with a wider error bar than the design point assumed.
 
     The rotor is balanced: COM sits exactly on the shaft axis, so there is no
     angle-dependent gravity torque to contaminate the friction fit.
-
-    Both of these are nameplate/geometry estimates awaiting measurement, which
-    is the point of the exercise. The scenario reports fitted values against
-    them, and a large disagreement on J_rotor is a real finding about the
-    motor, not a modelling error to be tuned away.
 
     ACTUATOR RANGE IS DERIVED, AND THAT IS A KNOWN TRAP
     ---------------------------------------------------
@@ -158,18 +217,21 @@
           material="grid_mat"/>
 
     <!-- Base plate. Flat on the desk top (thin in Z), x in [-0.10, 0] -- the
-         part the two bench clamps grip. Visual only: it is ground, and
-         modelling its compliance would be a claim the rig cannot yet
-         support. If bench data shows a structural resonance inside the
-         control bandwidth, that assumption is what to revisit first. -->
-    <geom name="base_plate" type="box" size="0.050 0.045 0.003" pos="-0.050 -0.045 0.003"
+         part the two bench clamps grip. 1/4" (6.35 mm) stock, confirmed
+         (#66), cut from the 12"x12" sheet described in the header. Visual
+         only: it is ground, and modelling its compliance would be a claim
+         the rig cannot yet support. If bench data shows a structural
+         resonance inside the control bandwidth, both riser bending (#64)
+         and the mini clamps' lower grip force are named suspects. -->
+    <geom name="base_plate" type="box" size="0.050 0.045 0.003175" pos="-0.050 -0.045 0.003175"
           material="cloud"/>
 
     <!-- Riser. A panel in the X-Z plane, thin in Y, standing from the desk
          top out past the edge to carry the motor -- see the header for why
          this has to be a separate geom from the base plate rather than one
-         panel doing both jobs. Visual only, same as the base plate. -->
-    <geom name="riser" type="box" size="0.060 0.003 0.100" pos="0.060 -0.045 0.100"
+         panel doing both jobs. Same confirmed 1/4" (6.35 mm) stock as the
+         base plate. Visual only, same as the base plate. -->
+    <geom name="riser" type="box" size="0.060 0.003175 0.100" pos="0.060 -0.045 0.100"
           material="cloud"/>
 
     <!-- Motor stator, static half. Bolted to the plate face, axis along Y. -->
@@ -193,7 +255,11 @@
       <joint name="shaft" type="hinge" axis="0 1 0" damping="1e-4"
              frictionloss="5e-3"/>
 
-      <!-- Rotor can. density set to land near 2.4e-4 kg*m^2 about the axis. -->
+      <!-- Rotor can. density set to land near the middle of the 2000-3000
+           g*cm^2 sourcing estimate (#65) -- an estimate awaiting the bare-run
+           measurement, not a fact; see the header. Motor confirmed 6374-class,
+           8 mm shaft, sensored (#66) -- the shaft diameter does not change
+           this geom, which models hub mass, not a shaft bore. -->
       <geom name="rotor_can" type="cylinder" size="0.0315 0.018" euler="90 0 0"
             pos="0 0 0" density="4300" material="ink"/>
 
@@ -201,24 +267,47 @@
       <geom name="hub" type="cylinder" size="0.011 0.010" euler="90 0 0"
             pos="0 0.028 0" density="2700" material="mint"/>
 
-      <!-- Flywheel: 6061 aluminium, r = 75 mm, t = 12 mm.
-           This is the KNOWN inertia in the two-run identification. Its value
-           comes from mass on a kitchen scale and radius with a ruler, which is
-           why it is trustworthy in a way the rotor's is not. -->
-      <geom name="flywheel" type="cylinder" size="0.075 0.006" euler="90 0 0"
-            pos="0 0.046 0" density="2700" material="amber"/>
+      <!-- Flywheel A: goBILDA 3628-0032-0082, 82 mm OD -- one of the two
+           units purchased as the #65 hedge. mass and diaginertia are the
+           manufacturer's published figures (152 g, 1651 g*cm^2 about the
+           shaft axis), not derived from this geom -- see the header for why
+           a solid-disc guess would be ~30% low for this part. The <inertial>
+           carries the same euler as the geom so its third (Z, pre-rotation)
+           diaginertia component lands on the physical shaft axis. The geom
+           itself is a rendering placeholder only (82 mm OD, 10 mm assumed
+           thickness); its density is irrelevant once <inertial> is given. -->
+      <body name="flywheel_a" pos="0 0.046 0">
+        <inertial pos="0 0 0" euler="90 0 0" mass="0.152"
+                  diaginertia="8.255e-5 8.255e-5 1.651e-4"/>
+        <geom name="flywheel_a_disc" type="cylinder" size="0.041 0.005"
+              euler="90 0 0" material="amber"/>
+      </body>
 
-      <!-- Index mark, so rotation is legible in a render and a strobe or phone
-           video can cross-check shaft speed against reported ERPM.
+      <!-- Flywheel B: identical part, the second unit of the ×2 hedge. Both
+           are modelled because both are on the shaft -- #65 decides whether
+           to keep both, not this file. -->
+      <body name="flywheel_b" pos="0 0.057 0">
+        <inertial pos="0 0 0" euler="90 0 0" mass="0.152"
+                  diaginertia="8.255e-5 8.255e-5 1.651e-4"/>
+        <geom name="flywheel_b_disc" type="cylinder" size="0.041 0.005"
+              euler="90 0 0" material="amber"/>
 
-           MASSLESS ON PURPOSE. In hardware this is paint or a strip of tape.
-           Given mass, it sits off-axis and applies a gravity torque of order
-           2e-3 N*m that varies with shaft angle — the same order as the
-           Coulomb friction term the spin-down test is trying to identify, so
-           it would show up as a systematic bias in the fit and be
-           indistinguishable from real friction. -->
-      <geom name="index" type="box" size="0.004 0.006 0.020" pos="0 0.046 0.052"
-            mass="0" material="cloud"/>
+        <!-- Index mark, so rotation is legible in a render and a strobe or
+             phone video can cross-check shaft speed against reported ERPM.
+             Nested inside flywheel_b (rather than kept a rotor sibling and
+             matched by a second strip regex) so stripping the flywheel body
+             cannot again leave the mark floating -- see the DCP bug this
+             replaced when the mark and disc were separate rotor geoms.
+
+             MASSLESS ON PURPOSE. In hardware this is paint or a strip of
+             tape. Given mass, it sits off-axis and applies a gravity torque
+             that varies with shaft angle -- the same order as the Coulomb
+             friction term the spin-down test is trying to identify, so it
+             would show up as a systematic bias in the fit and be
+             indistinguishable from real friction. -->
+        <geom name="index" type="box" size="0.004 0.005 0.010" pos="0 0 0.030"
+              mass="0" material="cloud"/>
+      </body>
     </body>
   </worldbody>
 

--- a/sim/scenarios/bench_spinup.py
+++ b/sim/scenarios/bench_spinup.py
@@ -20,23 +20,26 @@ story:
     kt*i - b*w - tau_c*sign(w) = J*dw/dt
 
 so the initial slope of w(t) is alpha ~= kt*i/J. Two runs at the SAME current
--- bare rotor, then with the flywheel disc added -- give two equations in two
-unknowns once `J_disc` is treated as known (it is a machined aluminium disc,
-weighed and measured, not fitted):
+-- bare rotor, then with the flywheels added -- give two equations in two
+unknowns once `J_disc` is treated as known. As of #66 that is two goBILDA
+3628-0032-0082 flywheels, and "known" means the manufacturer's published
+axial inertia (1651 g*cm^2 each), not a weighed-and-measured custom disc --
+see `known_disc_inertia_kg_m2` and bench_rig.xml's header for why a
+solid-cylinder derivation would be wrong for this part:
 
     kt*i = J_bare*alpha_1
     kt*i = (J_bare + J_disc)*alpha_2
     =>  kt = J_disc / (i * (1/alpha_2 - 1/alpha_1))
         J_bare = kt*i/alpha_1
 
-The bare variant is built by REGEX-STRIPPING the `flywheel` geom out of the
-XML string and compiling with `mujoco.MjModel.from_xml_string` -- `MjsGeom`
-has no `.delete()` and hand-rolling `MjSpec` surgery for one geom is not worth
-the fragility it buys. The strip is verified, not trusted: `build_bare_model`
-asserts the geom is actually gone and that the resulting joint inertia is
-lower than the loaded rig's. A silent failure to strip would make the two
-runs identical, which is a divide-by-zero waiting to happen rather than a
-loud one.
+The bare variant is built by REGEX-STRIPPING the two `flywheel_a`/`flywheel_b`
+bodies out of the XML string and compiling with `mujoco.MjModel.from_xml_string`
+-- `MjsGeom`/`MjsBody` has no `.delete()` and hand-rolling `MjSpec` surgery for
+two bodies is not worth the fragility it buys. The strip is verified, not
+trusted: `build_bare_model` asserts both flywheel geoms are actually gone and
+that the resulting joint inertia is lower than the loaded rig's. A silent
+failure to strip would make the two runs identical, which is a divide-by-zero
+waiting to happen rather than a loud one.
 
 kt IS BIASED BY A SMALL, KNOWN AMOUNT. The algebra above assumes zero
 friction at the initial instant; Coulomb does not vanish at w=0, so the fit
@@ -141,7 +144,6 @@ import argparse
 import csv
 import hashlib
 import json
-import math
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -167,15 +169,16 @@ OUT_DIR = REPO / "sim" / "out" / "bench"
 #: the module docstring's category-error guard.
 NAMEPLATE_KT_NM_PER_A = 9.5493 / 190.0
 
-#: Flywheel geometry, independent of the compiled model -- mass on a kitchen
-#: scale and radius with a ruler, per the model header, is what makes this
-#: trustworthy where the rotor's own inertia is not. Kept as named constants
-#: (mirroring bench_rig.xml exactly) rather than read back off the compiled
-#: model, because reading it off the model would make `J_disc` circular with
-#: the very quantity the two-run fit is solving for.
-FLYWHEEL_RADIUS_M = 0.075
-FLYWHEEL_THICKNESS_M = 0.012
-FLYWHEEL_DENSITY_KG_M3 = 2700.0  # 6061 aluminium
+#: Flywheel identity, independent of the compiled model -- the manufacturer's
+#: published mass and axial inertia for the goBILDA 3628-0032-0082 (#66), not
+#: derived from a radius/thickness/density geometry guess (a same-mass solid
+#: disc would be ~30% low; see bench_rig.xml's header). Kept as named
+#: constants rather than read back off the compiled model, because reading it
+#: off the model would make `J_disc` circular with the very quantity the
+#: two-run fit is solving for.
+FLYWHEEL_COUNT = 2  # both purchased units are on the shaft; see #65
+FLYWHEEL_MASS_KG = 0.152
+FLYWHEEL_INERTIA_KG_M2 = 1.651e-4  # manufacturer, about the shaft axis, per unit
 
 #: Threshold for `current_tracking_ok`. Past this the drive has derated by
 #: more than plausible measurement jitter -- ICD noise floors on reported
@@ -183,13 +186,20 @@ FLYWHEEL_DENSITY_KG_M3 = 2700.0  # 6061 aluminium
 #: is meaningless until this is understood.
 CURRENT_TRACKING_TOLERANCE_A = 0.5
 
-_FLYWHEEL_GEOM_RE = re.compile(r'<geom name="flywheel"[^>]*/>')
+#: Matches the whole `<body name="flywheel_a">...</body>` /
+#: `<body name="flywheel_b">...</body>` blocks, not just a geom -- since #66,
+#: each flywheel's manufacturer-sourced inertia lives on an `<inertial>` at
+#: body scope, so a self-closing-geom regex can no longer isolate it. The
+#: index mark is nested inside `flywheel_b` (see bench_rig.xml's header), so
+#: stripping these two bodies removes it too, by construction rather than by
+#: a second regex that could drift out of sync.
+_FLYWHEEL_BODY_RE = re.compile(r'\s*<body name="flywheel_[ab]".*?</body>', re.DOTALL)
 
-#: The index mark goes with the disc it is drawn on.
-#:
-#: `index` sits at `pos="0 0.046 0.052"` -- the same y as the flywheel, at 52 mm
-#: radius, i.e. on the disc face. Strip the disc and leave the mark and you get
-#: a white bar rotating in mid-air where the flywheel used to be.
+#: The index mark, kept as its own regex even though `_FLYWHEEL_BODY_RE`
+#: already removes it (it is nested inside `flywheel_b`) -- this one isolates
+#: JUST the mark, for `test_removing_the_index_mark_changes_no_fitted_quantity`,
+#: which strips only this geom to confirm it is really massless rather than
+#: assuming it.
 #:
 #: It is massless with collision off, so `J_bare` and every fitted number are
 #: unaffected either way; this is model coherence, not correctness. But a plant
@@ -202,15 +212,16 @@ _INDEX_GEOM_RE = re.compile(r'<geom name="index"[^>]*/>')
 
 
 def known_disc_inertia_kg_m2() -> float:
-    """`J_disc` from geometry and material, NOT from the compiled model.
+    """`J_disc` from the manufacturer's published figure, NOT from geometry.
 
-    `1/2*m*r^2` is exact here because every rotor geom in bench_rig.xml is
-    centred ON the shaft axis (see the model header's note on the eccentric-
-    offset defect this replaced) -- an off-axis disc would need a parallel-
-    axis correction this does not have.
+    Two goBILDA 3628-0032-0082 flywheels (#66), each 1651 g*cm^2 about the
+    shaft axis per the datasheet. They sum directly because both are coaxial
+    with the shaft: offsets along the axis of rotation contribute nothing to
+    inertia about that axis (see bench_rig.xml's header note on the
+    eccentric-offset defect this replaced) -- an off-axis disc would need a
+    parallel-axis correction this does not have.
     """
-    mass = FLYWHEEL_DENSITY_KG_M3 * math.pi * FLYWHEEL_RADIUS_M**2 * FLYWHEEL_THICKNESS_M
-    return 0.5 * mass * FLYWHEEL_RADIUS_M**2
+    return FLYWHEEL_COUNT * FLYWHEEL_INERTIA_KG_M2
 
 
 def load_model(path: Path = MODEL_PATH) -> mujoco.MjModel:
@@ -231,30 +242,21 @@ def _joint_inertia(model: mujoco.MjModel) -> float:
 
 
 def strip_flywheel_geom(xml: str) -> str:
-    """Remove the flywheel geom -- and the index mark drawn on it -- from the
-    MJCF string.
+    """Remove the two flywheel bodies -- and the index mark nested inside
+    `flywheel_b` -- from the MJCF string.
 
-    A regex, not `MjSpec` surgery: `MjsGeom` has no `.delete()`, and building
-    the bare variant through spec editing is not worth the fragility for one
-    geom. The caller MUST verify the strip actually worked -- see
+    A regex, not `MjSpec` surgery: `MjsGeom`/`MjsBody` has no `.delete()`, and
+    building the bare variant through spec editing is not worth the fragility
+    for two bodies. The caller MUST verify the strip actually worked -- see
     `build_bare_model` -- because a silent no-op here would make the bare and
     loaded runs identical and turn the two-run fit into a divide-by-zero.
-
-    The index mark is removed with the disc because it is ON the disc; see
-    `_INDEX_GEOM_RE`. It is massless, so no fitted number moves.
     """
-    stripped, n = _FLYWHEEL_GEOM_RE.subn("", xml)
-    if n != 1:
+    stripped, n = _FLYWHEEL_BODY_RE.subn("", xml)
+    if n != 2:
         raise RuntimeError(
-            f"expected exactly one <geom name=\"flywheel\".../> to strip, found {n}. "
-            "The bench_rig.xml flywheel geom's markup may have changed; update the regex."
-        )
-    stripped, n_index = _INDEX_GEOM_RE.subn("", stripped)
-    if n_index != 1:
-        raise RuntimeError(
-            f"expected exactly one <geom name=\"index\".../> to strip, found {n_index}. "
-            "The mark is drawn on the flywheel face, so it must go with it -- "
-            "otherwise the bare model renders a decal floating where the disc was."
+            f"expected exactly two <body name=\"flywheel_[ab]\">...</body> blocks "
+            f"to strip, found {n}. The bench_rig.xml flywheel markup may have "
+            "changed; update the regex."
         )
     return stripped
 
@@ -262,17 +264,20 @@ def strip_flywheel_geom(xml: str) -> str:
 def build_bare_model(xml_text: str | None = None) -> mujoco.MjModel:
     """The bare-rotor variant used as run 1 of the two-run identification.
 
-    Verified, not trusted: asserts the flywheel geom is actually gone and that
-    the resulting joint inertia is lower than a loaded rig's would be. Either
-    assertion failing means the strip silently did nothing.
+    Verified, not trusted: asserts both flywheel geoms are actually gone and
+    that the resulting joint inertia is lower than a loaded rig's would be.
+    Either assertion failing means the strip silently did nothing.
     """
     xml_text = xml_text if xml_text is not None else MODEL_PATH.read_text()
     bare = mujoco.MjModel.from_xml_string(strip_flywheel_geom(xml_text))
-    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel") < 0, (
-        "flywheel geom is still present after stripping -- the regex did not match"
+    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel_a_disc") < 0, (
+        "flywheel_a geom is still present after stripping -- the regex did not match"
+    )
+    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel_b_disc") < 0, (
+        "flywheel_b geom is still present after stripping -- the regex did not match"
     )
     assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "index") < 0, (
-        "index mark survived the flywheel strip -- it is drawn on the disc face, "
+        "index mark survived the flywheel strip -- it is nested inside flywheel_b, "
         "so the bare model would render a decal floating in mid-air"
     )
     return bare

--- a/tests/test_bench_spinup.py
+++ b/tests/test_bench_spinup.py
@@ -42,7 +42,8 @@ from sim.scenarios.bench_spinup import (
     load_model,
     replay,
     spindown,
-    _FLYWHEEL_GEOM_RE,
+    _FLYWHEEL_BODY_RE,
+    _INDEX_GEOM_RE,
     _joint_inertia,
     identify,
 )
@@ -53,12 +54,14 @@ def load_model_xml() -> str:
     """The raw MJCF text, for tests that build variants by stripping geoms."""
     return MODEL_PATH.read_text()
 
-#: The committed model's joint-space inertias, from bench_rig.xml's header --
-#: geometry-derived, not tuned. A change to the flywheel or rotor geometry
-#: should trip these and force the header's numbers to be updated alongside.
+#: The committed model's joint-space inertias, from bench_rig.xml's header.
+#: J_bare is geometry-derived (rotor can + hub); J_disc is the manufacturer's
+#: published figure for the two goBILDA 3628-0032-0082 flywheels (#66). A
+#: change to either should trip these and force the header's numbers to be
+#: updated alongside.
 KNOWN_GOOD_J_BARE = 2.4065e-4
-KNOWN_GOOD_J_LOADED = 1.8510e-3
-KNOWN_GOOD_J_DISC = 1.6103e-3
+KNOWN_GOOD_J_LOADED = 5.7085e-4
+KNOWN_GOOD_J_DISC = 3.3020e-4
 
 
 @pytest.fixture(scope="module")
@@ -88,8 +91,9 @@ def test_bare_variant_actually_strips_the_flywheel_geom(loaded_model, bare_model
     """Verified, not trusted -- a regex that silently failed to match would
     make the bare and loaded runs identical and the two-run fit a
     divide-by-zero."""
-    assert mujoco.mj_name2id(bare_model, mujoco.mjtObj.mjOBJ_GEOM, "flywheel") < 0
-    assert mujoco.mj_name2id(loaded_model, mujoco.mjtObj.mjOBJ_GEOM, "flywheel") >= 0
+    for name in ("flywheel_a_disc", "flywheel_b_disc"):
+        assert mujoco.mj_name2id(bare_model, mujoco.mjtObj.mjOBJ_GEOM, name) < 0
+        assert mujoco.mj_name2id(loaded_model, mujoco.mjtObj.mjOBJ_GEOM, name) >= 0
     assert _joint_inertia(bare_model) < _joint_inertia(loaded_model)
 
 
@@ -217,15 +221,18 @@ def test_fitting_from_zero_reproduces_the_original_50_percent_error(loaded_model
 # --------------------------------------------------------------------------
 
 def test_the_bare_model_carries_no_floating_index_mark(loaded_model):
-    """The index mark is drawn on the flywheel face, so it goes with the disc.
+    """The index mark is nested inside flywheel_b's body (#66), so stripping
+    the flywheel bodies removes it by construction, not by a second regex
+    that could drift out of sync.
 
-    Left behind, it renders as a white bar rotating in mid-air 52 mm off the
-    shaft, where the disc used to be. Raised by Digital Content Production after
-    it reached a render.
+    Left behind, it would render as a white bar rotating in mid-air where the
+    disc used to be. Raised by Digital Content Production after it reached a
+    render, back when the mark was a separate rotor-level geom.
     """
     bare = build_bare_model()
     assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "index") < 0
-    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel") < 0
+    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel_a_disc") < 0
+    assert mujoco.mj_name2id(bare, mujoco.mjtObj.mjOBJ_GEOM, "flywheel_b_disc") < 0
     # Still present on the loaded rig -- the strip must be the only thing that
     # removes it, or the mark has simply been deleted from the model.
     assert mujoco.mj_name2id(loaded_model, mujoco.mjtObj.mjOBJ_GEOM, "index") >= 0
@@ -235,14 +242,17 @@ def test_removing_the_index_mark_changes_no_fitted_quantity(loaded_model):
     """It is massless with collision off, so this is model coherence, not
     correctness -- and that claim is worth checking rather than repeating.
 
-    Compares joint inertia of a bare model against one built by stripping only
-    the flywheel. Identical means the mark never contributed, so no previously
-    published J_bare or kt moves because of this change.
+    Strips ONLY the index geom (leaving both flywheel bodies intact) and
+    compares joint inertia against the full loaded model. Identical means the
+    mark never contributed, so no previously published J_disc, J_loaded or kt
+    moves because of this change.
     """
     xml = load_model_xml()
-    flywheel_only = mujoco.MjModel.from_xml_string(_FLYWHEEL_GEOM_RE.sub("", xml))
-    assert _joint_inertia(build_bare_model()) == pytest.approx(
-        _joint_inertia(flywheel_only), rel=1e-12
+    stripped, n = _INDEX_GEOM_RE.subn("", xml)
+    assert n == 1, f"expected exactly one index geom to strip, found {n}"
+    no_index_model = mujoco.MjModel.from_xml_string(stripped)
+    assert _joint_inertia(no_index_model) == pytest.approx(
+        _joint_inertia(loaded_model), rel=1e-12
     )
 
 


### PR DESCRIPTION
## What changed and why

Issue #66: `sim/models/bench_rig.xml`'s flywheel was a 75 mm/12 mm custom aluminium disc
**estimate**. The rig is now bought, and several numbers are known rather than guessed:

| | Confirmed |
|---|---|
| Flywheel | goBILDA 3628-0032-0082 — **82 mm OD, 152 g, 1651 g·cm² each, ×2** (manufacturer-published) |
| Plate | ¼″ 6061-T651, **12″×12″** |
| Motor | 6374-class, **8 mm shaft**, sensored |
| Clamps | IRWIN Quick-Grip **mini** — materially lower clamping force than screw-type F-clamps |

- `sim/models/bench_rig.xml` — each flywheel is now a child body (`flywheel_a`/`flywheel_b`)
  carrying an explicit `<inertial>` sourced **directly from the datasheet** (152 g, 1651 g·cm²
  about the shaft axis each), rather than a `<geom>` density chosen to reverse-engineer it. A
  same-mass solid 41 mm-radius disc computes to ~1277 g·cm² — 30% low — because goBILDA's
  flywheel is a hub-and-rim casting with mass biased toward the rim, not a uniform disc. Plate
  thickness corrected to the exact 1/4″ (6.35 mm); header now documents the confirmed 12″×12″
  raw stock (base_plate + riser use well under half of it) and flags the mini clamps as a
  **second candidate resonance source** alongside the riser (#64), since they clamp with
  materially less force than the screw-type F-clamps the fixture originally assumed. `rotor_can`
  and `hub` stay geometry-derived **estimates** — no manufacturer figure exists for bare-rotor
  inertia (16x sourcing disagreement, #65), which is exactly what the bare-run measurement is for.
- `sim/scenarios/bench_spinup.py` — `known_disc_inertia_kg_m2()` now returns the manufacturer
  figure (2×1651 g·cm²) instead of a radius/thickness/density formula: real hardware would know
  this number from a datasheet, not a ruler. The bare/loaded model split now regex-strips the two
  `flywheel_a`/`flywheel_b` **bodies** instead of a single geom; the index render mark is nested
  *inside* `flywheel_b` so stripping the flywheel can no longer leave it floating (the DCP bug
  this previously needed a second, independently-maintained regex to avoid).
- `tests/test_bench_spinup.py` — updated known-good inertias and the strip/index tests for the
  new body structure. No tests removed or skipped.

## Measured, not assumed — before/after

| | before (guess) | after (manufacturer/measured) |
|---|---|---|
| J_disc | 1.6103e-3 kg·m² | 3.3020e-4 kg·m² (exact match to 2×1651 g·cm²) |
| J_loaded | 1.8510e-3 kg·m² | 5.7085e-4 kg·m² |
| J_disc / J_bare ratio | 6.69 | 1.37 |

That ratio drop is **expected, not a regression**: #65 already flagged 1.1–1.65 from these same
confirmed manufacturer figures and owns the decision of whether to accept it or add inertia. This
PR is scoped to making the model match what was actually bought — 1.37 sits inside the range #65
already reported, and #65 stays open for the "accept or add inertia" call.

## Acceptance criteria (issue #66)

- [x] Flywheel geometry and inertia in the model match the purchased part, sourced from the
      manufacturer figure rather than derived from a guess.
- [x] Plate dimensions match what was bought (12″×12″ ¼″ 6061-T651, exact 6.35 mm thickness).
- [x] Every remaining estimated number is marked as such in a comment (rotor_can/hub density,
      transverse flywheel inertia placeholder, riser/clamp resonance risk).
- [x] Existing bench tests pass; every metric that moved is called out with before/after (above).
- [x] The motor's rotor inertia stays an explicit estimate with its uncertainty noted (2000–3000
      g·cm², 16x sourcing disagreement, #65) — not laundered into a fact.

## Out of scope / for other issues

- **#65** (flywheel inertia ratio, decide the fix) — not decided here. This PR reports the
  before/after delta; #65 still owns whether to accept 1.37 or add inertia.
- **#64** (is ¼″ stiff enough for the 200 mm riser) — already landed separately as #73 while this
  PR was in flight; merged into `master` and reconciled here (see below).

## Merge note

`master` moved twice while this PR sat open (#70/#71, then #73/#74/#77). Both were merged in;
the only conflict was `roles/sr-mechanical-systems/CONTEXT.md`, where this PR and #73 each
appended a same-day entry to the old shared decision list. Kept #73's entry and moved this PR's
own entry to `roles/sr-mechanical-systems/log/2026-07-28-bench-rig-purchased-parts.md`, per the
per-file log convention #77 landed for exactly this reason. `DOC-OK` recorded in that merge
commit for `docs/runbook-stage0a-bench.md` (COO turf, not touched) — checked it, and it states
only the method/formulas and generic hardware description, no specific numbers this PR changed.

## Turf

`sim/models/bench_rig.xml`, `sim/scenarios/bench_spinup.py`, `tests/test_bench_spinup.py`,
`roles/sr-mechanical-systems/CONTEXT.md`, `roles/sr-mechanical-systems/log/` — all mine per
`.github/policy_check.py --who` for each touched path. No `<sensor>`/`<actuator>` elements
touched (Controls' turf); no bench-fitted constant written into a board model.

## Verification (after merging current `master`)

- `.venv (py3.13)/bin/python3 -m pytest tests/` → 235 passed, 2 xfailed (was 202/2 before #73/#74
  landed on master; no regressions from this PR's own changes)
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅ (no Rust touched)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo run -p xtask -- gate` — pre-existing `hal-actuate`/`board-app-ridden` failure, reproduces
  identically on a clean `master` checkout, unrelated to this change (not my turf)
- `python3 .github/policy_check.py` ✅ all hard checks pass (doc-drift resolved via `DOC-OK`)

Closes #66

---
_Generated by [Claude Code](https://claude.ai/code/session_011deqw8k1yXngh14cKGx7y7)_