### PR TITLE
fix(mech): decide the flywheel inertia ratio question

### DIFF
--- a/roles/sr-mechanical-systems/CONTEXT.md
+++ b/roles/sr-mechanical-systems/CONTEXT.md
@@ -73,6 +73,23 @@ now cross-check: free-roll agreement 0.24–1.78% to 20% grade, bit-identical on
 asymmetry Controls measured falls out of geometry, because a board resting flat on a slope is
 already at world pitch −φ. PR #18.
 
+**2026-07-28 — Add a $20-30 steel disc, sequenced behind the bare-run measurement, not before it.**
+Issue #65: the confirmed goBILDA flywheels (3302 g·cm² total, manufacturer figure) give a ratio
+against the estimated bare-rotor band of 1.1–1.65, against a 6.69 design point that was never
+actually buildable (it assumed a heavier custom disc that was never bought). Derived the
+error-amplification formula `sqrt(1+ρ²)/(ρ-1)` (ρ = alpha1/alpha2 = 1+ratio) from `identify()`'s
+own two-run algebra and cross-checked it numerically (independent finite-difference derivative,
+not a restatement) — `sim/scenarios/bench_inertia_ratio.py`. Result: 1.72×–2.11× amplification on
+the confirmed flywheels, 1.48×–1.82× worse than the 1.159× design point — a firm number where the
+issue only had "roughly doubles." **Decision: add inertia, not accept-and-carry.** A single ~150 mm/
+600 g steel disc stacked on the confirmed flywheels restores the ratio to 6.7–10.1 (amplification
+back to ~1.16×) for the cost the issue itself named, against torque figures every later stage
+inherits. **But order it only after the bench's own bare-rotor run measures `J_bare`** — that
+resolves the 16× sourcing disagreement for free (mode 1 of `identify()` already measures it), so
+buying before measuring risks sizing the disc against the wrong end of a 16×-wide guess.
+`recommend(j_bare_measured_kg_m2=...)` re-derives the pick once that number exists. PR pending,
+issue #65.
+
 ## Known dead ends
 
 - **Do not lift the board clear of the ground to isolate accelerometer geometry.** A free-floating

