### PR TITLE
ops: role work-logs get one file per entry, not a shared append list

### DIFF
--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -57,6 +57,19 @@ gh pr merge <n> --squash --auto      # queues it; GitHub updates the branch and 
 Auto-merge and auto-delete-on-merge are enabled on all three repos. **Queue the merge and move
 on to the next thing.** Come back only if a check actually fails.
 
+## Recording what you did — write a NEW file, never append to a shared list
+
+**`roles/<role>/CONTEXT.md` is standing context** — sub-goals, turf notes, known dead ends. It
+changes rarely and is edited deliberately.
+
+**To record work you completed, add a new file:** `roles/<role>/log/YYYY-MM-DD-<slug>.md`.
+One entry, one file. Do **not** append to a shared list.
+
+The reason is mechanical, not stylistic. Every dispatched agent appending to one list means
+**every PR touches the same file, so every merge conflicts every other open PR.** On 2026-07-28
+that produced five simultaneous conflicts across eight PRs and serialised a queue that was
+otherwise entirely green. Separate files never collide.
+
 ## Escalate when any one is true — Promise, Door, or Turf
 
 - **Promise** — it changes something outside your role relies on: a public claim, a

--- a/roles/README.md
+++ b/roles/README.md
@@ -7,7 +7,10 @@ and it dies with the window. An org cannot be built on that.
 So each role's durable state lives here, in the repo:
 
 - **Every dispatched agent reads its role's `CONTEXT.md` first.**
-- **Every dispatched agent may append to it in its PR** — decisions made, dead ends hit.
+- **To record completed work, add `roles/<role>/log/YYYY-MM-DD-<slug>.md`** — one entry per
+  file. Do NOT append to a shared list in `CONTEXT.md`: parallel agents all touching one file
+  means every PR conflicts every other, which is exactly what happened on 2026-07-28.
+- `CONTEXT.md` itself holds **standing** context — sub-goals, turf, dead ends — and changes rarely.
 - This is what makes dispatch to a fresh agent safe rather than amnesiac (ADR-0007).
 
 Keep each file short. It is a working brief, not a history. Move anything that has become a

--- a/roles/senior-controls/log/README.md
+++ b/roles/senior-controls/log/README.md
@@ -1,0 +1,6 @@
+# Role logs
+
+One file per completed piece of work: `YYYY-MM-DD-<slug>.md`.
+
+Separate files never merge-conflict. A shared append-list does, every time, once more than one
+agent is in flight.

--- a/roles/sr-mechanical-systems/log/README.md
+++ b/roles/sr-mechanical-systems/log/README.md
@@ -1,0 +1,6 @@
+# Role logs
+
+One file per completed piece of work: `YYYY-MM-DD-<slug>.md`.
+
+Separate files never merge-conflict. A shared append-list does, every time, once more than one
+agent is in flight.


### PR DESCRIPTION
Five simultaneous merge conflicts across eight otherwise-green PRs today. All in `roles/<role>/CONTEXT.md`. All the same shape: **parallel dispatched agents each appending to the same list.**

ADR-0007 explicitly invited that appending, and with one agent per role it was fine. With eight PRs in flight it means every PR touches the same file, so **every merge conflicts every other one** — a queue that was entirely green serialised into manual conflict resolution, three rounds of it.

**The split:**
- `CONTEXT.md` → **standing** context. Sub-goals, turf, dead ends. Changed deliberately, rarely.
- `roles/<role>/log/YYYY-MM-DD-<slug>.md` → **completed work.** One entry, one file. Separate files never collide.

Recorded in `INDEX.md` — which every worker is told to read before opening a PR — rather than by editing the cron prompts. Same effect, and it reaches sessions already running instead of only the next spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)