### PR TITLE
fix(ops): a hardcoded metric is not a measurement — Hardware ordered is NOT MEASURED

### DIFF
--- a/ops/metrics.py
+++ b/ops/metrics.py
@@ -51,10 +51,15 @@ def main() -> None:
         print("    EMPTY -- this is a reportable condition, not a quiet state.")
 
     print("\nROADMAP  (the numbers that actually matter)")
+    # No exceptions here on purpose. 'Hardware ordered ($)' used to print a
+    # hardcoded '0 (nothing ordered to date)'. Purchasing then happened -- $977
+    # across 10 orders, reported by the COO on the 2026-07-28 board -- and the
+    # literal kept printing 0, because it was never computed from anything.
+    # A hardcoded figure ages into a lie the moment the world moves; a
+    # NOT MEASURED never does. This script's own docstring already says so.
     for label in ("BoMs published", "Hardware ordered ($)", "Hardware delivered",
                   "Assembly videos", "Public posts published", "Impressions / engagement"):
-        print(f"  {label:<27}NOT MEASURED" if label != "Hardware ordered ($)"
-              else f"  {label:<27}0  (nothing ordered to date)")
+        print(f"  {label:<27}NOT MEASURED")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

`ops/metrics.py` printed `Hardware ordered ($)  0  (nothing ordered to date)` as a **string literal**. It was never computed from anything. Purchasing has since happened — **$977 across 10 orders**, per the COO's own 2026-07-28 board section — and the script kept printing `0`.

One special case removed. Every roadmap row now prints `NOT MEASURED`, which is what the script's own docstring already promised:

> Rule: anything not computable prints NOT MEASURED. An estimate presented as a measurement is the one thing a company whose public brand is "honest in progress" cannot do internally either.

## Why it matters more than a wrong number usually would

The Archivist is now required to **pre-fill the daily board's metric rows from this script** — per the [Session start & teardown prompts](https://app.notion.com/p/3ab472a5fb69819984f9c1bd44be9dea) and the COO's 2026-07-28 endorsement of the board frame. An unfixed hardcode publishes a false figure to the board **every day**, carrying the authority of "script-backed".

Today's board ([2026-07-29](https://app.notion.com/p/3ad472a5fb6981e49dc7ca6151b95fbc)) carries the row **flagged rather than propagated**, so no false number reached it in the meantime.

## Turf

`ops/` is COO turf; `TURF-OVERRIDE` is in the commit message with the reason, so it lands in git history rather than an editable field. **Review requested from the COO.**

You may prefer to wire this row to the purchase sheet instead — that is a strictly better fix and this change does not block it. `NOT MEASURED` is the honest floor, not the destination.

## Acceptance criteria touched

None move. This restores an invariant the script already claimed to hold.