--- a/sim/scenarios/bench_inertia_ratio.py
+++ b/sim/scenarios/bench_inertia_ratio.py
@@ -1,0 +1,243 @@
+"""Bench-rig flywheel/rotor inertia ratio: how much it costs, and what to do
+about it.
+
+Issue #65: the two goBILDA 82 mm flywheels are ordered and shipping, and
+their inertia is now a manufacturer figure rather than a guess -- 1651 g*cm^2
+each, 3302 g*cm^2 (3.302e-4 kg*m^2) together (see #66/#72's `bench_rig.xml`
+update). Against the estimated bare-rotor inertia band, 2000-3000 g*cm^2 (no
+manufacturer publishes this for an e-skate 6374, and the two sources found
+during sourcing disagreed 16x -- #65), that gives a ratio `J_disc/J_bare` of
+roughly 1.1-1.65. The sim originally validated the two-run method at 6.69,
+using a heavier custom aluminium disc that was never bought (`bench_spinup.
+NAMEPLATE_KT_NM_PER_A`'s sibling constant, the old 75 mm/572 g custom-disc
+estimate this rig has since moved off of).
+
+WHY THE RATIO MATTERS: THE ERROR-AMPLIFICATION DERIVATION
+-----------------------------------------------------------
+`identify()` (see `bench_spinup.py`) solves
+
+    kt = J_disc / (i * (1/alpha2 - 1/alpha1))
+
+from two fitted slopes, bare (`alpha1`) and loaded (`alpha2`). Let
+`rho = alpha1/alpha2 = 1 + J_disc/J_bare` -- the same slope-separation ratio
+`identify()`'s own docstring calls out (7.4x at the design point). Standard
+first-order error propagation, treating `alpha1` and `alpha2` as independent
+measurements each with relative error `eps` (from finite R^2, sensor noise,
+whatever the bench actually measures that error to be), gives a relative
+error in `kt` of
+
+    sigma_kt / kt  =  eps * sqrt(1 + rho^2) / (rho - 1)
+
+`kt_error_amplification()` is that multiplier, `sqrt(1+rho^2)/(rho-1)`,
+independent of `eps` -- it says how much WORSE (or better) a given per-alpha
+measurement error becomes once it passes through the two-run algebra, as a
+function of the ratio alone. It is cross-checked in
+`tests/test_bench_inertia_ratio.py` against a second, independent
+derivation: numerical differentiation of the actual `kt` expression above
+(not a restatement of the same formula), the same convention #64's
+`bench_riser.py` used for its own closed-form cross-check.
+
+THE NUMBERS, MEASURED FROM THE FORMULA RATHER THAN ASSERTED
+--------------------------------------------------------------
+    design point (ratio 6.69, never-bought disc)         amplification 1.159x
+    confirmed range, worst end   (ratio 1.101)            amplification 2.113x
+    confirmed range, best end    (ratio 1.651)             amplification 1.716x
+
+So accepting the confirmed flywheels costs a **1.48x-1.82x** increase in how
+much any given alpha-fit error shows up in `kt` -- "roughly doubles" (the
+issue's own estimate) is accurate at the pessimistic end and a bit
+conservative at the optimistic end. It is a real cost, but a bounded,
+finite one: nothing here blows up or goes non-invertible, because the
+confirmed ratio (>=1.1) still clears the "added inertia comparable to or
+larger than the unknown" floor the two-run method actually needs.
+
+THE CHEAP FIX, AND WHY IT WORKS
+---------------------------------
+`kt_error_amplification` falls fast as `ratio` grows past ~2 and flattens out
+above ~5 (`d(amplification)/d(ratio)` shrinks as `ratio` grows), so a single
+inexpensive disc that recovers most of the way to the design point buys back
+nearly all of the loss. A single ~150 mm-diameter, ~600 g steel disc
+(`STEEL_DISC_INERTIA_KG_M2`) stacked alongside the two confirmed flywheels
+gives a combined `J_disc` of ~2.018e-3 kg*m^2 -- against the SAME 2000-3000
+g*cm^2 bare-rotor band, that is a ratio of 6.7-10.1, i.e. amplification
+1.16x at the worst case: back to the design point, for the ~$20-30 the issue
+itself named. `RECOMMENDED_STACK_DESCRIPTION` states this as the pick.
+
+THE RECOMMENDATION (issue #65's four acceptance criteria)
+-------------------------------------------------------------
+1. **Add inertia, not "accept and carry the wider error bar."** The
+   confirmed ratio is workable (it clears the required floor) but the
+   amplification cost (1.5-1.8x) is not free, and the fix costs $20-30
+   against torque figures every later stage inherits. That asymmetry is
+   the whole justification.
+2. **Sequence it behind the bare-rotor measurement, not before it.** The
+   16x sourcing disagreement on `J_bare` is resolved for free by the first
+   bench session's own bare run (mode 1 of `identify()` already measures
+   it) -- no purchase is needed to get that number, and ordering before
+   measuring risks buying for the wrong end of a 16x-wide guess. Rerunning
+   `recommend()` with the measured `J_bare` in place of the estimated band
+   turns this from a range into a single, confirmed pick.
+3. **The error bar is the multiplier above, not an absolute number.** No
+   bench current-noise or R^2 figure exists yet for THIS rig (that is a
+   Stage-0B measurement, not a sim one), so `kt_error_amplification` is
+   reported as a multiplier on whatever that measured `eps` turns out to
+   be, not a fabricated absolute percentage.
+4. **Sequencing already answered under point 2** -- measure `J_bare` first.
+
+WHAT THIS MODULE DOES NOT DO
+-------------------------------
+It does not place an order. Platform selection is this role's remit
+(ROLES.md), but committing money is the CEO's -- this module states the
+arithmetic and the pick so that decision can be made in one read, not zero.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+#: goBILDA 3628-0032-0082, manufacturer-published (#65/#66): 1651 g*cm^2
+#: each, converted to SI (1 g*cm^2 = 1e-7 kg*m^2).
+FLYWHEEL_INERTIA_EACH_KG_M2 = 1651e-7
+FLYWHEEL_COUNT = 2
+J_DISC_CONFIRMED_KG_M2 = FLYWHEEL_INERTIA_EACH_KG_M2 * FLYWHEEL_COUNT
+
+#: Estimated bare-rotor inertia band for a 6374-class outrunner. No
+#: manufacturer publishes this figure and the two sources found during
+#: sourcing disagreed 16x (#65) -- this is a working range, not a
+#: measurement. `recommend()` should be re-run with the bench's own
+#: bare-run figure once it exists; see the module docstring.
+J_BARE_ESTIMATE_LOW_KG_M2 = 2000e-7
+J_BARE_ESTIMATE_HIGH_KG_M2 = 3000e-7
+
+#: The ratio the two-run method was originally sim-validated at, using a
+#: heavier custom aluminium disc (75 mm radius, 12 mm thick, 6061) that was
+#: never bought -- see `bench_spinup.py`'s FLYWHEEL_* constants, which still
+#: describe that never-built part, not the goBILDA discs actually shipped.
+DESIGN_POINT_RATIO = 6.69
+
+#: A single steel disc sized to recover most of the design-point margin
+#: cheaply, per the issue's own costing ("~150 mm steel disc (~600 g)
+#: reaches the design point for roughly $20-30"). 75 mm radius, 0.6 kg,
+#: solid disc about its own axis: J = 0.5*m*r^2.
+STEEL_DISC_MASS_KG = 0.6
+STEEL_DISC_RADIUS_M = 0.075
+STEEL_DISC_INERTIA_KG_M2 = 0.5 * STEEL_DISC_MASS_KG * STEEL_DISC_RADIUS_M**2
+
+RECOMMENDED_STACK_DESCRIPTION = (
+    "Both confirmed goBILDA flywheels plus one ~150 mm/600 g steel disc "
+    "(~$20-30, per the issue's own costing) -- ordered only after the "
+    "bare-rotor run measures J_bare, not before."
+)
+
+
+def slope_ratio(j_disc_kg_m2: float, j_bare_kg_m2: float) -> float:
+    """`alpha1/alpha2` in `identify()`'s own terms: `1 + J_disc/J_bare`."""
+    return 1.0 + j_disc_kg_m2 / j_bare_kg_m2
+
+
+def kt_error_amplification(j_disc_over_j_bare: float) -> float:
+    """How much a given relative error in each fitted slope (`alpha1`,
+    `alpha2`) is amplified in the resulting `kt`, as a function of the
+    disc/bare inertia ratio alone. See the module docstring for the
+    derivation and its independent numerical cross-check
+    (`tests/test_bench_inertia_ratio.py`).
+
+    `j_disc_over_j_bare` must be > 0 -- `identify()` itself divides by
+    `(1/alpha2 - 1/alpha1)`, which is exactly this constraint restated in
+    slope terms, since a ratio of 0 means no added inertia to measure
+    against at all.
+    """
+    if j_disc_over_j_bare <= 0.0:
+        raise ValueError(
+            f"J_disc/J_bare must be positive, got {j_disc_over_j_bare} -- "
+            "a non-positive ratio means no added inertia to fit against."
+        )
+    rho = 1.0 + j_disc_over_j_bare
+    return math.sqrt(1.0 + rho**2) / (rho - 1.0)
+
+
+@dataclass(frozen=True)
+class InertiaRatioAssessment:
+    """The #65 verdict, both ends of the bare-rotor estimate band."""
+
+    ratio_low: float
+    ratio_high: float
+    amplification_low: float
+    """Amplification at the LOWER ratio (larger assumed J_bare) -- the
+    worse, pessimistic case."""
+    amplification_high: float
+    """Amplification at the HIGHER ratio (smaller assumed J_bare) -- the
+    better, optimistic case."""
+    amplification_at_design_point: float
+    worst_case_relative_increase: float
+    """`amplification_low / amplification_at_design_point` -- how much worse
+    the worst confirmed case is than what the method was validated at."""
+
+
+def assess_confirmed_flywheels(
+    j_disc_kg_m2: float = J_DISC_CONFIRMED_KG_M2,
+    j_bare_low_kg_m2: float = J_BARE_ESTIMATE_LOW_KG_M2,
+    j_bare_high_kg_m2: float = J_BARE_ESTIMATE_HIGH_KG_M2,
+) -> InertiaRatioAssessment:
+    """Assess the confirmed goBILDA flywheels against the estimated bare-rotor
+    band. A larger assumed `J_bare` gives a SMALLER ratio (worse case) --
+    `ratio_low` therefore pairs with `j_bare_high_kg_m2` and vice versa.
+    """
+    ratio_low = j_disc_kg_m2 / j_bare_high_kg_m2
+    ratio_high = j_disc_kg_m2 / j_bare_low_kg_m2
+    amp_low = kt_error_amplification(ratio_low)
+    amp_high = kt_error_amplification(ratio_high)
+    amp_design = kt_error_amplification(DESIGN_POINT_RATIO)
+    return InertiaRatioAssessment(
+        ratio_low=ratio_low,
+        ratio_high=ratio_high,
+        amplification_low=amp_low,
+        amplification_high=amp_high,
+        amplification_at_design_point=amp_design,
+        worst_case_relative_increase=amp_low / amp_design,
+    )
+
+
+def assess_with_steel_disc(
+    j_bare_low_kg_m2: float = J_BARE_ESTIMATE_LOW_KG_M2,
+    j_bare_high_kg_m2: float = J_BARE_ESTIMATE_HIGH_KG_M2,
+) -> InertiaRatioAssessment:
+    """Same assessment, with `STEEL_DISC_INERTIA_KG_M2` stacked onto the
+    confirmed flywheels -- the recommended fix."""
+    return assess_confirmed_flywheels(
+        j_disc_kg_m2=J_DISC_CONFIRMED_KG_M2 + STEEL_DISC_INERTIA_KG_M2,
+        j_bare_low_kg_m2=j_bare_low_kg_m2,
+        j_bare_high_kg_m2=j_bare_high_kg_m2,
+    )
+
+
+def recommend(
+    j_bare_measured_kg_m2: float | None = None,
+) -> str:
+    """The #65 recommendation, in one string. Pass the bench's own measured
+    `J_bare` (from `identify()`'s bare run) once it exists to turn this from
+    a range into a single confirmed pick, per the module docstring's point 2.
+    """
+    if j_bare_measured_kg_m2 is not None:
+        ratio_as_shipped = J_DISC_CONFIRMED_KG_M2 / j_bare_measured_kg_m2
+        amp_as_shipped = kt_error_amplification(ratio_as_shipped)
+        ratio_with_disc = (
+            J_DISC_CONFIRMED_KG_M2 + STEEL_DISC_INERTIA_KG_M2
+        ) / j_bare_measured_kg_m2
+        amp_with_disc = kt_error_amplification(ratio_with_disc)
+        return (
+            f"Measured J_bare={j_bare_measured_kg_m2:.4e} kg*m^2: as-shipped ratio "
+            f"{ratio_as_shipped:.2f} (amplification {amp_as_shipped:.3f}x); with the "
+            f"steel disc, ratio {ratio_with_disc:.2f} (amplification "
+            f"{amp_with_disc:.3f}x). Add the disc if the as-shipped amplification "
+            "is not already acceptable against the bench's measured per-alpha error."
+        )
+    a = assess_confirmed_flywheels()
+    return (
+        f"Confirmed flywheels alone: ratio {a.ratio_low:.2f}-{a.ratio_high:.2f}, "
+        f"kt-error amplification {a.amplification_low:.3f}x-{a.amplification_high:.3f}x "
+        f"({a.worst_case_relative_increase:.2f}x worse than the "
+        f"{a.amplification_at_design_point:.3f}x design point). Recommendation: "
+        f"{RECOMMENDED_STACK_DESCRIPTION}"
+    )

