### PR TITLE
ops: the policy gate's diff-based checks had never once run in CI

### DIFF
--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -73,6 +73,28 @@ def git(*args: str) -> str:
     ).stdout.strip()
 
 
+IN_CI = bool(os.environ.get("GITHUB_ACTIONS"))
+
+
+def cannot_resolve(check: str, what: str) -> None:
+    """A diff-based check could not find its base.
+
+    Locally this is normal and skipping is right. **In CI it is the gate
+    failing open**, which is strictly worse than having no gate: `turf` and
+    `doc-drift` both skipped themselves on every PR for as long as they had
+    existed -- depth-1 checkout, no merge-base -- while the run still printed
+    "all hard checks pass". A skip that reports green is a lie the whole org
+    then builds on, so in CI it is a hard failure.
+    """
+    if IN_CI:
+        fail(check, f"cannot resolve {what} IN CI -- this check would have "
+                    f"silently skipped and the gate would have reported green. "
+                    f"Check the workflow's fetch-depth and POLICY_BRANCH/"
+                    f"POLICY_BASE_REF wiring")
+    else:
+        print(f"{check}: cannot resolve {what} -- skipping (local run)")
+
+
 # ---------------------------------------------------------------------------
 # The role registry -- docs/decisions/ROLES.md is the single home.
 # ---------------------------------------------------------------------------
@@ -226,12 +248,17 @@ def check_turf(roles: dict, rules: list) -> None:
     prefixes = {m["prefix"]: r for r, m in roles.items() if m["prefix"]}
     role = next((r for p, r in prefixes.items() if branch.startswith(p)), None)
     if role is None:
-        print(f"turf: branch {branch!r} matches no registered branch prefix -- skipping")
+        # "HEAD" means the workflow did not pass POLICY_BRANCH and we are on a
+        # detached checkout -- that is the wiring bug, not an unregistered role.
+        if branch == "HEAD":
+            cannot_resolve("turf", "the branch name (got the literal 'HEAD')")
+        else:
+            print(f"turf: branch {branch!r} matches no registered branch prefix -- skipping")
         return
 
     merge_base = git("merge-base", base, "HEAD")
     if not merge_base:
-        print(f"turf: cannot resolve {base} -- skipping")
+        cannot_resolve("turf", f"base {base!r}")
         return
     changed = [p for p in git("diff", "--name-only", f"{merge_base}...HEAD").split() if p]
     if not changed:
@@ -293,7 +320,7 @@ def check_doc_drift() -> None:
     base = os.environ.get("POLICY_BASE_REF", "origin/master")
     merge_base = git("merge-base", base, "HEAD")
     if not merge_base:
-        print("doc-drift: cannot resolve base -- skipping")
+        cannot_resolve("doc-drift", f"base {base!r}")
         return
     changed = set(p for p in git("diff", "--name-only", f"{merge_base}...HEAD").split() if p)
     if not changed:

--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -418,7 +418,13 @@ def check_claims() -> None:
 
 def who(path: str) -> int:
     roles, rules = load_roles(), load_codeowners()
-    hit = owner_of(path.lstrip("./"), rules)
+    # removeprefix, not lstrip: lstrip takes a SET of characters, so
+    # ".github/workflows/ci.yml".lstrip("./") returned "github/workflows/ci.yml",
+    # which matches no specific rule and fell through to the '*' catch-all. Every
+    # path under .github/ -- CODEOWNERS and this file included -- reported the
+    # wrong owner, from the one command CLAUDE.md tells roles to trust to answer
+    # "am I trespassing?". The turf check never used this path and was correct.
+    hit = owner_of(path.removeprefix("./"), rules)
     if hit is None:
         print(f"{path}: no rule matches (this should be impossible -- '*' is a catch-all)")
         return 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # fetch-depth: 0 is load-bearing, not hygiene. The default depth-1
+      # checkout has no origin/master and no merge-base, so every diff-based
+      # check (turf, doc-drift) resolved no base and SKIPPED ITSELF while the
+      # gate still printed "all hard checks pass". Both had never once run in
+      # CI. See POLICY_BRANCH below for the second half of the same bug.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -171,6 +178,16 @@ jobs:
       # status: `tee` succeeds even when the check does not, and a policy gate
       # that reports green because its logger worked would be worse than none.
       - name: Policy gate
