### PR TITLE
fix(controls): pin r_eff to the model's actual tire radius, not a stale nominal guess

### DIFF
--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -16,15 +16,12 @@
   loosened blindly: `test_there_is_large_margin_on_actuation_delay` was pinned at 6.80 deg
   (truth pitch) and is now 9.71 deg (the honest number) — still clear of the 18.57 deg strike
   angle, re-baselined to `< 10.5`.
-  **AC2 also now cleared (PR TBD):** the disturbance-rejection envelope is mapped, not one
-  fixed magnitude — see the decision-log entry below. **Still open — issue #24's other three
-  ACs, deliberately not attempted in the same PR:** the `r_eff` tyre-ground justification
-  (geometry is Mechanical's turf — this role can investigate and report, not edit
-  `sim/models/`); confirming every scenario already emits bit-identical metrics JSON
-  (spot-checked true for impulse and closed-loop via existing determinism tests, not
-  re-verified for hill/terrain/shuttle); and an audit marking every acceptance number in the
-  scenario docs as measured vs. assumed. Each is its own well-scoped increment, not a blocker
-  for this one.
+  **AC2 also now cleared (#67):** the disturbance-rejection envelope is mapped, not one fixed
+  magnitude. **AC3 also now cleared (see the decision-log entry below):** the `r_eff` tyre-ground
+  question — couldn't be justified, so fixed. **AC4 addressed in a separate open PR (#74, not
+  yet merged as of this entry):** determinism audited across all four scenarios. **Still open —
+  issue #24's one remaining AC:** an audit marking every acceptance number in the scenario docs
+  as measured vs. assumed. Its own well-scoped increment, not a blocker for any of the above.
 - Closed-loop control is in sim; the estimator now closes the loop on the driverless impulse gate
   and the ridden cascade too, not only the shuttle.
 
@@ -66,6 +63,7 @@
   Stage-0's eventual bench measurement will produce.
   AC5 (measured-vs-assumed audit of every scenario-doc acceptance number) remains open, its own
   increment.
+
 - **Issue #24, AC2 — disturbance-rejection envelope (PR TBD).** Added
   `sim/scenarios/disturbance_envelope.py` (`sweep_closed_loop`, `EnvelopeResult`),
   `tests/test_disturbance_envelope.py`, and `scripts/disturbance_envelope.py`. A grid sweep

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -36,6 +36,36 @@
 
 ## Decisions made (append as you go)
 