--- a/tests/test_bench_inertia_ratio.py
+++ b/tests/test_bench_inertia_ratio.py
@@ -1,0 +1,151 @@
+"""Acceptance gate for issue #65: the flywheel/rotor inertia ratio decision.
+
+Pins the arithmetic (an independent numerical cross-check of the closed-form
+error-amplification formula, so a coding slip doesn't silently move the
+verdict) and the current recommendation against the confirmed goBILDA
+figures (#65/#66) -- a regression gate, so a change to the confirmed
+flywheel or bare-rotor estimate quietly moving the verdict is caught rather
+than assumed.
+"""
+
+import math
+
+import pytest
+
+from sim.scenarios.bench_inertia_ratio import (
+    DESIGN_POINT_RATIO,
+    FLYWHEEL_COUNT,
+    FLYWHEEL_INERTIA_EACH_KG_M2,
+    J_BARE_ESTIMATE_HIGH_KG_M2,
+    J_BARE_ESTIMATE_LOW_KG_M2,
+    J_DISC_CONFIRMED_KG_M2,
+    STEEL_DISC_INERTIA_KG_M2,
+    assess_confirmed_flywheels,
+    assess_with_steel_disc,
+    kt_error_amplification,
+    recommend,
+    slope_ratio,
+)
+
+
+def _numeric_amplification(ratio: float, eps: float = 1e-6) -> float:
+    """Independent cross-check: numerically differentiate `identify()`'s own
+    `kt = J_disc/(i*(1/alpha2 - 1/alpha1))` expression (dropping the
+    constants `J_disc` and `i`, which cancel in a *relative* sensitivity)
+    with respect to `alpha1` and `alpha2` directly, rather than restating
+    the closed-form `sqrt(1+rho^2)/(rho-1)` a second time. `alpha1=1` is a
+    free choice of units; only the ratio `alpha1/alpha2 = 1+ratio` matters.
+    """
+    alpha1 = 1.0
+    alpha2 = alpha1 / (1.0 + ratio)
+
+    def ln_kt(d_alpha1: float, d_alpha2: float) -> float:
+        a1 = alpha1 * (1.0 + d_alpha1)
+        a2 = alpha2 * (1.0 + d_alpha2)
+        return math.log(1.0 / (1.0 / a2 - 1.0 / a1))
+
+    d_ln_d_alpha1 = (ln_kt(eps, 0.0) - ln_kt(-eps, 0.0)) / (2 * eps)
+    d_ln_d_alpha2 = (ln_kt(0.0, eps) - ln_kt(0.0, -eps)) / (2 * eps)
+    return math.sqrt(d_ln_d_alpha1**2 + d_ln_d_alpha2**2)
+
+
+@pytest.mark.parametrize("ratio", [0.05, 0.5, 1.101, 1.37, 1.651, 2.201, 6.69, 20.0])
+def test_amplification_matches_independent_numeric_derivative(ratio):
+    closed_form = kt_error_amplification(ratio)
+    numeric = _numeric_amplification(ratio)
+    assert closed_form == pytest.approx(numeric, rel=1e-6)
+
+
+def test_amplification_rejects_nonpositive_ratio():
+    with pytest.raises(ValueError):
+        kt_error_amplification(0.0)
+    with pytest.raises(ValueError):
+        kt_error_amplification(-1.0)
+
+
+def test_amplification_decreases_as_ratio_grows():
+    # More added inertia relative to the unknown always helps -- monotonic,
+    # not just numerically close, across the whole confirmed-to-design range.
+    ratios = [1.0, 1.101, 1.37, 1.651, 2.201, 6.69, 6.726, 20.0]
+    amplifications = [kt_error_amplification(r) for r in ratios]
+    assert amplifications == sorted(amplifications, reverse=True)
+
+
+def test_slope_ratio_matches_identifys_own_two_run_algebra():
+    # identify()'s docstring: alpha1/alpha2 = 1 + J_disc/J_bare. The
+    # never-bought custom disc (1.6103e-3 kg*m^2, #72's before/after table)
+    # against the same bare-rotor estimate this module uses is what produces
+    # the design point 6.69 in the first place.
+    j_disc_old_custom_estimate = 1.6103e-3
+    j_bare = 2.4071e-4
+    rho = slope_ratio(j_disc_old_custom_estimate, j_bare)
+    assert rho == pytest.approx(1.0 + j_disc_old_custom_estimate / j_bare, rel=1e-9)
+    assert rho == pytest.approx(DESIGN_POINT_RATIO + 1.0, rel=1e-3)
+
+
+def test_confirmed_flywheel_inertia_matches_manufacturer_figure():
+    # goBILDA 3628-0032-0082: 1651 g*cm^2 each, two on the shaft (#65/#66).
+    assert FLYWHEEL_COUNT == 2
+    assert FLYWHEEL_INERTIA_EACH_KG_M2 == pytest.approx(1651e-7, rel=1e-9)
+    assert J_DISC_CONFIRMED_KG_M2 == pytest.approx(3.302e-4, rel=1e-6)
+
+
+def test_confirmed_flywheels_land_in_the_issues_stated_ratio_band():
+    a = assess_confirmed_flywheels()
+    # Issue #65: "against an estimated bare-rotor inertia of 2000-3000
+    # g*cm^2 ... a ratio of roughly 1.1-1.65."
+    assert a.ratio_low == pytest.approx(1.101, abs=0.01)
+    assert a.ratio_high == pytest.approx(1.651, abs=0.01)
+
+
+def test_confirmed_flywheels_cost_roughly_a_doubling_vs_design_point():
+    a = assess_confirmed_flywheels()
+    # Issue #65: "error amplification on kt roughly doubles." The exact
+    # figure this module derives is 1.48x-1.82x -- accurate at the
+    # pessimistic end of "roughly doubles" and a firm number where the
+    # issue only had an estimate.
+    assert 1.4 < a.worst_case_relative_increase < 1.9
+    assert a.amplification_at_design_point == pytest.approx(1.159, abs=0.005)
+    assert a.amplification_low == pytest.approx(2.113, abs=0.005)
+    assert a.amplification_high == pytest.approx(1.716, abs=0.005)
+
+
+def test_steel_disc_recovers_the_design_point_amplification():
+    a = assess_with_steel_disc()
+    # The whole justification for the recommended fix: worst-case
+    # amplification with the disc added should land back near (not just
+    # "better than") the original design-point figure.
+    assert a.amplification_low == pytest.approx(
+        a.amplification_at_design_point, rel=0.01
+    )
+    # And it should clear the design-point ratio outright, not just approach
+    # it from below.
+    assert a.ratio_low >= DESIGN_POINT_RATIO
+
+
+def test_steel_disc_costs_less_inertia_than_a_third_flywheel_would_need():
+    # Sanity bound on the recommended part: cheaper, lower-part-count than
+    # reaching the same ratio by adding more 82 mm flywheels alone (~$16
+    # each per the issue, but it would take several -- see the module
+    # docstring's arithmetic).
+    j_bare_high = J_BARE_ESTIMATE_HIGH_KG_M2
+    j_disc_needed = DESIGN_POINT_RATIO * j_bare_high
+    flywheels_needed = j_disc_needed / FLYWHEEL_INERTIA_EACH_KG_M2
+    assert flywheels_needed > 12  # far more than the two already bought
+    assert STEEL_DISC_INERTIA_KG_M2 > 0.0
+
+
+def test_recommend_without_measurement_reports_the_range_and_the_pick():
+    text = recommend()
+    assert "1.10" in text or "1.11" in text  # ratio_low, formatted to 2dp
+    assert "steel disc" in text.lower()
+
+
+def test_recommend_with_measured_j_bare_uses_it_instead_of_the_band():
+    # Once the bench's own bare run exists, the recommendation should react
+    # to it rather than staying pinned to the estimated band -- this is the
+    # point of sequencing the purchase behind the measurement.
+    text_low_bare = recommend(j_bare_measured_kg_m2=J_BARE_ESTIMATE_LOW_KG_M2)
+    text_high_bare = recommend(j_bare_measured_kg_m2=J_BARE_ESTIMATE_HIGH_KG_M2)
+    assert text_low_bare != text_high_bare
+    assert "Measured J_bare" in text_low_bare


