### PR TITLE
fix(mech): riser first-mode ROM — inadequate as designed, gusset fixes it

### DIFF
--- a/roles/sr-mechanical-systems/CONTEXT.md
+++ b/roles/sr-mechanical-systems/CONTEXT.md
@@ -73,6 +73,20 @@ now cross-check: free-roll agreement 0.24–1.78% to 20% grade, bit-identical on
 asymmetry Controls measured falls out of geometry, because a board resting flat on a slope is
 already at world pitch −φ. PR #18.
 
+**2026-07-28 — The riser is undersized for the >50 Hz target, and a modest gusset fixes it.**
+`sim/scenarios/bench_riser.py` models the 200 mm riser as a cantilever with the motor + hub +
+both confirmed goBILDA flywheels (152 g each, #65/#66) hanging off the tip, weak-axis (out-of-
+plane) bending only — the axis the flywheel overhang loads, not the axis motor torque loads.
+First mode comes out **39.5–42.6 Hz** across an assumed 500–650 g motor-mass range (no datasheet
+in this repo states the real mass, and this environment has no web access to find one — the
+honest fix is a kitchen-scale weighing, not a better guess). That is below Runbook §3.2's 50 Hz
+target: **INADEQUATE as designed.** A diagonal gusset from the base plate to 80 mm up the riser
+(cut from the 12×12 stock's ~60% spare per #66, no new purchase) raises it to **86.7–93.7 Hz** —
+comfortably adequate. Both figures are a first-mode ROM (cantilever-beam closed form + Rayleigh
+mass correction), not an FEA; a tap test with a phone microphone is the cheap way to confirm it
+at the bench, and `describe_bench_signature()` says what a real riser mode looks like in the
+§6c step-response data so it isn't mistaken for plant behaviour. PR pending, issue #64.
+
 ## Known dead ends
 
 - **Do not lift the board clear of the ground to isolate accelerometer geometry.** A free-floating

--- a/sim/scenarios/bench_riser.py
+++ b/sim/scenarios/bench_riser.py
@@ -1,0 +1,339 @@
+"""Bench-rig riser: first structural mode, against the >50 Hz Stage-0A target.
+
+Issue #64: nobody had checked whether the 1/4" 6061 riser is stiff enough
+before the plate was cut. The plate is bought and non-returnable, so this is
+a verdict on the design as it stands, not a chance to pick a new thickness.
+
+WHY THIS MATTERS, AND WHY IT IS EASY TO MISS
+---------------------------------------------
+Runbook Sec 3.2 requires the fixture's first resonance well above the control
+bandwidth (>50 Hz). Motor TORQUE loads the riser about its own axis -- the
+riser's face is the X-Z plane (see bench_rig.xml's header), so an in-plane
+moment there uses the riser's large width and height as bending dimensions
+and is stiff. The problem is the FLYWHEEL MASS hanging off the shaft: it
+overhangs in Y, off the plate's face, and its weight bends the riser OUT of
+that plane -- deflection in Y, resisted only by the plate's 6.35 mm
+THICKNESS. Bending stiffness scales with the cube of the beam depth in the
+bending direction, so the riser's weak axis is ~(120/6.35)^3 ~= 6800x more
+compliant than its strong one. A mode that sits inside the control bandwidth
+would corrupt the very torque->pitch identification the rig exists to
+perform, while producing bench data that LOOKS like a plant defect rather
+than a fixture one -- see `describe_bench_signature` for how to tell them
+apart.
+
+MODEL: A CANTILEVER BEAM WITH A TIP MASS
+-----------------------------------------
+The riser is fixed at its base (bolted/co-planar with the base plate the
+clamps grip) and free at the top, where the motor stator bolts on. Treating
+it as a uniform cantilever, weak-axis bending only:
+
+    I      = b * t^3 / 12                  (b = width, t = thickness, weak
+                                             axis: bending moment about X,
+                                             deflection along Y)
+    k      = 3 * E * I / L^3               (tip stiffness, point load at L)
+    m_eff  = m_tip + 0.236 * m_beam         (Rayleigh correction: a uniform
+                                             cantilever's own mass acts at
+                                             the tip as roughly a quarter of
+                                             itself, for a first-mode estimate)
+    f1     = (1 / 2*pi) * sqrt(k / m_eff)
+
+This is a first-mode ROM (rough order of magnitude), not an FEA: it ignores
+shear deformation (fine, L/t ~= 31, a slender-beam assumption holds well),
+rotary inertia of the tip mass, and any stiffness the desk clamp itself
+lacks (a separate, second candidate resonance -- see bench_rig.xml's note on
+the IRWIN Quick-Grip minis). `verdict()` reports a margin, not a single
+pass/fail line, because a ROM this coarse deserves one.
+
+WHAT IS MEASURED, WHAT IS CONFIRMED, WHAT IS ASSUMED
+-----------------------------------------------------
+    MEASURED    riser height (0.20 m) and width (0.12 m) come straight off
+                the compiled `bench_rig.xml` geom -- the same rig the model
+                describes, not a separate guess.
+
+    CONFIRMED   riser thickness (6.35 mm, exact 1/4"), flywheel mass
+                (152 g each, x2) and material (6061-T651) are manufacturer
+                or purchase-order figures, per issues #65/#66. The thickness
+                is hardcoded here rather than read off the compiled model
+                because the model currently rounds it to 6 mm (#66's fix is
+                a separate, unmerged PR) -- this analysis uses the true
+                purchased dimension either way.
+
+    ASSUMED     motor mass. No datasheet in this repo states it, and this
+                sandbox has no web access to find one -- a 6374-class
+                sensored outrunner is assumed at 500-650 g (a working range,
+                not a measurement) and every result below is reported across
+                that range rather than at a single point. THE FIX FOR THIS
+                ASSUMPTION IS A KITCHEN SCALE, not a better guess -- weighing
+                the actual motor takes under a minute and turns this from an
+                estimate into a fact, same convention as the flywheel mass
+                before it shipped as a bought part.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import mujoco
+
+REPO = Path(__file__).resolve().parents[2]
+MODEL_PATH = REPO / "sim" / "models" / "bench_rig.xml"
+OUT_DIR = REPO / "sim" / "out" / "bench"
+
+#: Height up the riser (from the base plate) a diagonal gusset is evaluated
+#: at when the unbraced design comes out marginal or inadequate. 80 mm is
+#: 40% of the 200 mm riser height -- comfortably short of the motor mount at
+#: the top, and, per `assess_riser`'s own numbers, enough margin on its own
+#: that hunting for the minimum viable brace height is not worth doing.
+DEFAULT_BRACE_HEIGHT_M = 0.08
+
+#: 6061-T651, per bench_rig.xml's own material call-out.
+ALUMINUM_E_PA = 68.9e9
+ALUMINUM_DENSITY_KG_M3 = 2700.0
+
+#: Confirmed purchased dimension (#66) -- see module docstring for why this
+#: is hardcoded rather than read off the compiled model.
+RISER_THICKNESS_M = 0.00635
+
+#: goBILDA 3628-0032-0082, manufacturer-published (#65/#66). Two are bolted
+#: to the shaft.
+FLYWHEEL_MASS_EACH_KG = 0.152
+FLYWHEEL_COUNT = 2
+
+#: A 6374-class sensored outrunner's mass, per no datasheet this repo has
+#: access to -- a stated working assumption, not a measurement. See the
+#: module docstring's ASSUMED section.
+MOTOR_MASS_LOW_KG = 0.500
+MOTOR_MASS_HIGH_KG = 0.650
+
+#: Runbook Sec 3.2.
+TARGET_HZ = 50.0
+
+#: `verdict()` bands. "Adequate" asks for margin above the target, not just
+#: clearing it -- a mode sitting at 51 Hz is not a result anyone should be
+#: comfortable calling done.
+ADEQUATE_MARGIN = 1.5
+
+
+@dataclass(frozen=True)
+class RiserGeometry:
+    length_m: float
+    width_m: float
+    thickness_m: float
+
+
+def riser_geometry_from_model(path: Path = MODEL_PATH) -> RiserGeometry:
+    """Height and width straight off the compiled rig -- see the module
+    docstring's MEASURED/CONFIRMED/ASSUMED breakdown for why thickness is
+    not read from here too."""
+    model = mujoco.MjModel.from_xml_path(str(path))
+    geom_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "riser")
+    if geom_id < 0:
+        raise ValueError("bench_rig.xml has no geom named 'riser'")
+    half_x, _half_y, half_z = model.geom_size[geom_id]
+    return RiserGeometry(
+        length_m=2.0 * half_z,
+        width_m=2.0 * half_x,
+        thickness_m=RISER_THICKNESS_M,
+    )
+
+
+#: bench_rig.xml's own hub geom density (6061 aluminium, matching its
+#: header). Compiled `MjModel` does not expose per-geom density once built,
+#: so the volume is read off the compiled geometry and paired with this
+#: same constant the XML declares -- not re-derived or re-guessed.
+_HUB_DENSITY_KG_M3 = 2700.0
+
+
+def hub_mass_from_model(path: Path = MODEL_PATH) -> float:
+    """The set-screw hub's mass, exactly -- it is modelled geometry (density
+    x volume), not an assumption, unlike the motor mass beside it."""
+    model = mujoco.MjModel.from_xml_path(str(path))
+    geom_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "hub")
+    if geom_id < 0:
+        raise ValueError("bench_rig.xml has no geom named 'hub'")
+    radius, half_len, _ = model.geom_size[geom_id]
+    volume = math.pi * radius**2 * (2.0 * half_len)
+    return _HUB_DENSITY_KG_M3 * volume
+
+
+def cantilever_first_mode_hz(
+    tip_mass_kg: float,
+    geometry: RiserGeometry,
+    unbraced_length_m: float | None = None,
+) -> float:
+    """First bending-mode frequency of the riser as a cantilever with a tip
+    mass, weak-axis (out-of-plane) bending only.
+
+    `unbraced_length_m` lets a proposed brace be evaluated by shortening the
+    unsupported span, rather than duplicating this whole function for the
+    braced case -- see `braced_first_mode_hz`.
+    """
+    length = unbraced_length_m if unbraced_length_m is not None else geometry.length_m
+    moment_of_inertia = geometry.width_m * geometry.thickness_m**3 / 12.0
+    stiffness = 3.0 * ALUMINUM_E_PA * moment_of_inertia / length**3
+    beam_mass = ALUMINUM_DENSITY_KG_M3 * geometry.width_m * geometry.thickness_m * length
+    effective_mass = tip_mass_kg + 0.236 * beam_mass
+    return math.sqrt(stiffness / effective_mass) / (2.0 * math.pi)
+
+
+def tip_mass_bounds_kg(hub_mass_kg: float) -> tuple[float, float]:
+    """(low, high) mass hanging off the riser's free end: motor (assumed
+    range) + hub (exact, from the model) + both flywheels (confirmed)."""
+    flywheels = FLYWHEEL_MASS_EACH_KG * FLYWHEEL_COUNT
+    low = MOTOR_MASS_LOW_KG + hub_mass_kg + flywheels
+    high = MOTOR_MASS_HIGH_KG + hub_mass_kg + flywheels
+    return low, high
+
+
+def verdict(freq_low_hz: float, freq_high_hz: float) -> str:
+    """"adequate" / "marginal" / "inadequate" against `TARGET_HZ`, evaluated
+    at the PESSIMISTIC (lower) end of the assumed range -- an estimate this
+    coarse should not get to claim the optimistic case."""
+    worst = min(freq_low_hz, freq_high_hz)
+    if worst >= TARGET_HZ * ADEQUATE_MARGIN:
+        return "adequate"
+    if worst >= TARGET_HZ:
+        return "marginal"
+    return "inadequate"
+
+
+def gusset_brace_first_mode_hz(
+    tip_mass_kg: float, geometry: RiserGeometry, brace_height_m: float
+) -> float:
+    """First mode with a diagonal gusset from the base plate to
+    `brace_height_m` up the riser, modelled as shortening the unbraced span
+    to `geometry.length_m - brace_height_m` -- i.e. treating the brace
+    attachment as a near-rigid support, which a triangulated strut in
+    axial tension/compression approximates far better than the unbraced
+    plate approximates a rigid mount. This is the same ROM-level
+    simplification as the rest of this module, not an FEA of the brace
+    itself: it is meant to show whether the fix is in the right ballpark,
+    which a tap test then confirms.
+    """
+    unbraced = geometry.length_m - brace_height_m
+    return cantilever_first_mode_hz(tip_mass_kg, geometry, unbraced_length_m=unbraced)
+
+
+def describe_bench_signature(freq_hz: float) -> str:
+    return (
+        f"A riser mode near {freq_hz:.0f} Hz would show up in Sec 6c step-response "
+        "captures as ringing at that frequency riding on top of the expected "
+        "torque/pitch response -- present on every step regardless of commanded "
+        "current or direction, NOT scaling with the current-loop time constant, "
+        "and reproducible by tapping the rig by hand near the motor with the "
+        "controller idle (a phone microphone's spectrum view is enough to read "
+        "the frequency off directly). A plant defect does not do any of that: "
+        "it depends on the command, and it vanishes when the motor is off."
+    )
+
+
+@dataclass
+class RiserAssessment:
+    """The full #64 verdict: as-designed, and braced if that verdict needed it.
+
+    Every frequency is reported as a (pessimistic, optimistic) pair across
+    the assumed motor-mass range -- see the module docstring's ASSUMED
+    section -- rather than collapsed to one number.  `verdict` and
+    `braced_verdict` are both evaluated at the pessimistic end.
+    """
+
+    geometry: RiserGeometry
+    hub_mass_kg: float
+    tip_mass_low_kg: float
+    tip_mass_high_kg: float
+    first_mode_low_hz: float
+    first_mode_high_hz: float
+    verdict: str
+    bench_signature: str
+    brace_height_m: float | None = None
+    braced_first_mode_low_hz: float | None = None
+    braced_first_mode_high_hz: float | None = None
+    braced_verdict: str | None = None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["geometry"] = asdict(self.geometry)
+        return d
+
+
+def assess_riser(
+    path: Path = MODEL_PATH,
+    brace_height_m: float = DEFAULT_BRACE_HEIGHT_M,
+    geometry: RiserGeometry | None = None,
+    hub_mass_kg: float | None = None,
+) -> RiserAssessment:
+    """The single entry point for issue #64: as-designed verdict, and a
+    braced re-check if (and only if) the unbraced design does not clear
+    `TARGET_HZ` with margin.
+
+    `geometry`/`hub_mass_kg` let a test exercise the early-return path (an
+    adequate-as-designed riser) without needing a second XML fixture on
+    disk; production callers should leave both at their defaults, which read
+    the real compiled rig.
+    """
+    if geometry is None:
+        geometry = riser_geometry_from_model(path)
+    if hub_mass_kg is None:
+        hub_mass_kg = hub_mass_from_model(path)
+    hub_mass = hub_mass_kg
+    tip_low, tip_high = tip_mass_bounds_kg(hub_mass)
+
+    # Heavier tip mass -> lower frequency, so pair (tip_high -> f_low).
+    f_low = cantilever_first_mode_hz(tip_high, geometry)
+    f_high = cantilever_first_mode_hz(tip_low, geometry)
+    as_designed_verdict = verdict(f_low, f_high)
+
+    assessment = RiserAssessment(
+        geometry=geometry,
+        hub_mass_kg=hub_mass,
+        tip_mass_low_kg=tip_low,
+        tip_mass_high_kg=tip_high,
+        first_mode_low_hz=f_low,
+        first_mode_high_hz=f_high,
+        verdict=as_designed_verdict,
+        bench_signature=describe_bench_signature(f_low),
+    )
+
+    if as_designed_verdict == "adequate":
+        return assessment
+
+    braced_low = gusset_brace_first_mode_hz(tip_high, geometry, brace_height_m)
+    braced_high = gusset_brace_first_mode_hz(tip_low, geometry, brace_height_m)
+    assessment.brace_height_m = brace_height_m
+    assessment.braced_first_mode_low_hz = braced_low
+    assessment.braced_first_mode_high_hz = braced_high
+    assessment.braced_verdict = verdict(braced_low, braced_high)
+    return assessment
+
+
+def main() -> int:
+    assessment = assess_riser()
+    print(f"=== bench riser first mode  [target >= {TARGET_HZ:.0f} Hz]")
+    print(f"  geometry        L={assessment.geometry.length_m * 1000:.0f} mm, "
+          f"b={assessment.geometry.width_m * 1000:.0f} mm, "
+          f"t={assessment.geometry.thickness_m * 1000:.2f} mm")
+    print(f"  tip mass range  {assessment.tip_mass_low_kg:.3f} - "
+          f"{assessment.tip_mass_high_kg:.3f} kg "
+          f"(hub {assessment.hub_mass_kg * 1000:.1f} g exact, motor "
+          f"{MOTOR_MASS_LOW_KG * 1000:.0f}-{MOTOR_MASS_HIGH_KG * 1000:.0f} g ASSUMED)")
+    print(f"  first mode      {assessment.first_mode_low_hz:.1f} - "
+          f"{assessment.first_mode_high_hz:.1f} Hz  -> {assessment.verdict.upper()}")
+    if assessment.braced_verdict is not None:
+        print(f"  with a gusset to {assessment.brace_height_m * 1000:.0f} mm: "
+              f"{assessment.braced_first_mode_low_hz:.1f} - "
+              f"{assessment.braced_first_mode_high_hz:.1f} Hz  -> "
+              f"{assessment.braced_verdict.upper()}")
+    print(f"  {assessment.bench_signature}")
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = OUT_DIR / "bench_riser.json"
+    out_path.write_text(json.dumps(assessment.to_dict(), indent=2) + "\n")
+    print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_riser.py
+++ b/tests/test_bench_riser.py
@@ -1,0 +1,182 @@
+"""Acceptance gate for issue #64: is the 1/4" riser stiff enough?
+
+`bench_riser.py`'s first-mode ROM is a hand-derivable cantilever-with-tip-mass
+calculation; these tests pin both the ARITHMETIC (independent scaling checks
+against the analytic formula, so a coding slip doesn't silently move the
+verdict) and the CURRENT VERDICT against the rig as designed and as purchased
+(#65/#66's confirmed flywheel figures) -- a regression gate, so a geometry
+change to bench_rig.xml that quietly moves the riser back into "adequate" or
+further into "inadequate" is caught rather than assumed.
+"""
+
+import math
+
+import pytest
+
+from sim.scenarios.bench_riser import (
+    ALUMINUM_DENSITY_KG_M3,
+    ALUMINUM_E_PA,
+    DEFAULT_BRACE_HEIGHT_M,
+    FLYWHEEL_COUNT,
+    FLYWHEEL_MASS_EACH_KG,
+    MOTOR_MASS_HIGH_KG,
+    MOTOR_MASS_LOW_KG,
+    TARGET_HZ,
+    RiserGeometry,
+    assess_riser,
+    cantilever_first_mode_hz,
+    describe_bench_signature,
+    gusset_brace_first_mode_hz,
+    hub_mass_from_model,
+    riser_geometry_from_model,
+    tip_mass_bounds_kg,
+    verdict,
+)
+
+# A convenient, round test fixture -- not the real rig -- for the arithmetic
+# checks below, so the numbers are easy to hand-verify.
+_TEST_GEOM = RiserGeometry(length_m=0.2, width_m=0.12, thickness_m=0.00635)
+
+
+def test_riser_geometry_from_model_matches_confirmed_purchase():
+    geom = riser_geometry_from_model()
+    assert geom.length_m == pytest.approx(0.20, abs=1e-9)
+    assert geom.width_m == pytest.approx(0.12, abs=1e-9)
+    # Confirmed purchased dimension (#66), not whatever the compiled model
+    # currently rounds it to -- see the module docstring.
+    assert geom.thickness_m == pytest.approx(0.00635, abs=1e-9)
+
+
+def test_hub_mass_matches_geometry_times_density():
+    mass = hub_mass_from_model()
+    # bench_rig.xml: hub is a cylinder, r=0.011, half-length=0.010, density 2700.
+    expected = 2700.0 * math.pi * 0.011**2 * (2 * 0.010)
+    assert mass == pytest.approx(expected, rel=1e-6)
+
+
+def test_cantilever_first_mode_matches_closed_form_no_beam_mass():
+    """With a massless beam (density 0), `cantilever_first_mode_hz` must
+    reduce exactly to f = (1/2pi)*sqrt(3EI/(L^3*m)) -- the textbook formula
+    with no Rayleigh correction to get wrong."""
+    geom = RiserGeometry(length_m=0.2, width_m=0.12, thickness_m=0.00635)
+    tip_mass = 0.9
+
+    moment_of_inertia = geom.width_m * geom.thickness_m**3 / 12.0
+    stiffness = 3.0 * ALUMINUM_E_PA * moment_of_inertia / geom.length_m**3
+    expected = math.sqrt(stiffness / tip_mass) / (2.0 * math.pi)
+
+    # Zero out the Rayleigh beam-mass term by using a vanishingly light beam:
+    # same closed form, computed independently of the module's own beam-mass
+    # constant so this is a real cross-check rather than the same formula
+    # copy-pasted.
+    import sim.scenarios.bench_riser as br
+
+    original_density = br.ALUMINUM_DENSITY_KG_M3
+    try:
+        br.ALUMINUM_DENSITY_KG_M3 = 1e-12
+        result = cantilever_first_mode_hz(tip_mass, geom)
+    finally:
+        br.ALUMINUM_DENSITY_KG_M3 = original_density
+
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_first_mode_scales_as_thickness_to_the_1p5():
+    """f ~ sqrt(I) ~ sqrt(t^3) = t^1.5, holding tip mass and beam mass fixed
+    (beam mass is a small correction here, so this is checked loosely)."""
+    thin = RiserGeometry(length_m=0.2, width_m=0.12, thickness_m=0.00635)
+    thick = RiserGeometry(length_m=0.2, width_m=0.12, thickness_m=0.0127)  # 2x
+    tip_mass = 0.9
+
+    f_thin = cantilever_first_mode_hz(tip_mass, thin)
+    f_thick = cantilever_first_mode_hz(tip_mass, thick)
+
+    assert f_thick / f_thin == pytest.approx(2.0**1.5, rel=0.05)
+
+
+def test_first_mode_scales_inversely_as_length_to_the_1p5():
+    """f ~ sqrt(1/L^3) = L^-1.5, same loose tolerance rationale as above."""
+    long_geom = RiserGeometry(length_m=0.2, width_m=0.12, thickness_m=0.00635)
+    short_geom = RiserGeometry(length_m=0.1, width_m=0.12, thickness_m=0.00635)  # half
+    tip_mass = 0.9
+
+    f_long = cantilever_first_mode_hz(tip_mass, long_geom)
+    f_short = cantilever_first_mode_hz(tip_mass, short_geom)
+
+    assert f_short / f_long == pytest.approx(2.0**1.5, rel=0.05)
+
+
+def test_heavier_tip_mass_lowers_frequency():
+    f_light = cantilever_first_mode_hz(0.5, _TEST_GEOM)
+    f_heavy = cantilever_first_mode_hz(1.5, _TEST_GEOM)
+    assert f_heavy < f_light
+
+
+def test_tip_mass_bounds_include_confirmed_flywheels_and_exact_hub():
+    hub = 0.0205
+    low, high = tip_mass_bounds_kg(hub)
+    flywheels = FLYWHEEL_MASS_EACH_KG * FLYWHEEL_COUNT
+    assert low == pytest.approx(MOTOR_MASS_LOW_KG + hub + flywheels)
+    assert high == pytest.approx(MOTOR_MASS_HIGH_KG + hub + flywheels)
+    assert flywheels == pytest.approx(0.304)  # 2 x goBILDA 3628-0032-0082, 152 g each
+
+
+@pytest.mark.parametrize(
+    "low,high,expected",
+    [
+        (TARGET_HZ * 1.5, TARGET_HZ * 1.5, "adequate"),
+        (TARGET_HZ * 1.5 - 0.01, TARGET_HZ * 2.0, "marginal"),  # worst end just misses
+        (TARGET_HZ, TARGET_HZ, "marginal"),
+        (TARGET_HZ - 0.01, TARGET_HZ * 10, "inadequate"),  # worst end just misses target
+    ],
+)
+def test_verdict_bands_are_evaluated_at_the_pessimistic_end(low, high, expected):
+    assert verdict(low, high) == expected
+
+
+def test_gusset_at_zero_height_is_the_unbraced_case():
+    unbraced = cantilever_first_mode_hz(0.9, _TEST_GEOM)
+    braced_at_base = gusset_brace_first_mode_hz(0.9, _TEST_GEOM, brace_height_m=0.0)
+    assert braced_at_base == pytest.approx(unbraced)
+
+
+def test_gusset_brace_raises_the_first_mode():
+    unbraced = cantilever_first_mode_hz(0.9, _TEST_GEOM)
+    braced = gusset_brace_first_mode_hz(0.9, _TEST_GEOM, brace_height_m=0.08)
+    assert braced > unbraced
+
+
+def test_as_designed_riser_is_inadequate_against_target():
+    """The regression gate: as purchased (200 mm x 120 mm x 6.35 mm 6061,
+    carrying two confirmed 152 g goBILDA flywheels + an assumed-range motor),
+    the riser's first mode sits BELOW the 50 Hz target, at both ends of the
+    assumed motor-mass range. If this ever flips to "adequate" because
+    someone changed the riser geometry, that is real news for #64 and this
+    test should be updated to say so explicitly -- not silently pass."""
+    assessment = assess_riser()
+    assert assessment.verdict == "inadequate"
+    assert assessment.first_mode_high_hz < TARGET_HZ
+
+
+def test_default_gusset_brace_reaches_adequate_with_margin():
+    assessment = assess_riser(brace_height_m=DEFAULT_BRACE_HEIGHT_M)
+    assert assessment.braced_verdict == "adequate"
+    assert assessment.braced_first_mode_low_hz > TARGET_HZ * 1.5
+
+
+def test_adequate_as_designed_riser_skips_the_braced_recheck():
+    """If a hypothetically stiffer riser clears the target on its own,
+    `assess_riser` should not report a braced result nobody asked for."""
+    stiff_geometry = RiserGeometry(length_m=0.05, width_m=0.12, thickness_m=0.00635)
+    assessment = assess_riser(geometry=stiff_geometry, hub_mass_kg=0.0205)
+    assert assessment.verdict == "adequate"
+    assert assessment.braced_verdict is None
+    assert assessment.braced_first_mode_low_hz is None
+    assert assessment.braced_first_mode_high_hz is None
+    assert assessment.brace_height_m is None
+
+
+def test_bench_signature_names_the_target_frequency_and_the_tap_test():
+    description = describe_bench_signature(40.0)
+    assert "40" in description
+    assert "tap" in description.lower()


### PR DESCRIPTION
## What changed and why

Issue #64: the ¼″ 6061 plate is bought and non-returnable, and nobody had checked whether the
~200 mm riser (base plate + riser bracket, `bench_rig.xml`) is stiff enough. Runbook §3.2 wants
the fixture's first structural resonance well above the control bandwidth (>50 Hz) — a mode
inside that band would corrupt the torque→pitch identification the rig exists to perform, while
looking like a plant defect rather than a fixture one.

- `sim/scenarios/bench_riser.py` (new) — models the riser as a cantilever beam with a tip mass,
  **weak-axis (out-of-plane) bending only** — motor torque loads the riser in its stiff in-plane
  direction (fine); the flywheel mass hanging off the shaft bends it out-of-plane, which is ¼″
  aluminium's weak axis (`I = b·t³/12`, and bending stiffness scales with the cube of the beam
  depth in the bending direction). First mode: closed-form cantilever formula + a Rayleigh
  beam-mass correction (`m_eff = m_tip + 0.236·m_beam`).
- `tests/test_bench_riser.py` (new) — 17 tests: independent arithmetic cross-checks against the
  closed-form (thickness^1.5 and length^-1.5 scaling, a massless-beam special case computed a
  second, independent way), and the regression gate pinning the current verdict.
- `roles/sr-mechanical-systems/CONTEXT.md` — decision log entry.

## Measured, confirmed, assumed — the honest split

- **Measured** (off the compiled model): riser height 200 mm, width 120 mm.
- **Confirmed** (manufacturer/purchase-order, #65/#66): thickness 6.35 mm (exact ¼″, hardcoded
  here since the compiled model on `master` still rounds it to 6 mm pending #66), material
  6061-T651, flywheel mass 152 g × 2 (goBILDA 3628-0032-0082), hub mass (exact, from the
  compiled geometry — 20.5 g).
- **Assumed**: motor mass. No datasheet for a 6374-class sensored outrunner exists in this
  repo, and this sandbox has no web access to find one, so every result is reported across an
  assumed 500–650 g range rather than at a single point, and the verdict is taken at the
  pessimistic end. **The fix for this assumption is a kitchen scale**, not a better guess — same
  convention as the flywheel mass before it shipped as a bought part.

## Result

| | First mode |
|---|---|
| As designed (unbraced) | **39.5–42.6 Hz** → **INADEQUATE** against the 50 Hz target |
| With a gusset to 80 mm up the riser | **86.7–93.7 Hz** → **ADEQUATE** (>1.5× margin) |

The gusset is modelled as shortening the unbraced cantilever span to the height above the brace
attachment — a standard ROM simplification for a triangulated strut acting as a near-rigid
support, not an FEA of the brace itself. 80 mm (40% up the 200 mm riser) was picked because it
already clears the adequate band with room to spare; there was no need to hunt for the minimum
viable height. It's an offcut of the same ¼″ 6061 stock already bought — the 12″×12″ raw stock
leaves ~60% spare per #66's PR — so this needs **no new purchase**.

## Acceptance criteria (issue #64)

- [x] First-mode estimate for the riser as designed, carrying the motor plus two 152 g
      flywheels at the shaft overhang, assumptions stated, calculation shown.
- [x] Clear verdict: **inadequate** against the >50 Hz target.
- [x] Cheapest fix using metal already owned: a gusset brace, with the arithmetic
      (86.7–93.7 Hz, well inside "adequate").
- [x] What a compliant riser looks like in the §6c step-response data, so it's recognised at the
      bench rather than mistaken for plant behaviour — `describe_bench_signature()`: ringing at
      the modal frequency on every step regardless of commanded current, not scaling with the
      current-loop time constant, reproducible by tapping the idle rig (phone mic spectrum).
- [x] Honest about what can't be bounded without measuring (motor mass) — flagged, bounded by a
      stated range, and a cheap real measurement (weigh it) named as the actual fix.

## Out of scope

- **Not** an FEA of the riser or the gusset — a ROM estimate, explicitly flagged as such, with a
  tap test named as the cheap way to confirm it at the bench.
- **Not** modifying `bench_rig.xml` itself — no gusset geometry added to the model, since #64
  asks for a verdict and a fix recommendation, not a rebuild of the rig. Cutting and fitting the
  physical gusset (and updating the model if bench data shows it's needed) is bench-build work,
  not sim work.
- The mini-clamp resonance risk `bench_rig.xml`/#66 already flagged is a second candidate
  resonance source, not analysed here — this PR is scoped to the riser itself.

## Turf

`sim/scenarios/bench_riser.py`, `tests/test_bench_riser.py`, `roles/sr-mechanical-systems/` — all
mine per `.github/policy_check.py --who` for each touched path. No `sim/models/` changes, no
`<sensor>`/`<actuator>` touched, no bench-fitted constant written into a board model.

## Verification

- `.venv (py3.13)/bin/python3 -m pytest tests/` → 219 passed, 2 xfailed (up from 201 on a clean
  `master` checkout; 17 new, no regressions), after `cargo build --release -p control-ffi`
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅ (no Rust touched)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `python3 .github/policy_check.py` ✅ all hard checks pass

Closes #64

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALBF56KAvz2D6vonrvA4Bc)_