+- **Issue #24, AC3 — `r_eff` tyre-ground justification (PR TBD).** Could not be justified, so
+  fixed rather than justified. `R_EFF_M`/`DEFAULT_R_EFF_M` (converts `wheel_hinge` angular rate
+  to forward speed, and current to force, in `hill.py`/`terrain.py`/`shuttle_run.py`/
+  `rust_controller.py`/`tests/test_closed_loop.py`/two `scripts/analyse_estimator*.py`) was
+  hand-copied as `0.14605` m in every one of those places, one of them (`hill.py`) claiming in a
+  comment that it "matches the tire in the model header." It did not: the model's actual
+  `wheel_geom` radius (`sim/models/overboard_onewheel.xml`, Mechanical's turf, not edited) is
+  `0.1454` m, the mesh-derived, enclosure-clearance figure that file's own header documents. A
+  *loaded* rolling radius bigger than the tire's own unloaded geometric radius is not physically
+  sensible regardless of provenance — compression under load only ever shrinks it — so this was
+  a stale figure (an 11.5" OD / 2 nominal-spec guess) that predated the mesh integration and was
+  never checked against the model everything else in this repo is measured against.
+  Consolidated to one constant (`rust_controller.DEFAULT_R_EFF_M`), imported everywhere instead
+  of re-declared, and added `tests/test_r_eff_matches_model.py`, which reads the *compiled*
+  model's `wheel_geom` size directly rather than re-asserting a literal, so this cannot silently
+  drift again. Full suite re-run clean (205 passed, 2 xfailed, no regressions; no pinned
+  threshold moved — the shift is 0.45%, inside every existing tolerance).
+  **Deliberately left out, flagged rather than fixed:** the same `0.14605` literal also appears,
+  independently, four times in `crates/` (`sim-backend`, `control-ffi` ×2, `canary-ridden`,
+  `board-app-ridden`) as FFI-boundary defaults — real hardware/ridden-mode code, not sim
+  scenarios, and touching it needs its own increment and a decision on which crate should own a
+  shared constant (this PR does not invent one). Not part of issue #24's AC3, which is scoped to
+  the sim scenarios; reported separately in the PR as an out-of-scope finding.
+  **Could not verify:** what the BoardIo ICD §10.5 entry for `r_eff_m` actually specifies — that
+  document lives in Notion, which this session has no access to. This fix only pins internal
+  consistency against the sim model; it does not claim to have confirmed or superseded whatever
+  Stage-0's eventual bench measurement will produce.
+  AC5 (measured-vs-assumed audit of every scenario-doc acceptance number) remains open, its own
+  increment.
+
 - **Issue #32, Stage-0B Pi image design (`docs/design-pi-image-stage0b.md`).** Design only, no
   implementation. Repo boundary: a `pi/` directory **in this repo**, argued on the *runtime
   contract* (kernel flavour, `isolcpus` layout, RT priority budget, CAN naming/bitrate, systemd

--- a/scripts/analyse_estimator.py
+++ b/scripts/analyse_estimator.py
@@ -26,7 +26,7 @@ import mujoco  # noqa: E402
 from sim.scenarios.imperfections import STAGE0_PLACEHOLDER, ImperfectionState  # noqa: E402
 from sim.scenarios.impulse_response import frame_pitch_rad  # noqa: E402
 from sim.scenarios.plant import build_model, imu_readings  # noqa: E402
-from sim.scenarios.rust_controller import RustController  # noqa: E402
+from sim.scenarios.rust_controller import DEFAULT_R_EFF_M, RustController  # noqa: E402
 from sim.scenarios.shuttle_run import ShuttleParams, VelocityProfile  # noqa: E402
 
 INK, AMBER, MINT, MUTED = "#16232E", "#F2A24A", "#2AAE97", "#96A8B0"
@@ -90,7 +90,7 @@ def collect(kind: str) -> dict:
             t.append(float(data.time))
             th.append(frame_pitch_rad(model, data))
             ax.append(a[0]); az.append(a[2]); gy.append(g[1])
-            v.append(float(data.qvel[6]) * 0.14605)
+            v.append(float(data.qvel[6]) * DEFAULT_R_EFF_M)
     return {k: np.asarray(x) for k, x in
             dict(t=t, truth=th, ax=ax, az=az, gyro=gy, v=v, dt=dt).items()}
 

--- a/scripts/analyse_estimator_phase.py
+++ b/scripts/analyse_estimator_phase.py
@@ -58,7 +58,7 @@ from sim.scenarios.impulse_response import (  # noqa: E402
     nose_strike_angle_deg,
 )
 from sim.scenarios.plant import KT_NM_PER_A, build_model, imu_readings  # noqa: E402
-from sim.scenarios.rust_controller import RustController  # noqa: E402
+from sim.scenarios.rust_controller import DEFAULT_R_EFF_M, RustController  # noqa: E402
 from sim.scenarios.shuttle_run import ShuttleParams, VelocityProfile  # noqa: E402
 
 INK, AMBER, MINT, MUTED, RED = "#16232E", "#F2A24A", "#2AAE97", "#96A8B0", "#C2513B"
@@ -157,7 +157,7 @@ def simulate(
     disturb_fn=None,
     lag_tau_s: float = 0.0,
     bias_rad: float = 0.0,
-    r_eff_m: float = 0.14605,
+    r_eff_m: float = DEFAULT_R_EFF_M,
     est_tau_s: float = 1.0,
     aiding: str = "wheel",
 ) -> Run:
@@ -268,7 +268,7 @@ def validate_replica() -> dict:
     imp = ImperfectionState(profile=STAGE0_PLACEHOLDER, dt_s=dt)
     est = PyComplementary(1.0)
     wheel_accel = PyWheelAccel(0.05)
-    r_eff = 0.14605
+    r_eff = DEFAULT_R_EFF_M
     rust, mine = [], []
 
     prof = VelocityProfile(ShuttleParams())

--- a/sim/scenarios/hill.py
+++ b/sim/scenarios/hill.py
@@ -75,9 +75,7 @@ from .impulse_response import (
     nose_strike_angle_deg,
 )
 from .plant import MODEL_PATH, build_model, imu_readings, plant_summary
-
-#: Effective rolling radius, m. Matches the tire in the model header.
-R_EFF_M = 0.14605
+from .rust_controller import DEFAULT_R_EFF_M as R_EFF_M
 
 G = 9.81
 

--- a/sim/scenarios/rust_controller.py
+++ b/sim/scenarios/rust_controller.py
@@ -39,8 +39,18 @@ DEFAULT_KD_A_PER_RAD_S = 11.0
 #: Envelope clamp, amps. Matches the model's derived ctrlrange (40 A * kt).
 DEFAULT_MAX_CURRENT_A = 40.0
 
-#: Loaded rolling radius, m (ICD 10.5). Stage-0 will measure it.
-DEFAULT_R_EFF_M = 0.14605
+#: Loaded rolling radius, m (ICD 10.5). Stage-0 will measure the real, loaded
+#: figure; until then this is pinned to the sim model's actual tire geometry
+#: (`wheel_geom` in `sim/models/overboard_onewheel.xml`, 145.4 mm -- the
+#: mesh-derived enclosure-clearance radius documented in that file's header),
+#: not an independent nominal-tire-spec guess. It previously read 0.14605 m
+#: (an 11.5" OD / 2 figure) -- LARGER than the model's own unloaded tire
+#: radius, which cannot be right for a *loaded* rolling radius (compression
+#: under load only ever shrinks it) and was never actually checked against
+#: the model that every other closed-loop metric is measured against. See
+#: `tests/test_r_eff_matches_model.py`, which reads the compiled model
+#: directly so this cannot silently drift again.
+DEFAULT_R_EFF_M = 0.1454
 
 #: Outer-loop clamp: the most lean it may ask the inner loop to hold.
 DEFAULT_MAX_PITCH_REF_RAD = 0.087   # 5 degrees

--- a/sim/scenarios/shuttle_run.py
+++ b/sim/scenarios/shuttle_run.py
@@ -42,6 +42,7 @@ import numpy as np
 from .imperfections import STAGE0_PLACEHOLDER, ImperfectionProfile, ImperfectionState
 from .impulse_response import KT_NM_PER_A, frame_pitch_rad
 from .plant import MODEL_PATH, build_model, imu_readings, plant_summary
+from .rust_controller import DEFAULT_R_EFF_M as R_EFF_M
 
 #: Cruise speed for every leg, m/s. Modest on purpose: the outer loop's pitch
 #: reference is clamped at 5 deg, which caps acceleration at about
@@ -372,7 +373,7 @@ def run(
 
             commanded_pos += vprofile.v_ref(t) * dt
             fwd = float(-(data.xpos[frame][0] - x0))
-            v = float(data.qvel[6]) * 0.14605
+            v = float(data.qvel[6]) * R_EFF_M
 
             ts.append(float(data.time))
             pos.append(fwd)

--- a/sim/scenarios/terrain.py
+++ b/sim/scenarios/terrain.py
@@ -74,8 +74,7 @@ from .plant import (
     plant_summary,
     rider_geoms,
 )
-
-R_EFF_M = 0.14605
+from .rust_controller import DEFAULT_R_EFF_M as R_EFF_M
 
 #: Samples along the ride. 512 over a ~30 m ride is ~6 cm between samples --
 #: fine enough that the wheel never sees a facet, coarse enough to compile fast.

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -29,7 +29,7 @@ from sim.scenarios.impulse_response import (
     load_model,
     run,
 )
-from sim.scenarios.rust_controller import RustController, library_path
+from sim.scenarios.rust_controller import DEFAULT_R_EFF_M, RustController, library_path
 
 
 @pytest.fixture(scope="module")
@@ -212,7 +212,7 @@ def test_a_speed_setpoint_is_tracked(ridden_model):
     r, _ = _run(ridden_model, secs=14.0, **INNER, **dict(OUTER, v_ref_m_s=1.0))
     import numpy as np
 
-    v = np.asarray(r.wheel_rate_rads) * 0.14605
+    v = np.asarray(r.wheel_rate_rads) * DEFAULT_R_EFF_M
     settled = v[r.t >= r.t[-1] - 2.0]
     assert not r.metrics.nose_strike
     assert abs(float(settled.mean()) - 1.0) < 0.25, f"settled at {settled.mean():.2f} m/s"

--- a/tests/test_r_eff_matches_model.py
+++ b/tests/test_r_eff_matches_model.py
@@ -1,0 +1,48 @@
+"""Guard: every scenario's rolling-radius constant must match the sim model.
+
+Issue #24 (O1) AC3 flagged that `R_EFF_M`/`DEFAULT_R_EFF_M` (used to convert
+`wheel_hinge` angular rate to a forward speed, and current to force, across
+`hill.py`/`terrain.py`/`shuttle_run.py`/`rust_controller.py`) was hand-copied
+as `0.14605` m in half a dozen places, one of them (`hill.py`) claiming in a
+comment that it "matches the tire in the model header" -- it did not. The
+model's actual `wheel_geom` radius is 0.1454 m (the mesh-derived,
+enclosure-clearance figure `sim/models/overboard_onewheel.xml`'s own header
+documents), and a *loaded* rolling radius larger than the tire's own unloaded
+geometric radius is not physically sensible regardless of provenance.
+
+This does not re-litigate what the real, bench-measured loaded rolling radius
+should eventually be (Stage-0's job, ICD 10.5) -- it only pins the sim-side
+placeholder to be internally consistent with the one model every closed-loop
+metric in this repo is actually measured against, and fails loudly the next
+time either side drifts.
+"""
+
+from __future__ import annotations
+
+from sim.scenarios.hill import R_EFF_M as HILL_R_EFF_M
+from sim.scenarios.plant import build_model
+from sim.scenarios.rust_controller import DEFAULT_R_EFF_M
+from sim.scenarios.shuttle_run import R_EFF_M as SHUTTLE_R_EFF_M
+from sim.scenarios.terrain import R_EFF_M as TERRAIN_R_EFF_M
+
+
+def _model_wheel_radius_m() -> float:
+    """Read the tire radius the physics actually simulates, not a copy of it."""
+    model = build_model(ballast_mass=0.0, ballast_height=0.0, clamp_a=None)
+    return float(model.geom("wheel_geom").size[0])
+
+
+def test_model_wheel_radius_is_the_documented_145_4mm():
+    """Regression pin on the number every constant below is checked against."""
+    assert _model_wheel_radius_m() == 0.1454
+
+
+def test_default_r_eff_m_matches_the_compiled_model():
+    assert DEFAULT_R_EFF_M == _model_wheel_radius_m()
+
+
+def test_every_scenario_shares_the_one_r_eff_m_constant():
+    """No module may hand-copy its own value -- one constant, imported everywhere."""
+    assert HILL_R_EFF_M == DEFAULT_R_EFF_M
+    assert TERRAIN_R_EFF_M == DEFAULT_R_EFF_M
+    assert SHUTTLE_R_EFF_M == DEFAULT_R_EFF_M


### PR DESCRIPTION
## What changed and why

Issue #24 (AC3): *"Tyre–ground contact interrogated. `r_eff` currently derives from an enclosure
clearance gap — a tyre of that radius would have zero clearance. Either justify it or fix it."*

`R_EFF_M`/`DEFAULT_R_EFF_M` — used to convert `wheel_hinge` angular rate to forward speed, and
current to force — was hand-copied as **`0.14605` m** in six places: `sim/scenarios/hill.py`,
`terrain.py`, `shuttle_run.py`, `rust_controller.py`, `tests/test_closed_loop.py`, and twice in
`scripts/analyse_estimator_phase.py`/`analyse_estimator.py`. `hill.py`'s copy carried a comment
claiming it *"matches the tire in the model header."* **It did not.**

The model's actual `wheel_geom` radius (`sim/models/overboard_onewheel.xml`, Mechanical's turf,
not touched here) is **0.1454 m** — the mesh-derived, enclosure-clearance figure that file's own
header documents (`the gap between the enclosures is 290.8 mm, i.e. a 145.4 mm tire radius`).
`0.14605` m is **larger** than that, which cannot be justified as a *loaded* rolling radius
(ICD 10.5) — compression under load only ever shrinks the effective radius relative to the
unloaded/nominal one, never grows it. It reads as a stale `11.5" OD / 2` nominal-spec figure that
predated the mesh integration (`de8dd19`) and was never reconciled against it.

Could not be justified, so fixed:

- `sim/scenarios/rust_controller.py` — `DEFAULT_R_EFF_M` corrected to `0.1454`, comment rewritten
  to state the provenance and the correction, rather than re-asserting an unverified match.
- `sim/scenarios/hill.py`, `terrain.py`, `shuttle_run.py` — no longer each declare their own copy
  of the literal; all now `import DEFAULT_R_EFF_M as R_EFF_M` from `rust_controller`, so there is
  exactly one number in the codebase instead of six independently-drifting copies.
- `tests/test_closed_loop.py`, `scripts/analyse_estimator.py`, `scripts/analyse_estimator_phase.py`
  — same: import and use the one constant instead of a local literal.
- `tests/test_r_eff_matches_model.py` (new) — reads the **compiled** model's `wheel_geom.size[0]`
  directly (not a re-stated literal) and asserts every scenario constant equals it, so this
  specific defect — a comment asserting a match that was never checked — cannot recur silently.
- `roles/senior-controls/CONTEXT.md` — decision log entry.

## Measured, not assumed

Re-ran the full suite after the change: **205 passed, 2 xfailed**, no regressions, and **no
pinned regression threshold moved** — the shift is 0.45% (145.4 vs 146.05 mm), well inside every
existing tolerance (e.g. the 0.25 m/s band in `test_a_speed_setpoint_is_tracked`).

## Acceptance criteria (issue #24, AC3 only)

- [x] `r_eff` either justified or fixed: **could not be justified** (physically backwards for a
      loaded radius, and the comment asserting a match was simply false) — **fixed**, and pinned
      against the compiled model so it can't drift back unnoticed.

Issue #24 has other ACs already landed in separate PRs (AC1 estimator-in-the-loop, AC2 envelope
via #67, AC4 determinism audit via #74) and one still open (AC5, measured-vs-assumed audit of
scenario-doc acceptance numbers) — its own increment, not attempted here. Not closing #24.

## What I deliberately left out

- **`crates/` FFI-boundary defaults.** The same `0.14605` literal independently appears four more
  times — `crates/sim-backend/src/lib.rs`, `crates/control-ffi/src/lib.rs` (×2),
  `crates/canary-ridden/src/main.rs`, `crates/board-app-ridden/src/main.rs` — as hardware/ridden-mode
  default parameters. That's a real instance of the same defect, but it's FFI-boundary code
  touching ridden-mode actuation defaults, not a sim scenario, and it deserves its own increment
  and a decision on where a shared Rust constant should live (this PR does not invent one).
  **Flagging this as an out-of-scope finding**, not fixing it here.
- **AC5** (measured-vs-assumed audit of every scenario-doc acceptance number) — its own increment.
- Did not touch `sim/models/overboard_onewheel.xml` or `sim/scenarios/plant.py` — Mechanical's
  fidelity contract, read to confirm the actual radius, not edited.

## Could not verify

What BoardIo ICD §10.5 actually specifies for `r_eff_m` — that document lives in Notion, which
this session has no access to. This fix pins internal consistency against the sim model everything
else is measured against; it does not claim to have confirmed or pre-empted Stage-0's eventual
bench measurement of the real, loaded rolling radius.

## Turf

`sim/scenarios/{hill,terrain,shuttle_run,rust_controller}.py`, `tests/`, `scripts/`,
`roles/senior-controls/` — all mine per `python3 .github/policy_check.py --who` for each touched
path.

## Verification

- `.venv/bin/python3 -m pytest tests/` → 205 passed, 2 xfailed (after `cargo build --release -p control-ffi`)
- `cargo build --workspace --all-targets` ✅ (no Rust changed)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `python3 .github/policy_check.py` ✅ all hard checks pass

Closes: none (partial AC on issue #24, see above)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JPMk9rNBeZfzFhA2YJZPYk)_