### PR DESCRIPTION
## What changed and why

Issue #65: the two goBILDA 82 mm flywheels are ordered and shipping, and manufacturer figures are
now confirmed (1651 g·cm² each, 3302 g·cm² total). Against the estimated bare-rotor inertia band
(2000-3000 g·cm² — no manufacturer publishes this for an e-skate 6374, and the two sources found
during sourcing disagreed 16x), that's a ratio of roughly 1.1-1.65, well below the 6.69 point the
sim's two-run method was originally validated at (which used a heavier custom disc that was never
actually bought — see `bench_spinup.py`'s still-describing-that-part `FLYWHEEL_*` constants).
Nobody had turned "the ratio is lower" into a number anyone could act on.

- `sim/scenarios/bench_inertia_ratio.py` (new) — derives the `kt` error-amplification factor as a
  closed-form function of the disc/bare-rotor ratio alone, from `identify()`'s own two-run algebra
  (`kt = J_disc/(i*(1/alpha2 - 1/alpha1))`): `sqrt(1+ρ²)/(ρ-1)` where `ρ = alpha1/alpha2 = 1 +
  J_disc/J_bare`. Reports the confirmed-flywheel assessment, a recommended steel-disc fix, and a
  `recommend()` entry point that takes the bench's own measured `J_bare` once it exists.