+        env:
+          # `actions/checkout` leaves a detached HEAD, so the script's own
+          # `rev-parse --abbrev-ref HEAD` returned the literal string "HEAD",
+          # which matches no registered branch prefix -- so the turf check
+          # skipped on every PR. Pass the real branch name in.
+          POLICY_BRANCH: ${{ github.head_ref || github.ref_name }}
+          POLICY_BASE_REF: origin/${{ github.base_ref || github.event.repository.default_branch }}
+          # POLICY_PR_BODY is deliberately NOT set. Overrides must live in a
+          # commit message so the reason is in git history rather than in a
+          # field anyone can edit after the gate went green.
         run: |
           { echo '### Policy gate'; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
           set +e


### PR DESCRIPTION
## What was wrong

`turf` and `doc-drift` are **hard** checks in the policy gate. Both silently skipped themselves on every pull request, while the gate went on printing `all hard checks pass`.

Evidence, from the last green `policy` run on a feature branch ([30370173699](https://github.com/MikePaNtZ/overboard/actions/runs/30370173699)):

```
turf: branch 'HEAD' matches no registered branch prefix -- skipping
doc-drift: cannot resolve base -- skipping
policy: all hard checks pass (8 roles, 38 ownership rules)
```

Two independent causes, both in the workflow rather than in the checks:

1. `actions/checkout@v4` defaults to a **depth-1** fetch, so there is no `origin/master` and no merge-base. Both checks look for a base, find none, and return.
2. checkout leaves a **detached HEAD**, so the script's own `rev-parse --abbrev-ref HEAD` returned the literal string `"HEAD"`, which matches no registered branch prefix — so turf skipped a second, independent way.

**ADR-0008's doc-drift gate was ratified on 2026-07-28 and has never run.** The turf check from ADR-0002 has never run either. `policy` is not yet a required check, but its green light is already load-bearing: it is what the org has been reading to mean "nobody trespassed and no doc drifted."

## What this changes

**The wiring.** `fetch-depth: 0`, plus `POLICY_BRANCH`/`POLICY_BASE_REF` passed from the event. `render-needed` in this same workflow already uses `fetch-depth: 0` for the same reason.

**The more important half: a diff-based check that cannot resolve its base is now a hard failure in CI, not a skip.** Failing open is defensible locally, where there may genuinely be no base. In CI it means the gate reports green having enforced nothing — worse than having no gate, because everyone downstream trusts it. This is the bug class, not just this instance: the next check wired up wrong now fails loudly instead of joining the silent-skip club.

`POLICY_PR_BODY` stays deliberately unset, so an override lives in a commit message and therefore in git history, not in a field that can be edited after the gate went green.

## A second bug, found by the first

`--who` reported the **wrong owner for every path under `.github/`**:

```python
'.github/workflows/ci.yml'.lstrip('./')  ->  'github/workflows/ci.yml'
```

`lstrip` takes a *set of characters*, not a prefix. The stripped path matches no specific rule, so it fell through to the `*` catch-all and answered `CEO`. The correct owner is Senior Controls via CODEOWNERS:84.

This matters more than a normal off-by-one: **CLAUDE.md tells every role to run exactly this command to answer "am I trespassing?"**, and the paths it got wrong are the ownership-sensitive ones — CODEOWNERS itself, the workflows, this script. `check_turf` never used this code path, which is why the two disagreed; that disagreement is how I found it.

## Verification

Ran under simulated CI (`GITHUB_ACTIONS=1` + the new env) at each step:

| Case | Result |
|---|---|
| Branch with the wiring fixed | turf and doc-drift **both fire** — first time either has |
| `--who` on `.github/` paths | now agrees with `check_turf` |
| `--who` on a non-dot path | unchanged |
| Missing base in CI | hard failure |
| Missing base locally | still skips, labelled `(local run)` |

The two findings on this PR's own diff are both real and both logged as overrides in commit messages rather than papered over:

- **turf** — `ci.yml` is Senior Controls' by CODEOWNERS:84. The only hunk here is the `policy:` job, which is COO's by ADR-0003. Flagged rather than fixed by re-carving: **a whole-file rule for a workflow containing jobs owned by two different roles will keep producing this**, and re-drawing CODEOWNERS to authorise my own edit would be self-dealing without a row. Follow-up below.
- **doc-drift** — `docs/web-artifact-pipeline.md` covers `ci.yml`. It describes the deferred Phase C render/publish pipeline; nothing here touches those jobs, so there is no drift and the manifest is deliberately **not** re-stamped.

## Deliberately not in this PR

- **Making `policy` a required status check.** Its own comment says it must pass green once first, and that condition is now honestly rather than falsely met — but requiring it in the same PR that changes what it enforces is how you wedge the queue. Wants one green cycle on real PRs first.
- **The `roles/*/CONTEXT.md` append rule.** Written and tested, held back on purpose: it would red-build #76, which is stalled *right now* on exactly the conflict that rule prevents. It lands once #76 is merged.
- **Re-carving `ci.yml`'s ownership.** Needs a row, not a unilateral edit by the role it would benefit.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>