- `tests/test_bench_inertia_ratio.py` (new) — 18 tests: an independent numerical cross-check of the
  closed-form formula (finite-difference derivative of the actual `kt` expression, not a
  restatement of the same algebra — same convention #64's `bench_riser.py` used for its cantilever
  formula), monotonicity, the confirmed-ratio-band regression pin, and the recommendation text.
- `roles/sr-mechanical-systems/CONTEXT.md` — decision log entry.

## The numbers, measured from the formula rather than asserted

| | Ratio | kt-error amplification |
|---|---|---|
| Design point (never-bought custom disc) | 6.69 | **1.159x** |
| Confirmed flywheels, worst case (larger assumed `J_bare`) | 1.101 | **2.113x** |
| Confirmed flywheels, best case (smaller assumed `J_bare`) | 1.651 | **1.716x** |
| Confirmed flywheels + 1 steel disc, worst case | 6.73 | **1.158x** |

Accepting the confirmed flywheels costs **1.48x-1.82x** more amplification of any given per-alpha
measurement error than the design point — "roughly doubles" (the issue's own estimate) turns out
accurate at the pessimistic end and a little conservative at the optimistic end. It's a real cost,
but bounded and finite: the confirmed ratio still clears the floor the two-run method actually
needs (added inertia comparable to or larger than the unknown).

`kt_error_amplification` falls fast past ratio ~2 and flattens above ~5, so a single ~150 mm/600 g
steel disc (~$20-30, the issue's own costing) stacked on the confirmed flywheels recovers the
design-point amplification almost exactly — cheap because the curve is steep exactly where the
confirmed ratio currently sits.

## Acceptance criteria (issue #65)

- [x] **A recommendation, picked and justified: add inertia**, not accept-and-carry. The
      amplification cost (1.5-1.8x) is not free, and the fix costs $20-30 against torque figures
      every downstream stage inherits — that asymmetry is the whole justification.
- [x] **The cheapest concrete option, with the arithmetic**: one ~150 mm/600 g steel disc reaches
      the design point (worst case 6.73 vs the 6.69 point), for the ~$20-30 the issue itself named.
      Quantified against the alternative (more 82 mm flywheels) in
      `test_steel_disc_costs_less_inertia_than_a_third_flywheel_would_need`: matching the design
      point with 82 mm discs alone would take >12 of them.
- [x] **Quantified what accepting 2.3x separation costs**: the kt-error amplification multiplier,
      1.72x-2.11x (1.48x-1.82x worse than the design point) — a firm number, not "roughly."
- [x] **Confirmed the bench procedure should measure `J_bare` first**: yes — mode 1 of `identify()`
      already measures it for free during the first bench session, which resolves the 16x sourcing
      disagreement without spending anything. The disc purchase is sequenced *behind* that
      measurement (`recommend(j_bare_measured_kg_m2=...)`), not ahead of it — ordering blind risks
      sizing the disc against the wrong end of a 16x-wide guess.

## What this PR does not do

Does not place an order. Platform selection is this role's remit, but committing money is the
CEO's — this PR states the arithmetic and the pick so that decision can be made in one read.

## Turf

`sim/scenarios/bench_inertia_ratio.py`, `tests/test_bench_inertia_ratio.py`,
`roles/sr-mechanical-systems/CONTEXT.md` — all mine per `.github/policy_check.py --who` for each
touched path. No `sim/models/`, `plant.py`, or `imperfections.py` touched; no bench-fitted constant
written into a board model.

## Verification

- `python3.13 -m pytest tests/` → 220 passed, 2 xfailed (up from 201 on a clean `master` checkout —
  18 new, no regressions), after `cargo build --release -p control-ffi`
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅ (no Rust touched)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `python3 .github/policy_check.py` ✅ all hard checks pass

Closes #65


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFUqAtW88gGtfqLb5Fuaaf)_