### PR TITLE
docs(archive): record the first board-frame run and what it caught

### DIFF
--- a/roles/archivist/CONTEXT.md
+++ b/roles/archivist/CONTEXT.md
@@ -3,7 +3,8 @@
 - **Worktree:** `~/projects/overboard-archivist` (ADR-0006: one worktree per role)
 - **Branch prefix:** `feat/archive/`
 - **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md) — **Ratified 2026-07-27**
-- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md), then
+  [ADR-0008](../../docs/decisions/ADR-0008-documentation-drift.md) — it defines this surface
 
 ## Surface
 
@@ -15,6 +16,25 @@ Declared by the CEO 2026-07-27, ratified by the COO the same day.
 2. **Shared vocabulary across all three repos.** The canonical definition lives in
    [Shared Vocabulary](https://app.notion.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b).
 3. **Drift tooling.**
+4. **The daily board frame** — CEO, 2026-07-28. See below.
+
+In one line: *this role owns whether the record is true, current and consistent — not whether
+the strategy is right.*
+
+## The board frame — standing duty, every board
+
+**Create the next dated doc at the close of each board**, under
+[Board level management](https://app.notion.com/p/c1ce234db5c2412382794af2e2cd3411), and repoint
+its *Active board meeting* link — roles publish wherever that points. Never batch-create a week
+ahead; batch docs go stale and invite the re-pasting the cadence exists to stop. Shape to copy:
+[Board — 2026-07-29](https://app.notion.com/p/3ad472a5fb6981e49dc7ca6151b95fbc).
+
+**You own the frame, each role owns its content** — preamble, carried-forward ledger, CEO-asks
+table, stubbed sections, script-backed metric rows. Never write in another role's section.
+
+Two habits are the whole value: **re-derive every carried row from current state** (7 of 11 were
+already resolved on the first run), and **read the previous board's comments first** — the CEO
+answers inline and a Notion comment is a *poll, not a push*; six answers had reached no role.
 
 ## Turf
 
@@ -25,17 +45,47 @@ land as **small PRs with review requested from whoever owns the file**, which is
 
 The **policy gate itself** (`.github/policy_check.py`) stays with the COO. Division: this role
 owns the *data* — the retired-to-current term map — and the COO owns the *gate* that consumes
-it. When `docs/vocabulary/` holds a machine-readable mapping, the COO wires a `vocab` check into
-the policy job.
+it. `retired-terms.json` has been populated since 2026-07-27; **the `vocab` check that consumes
+it is still unwritten, and it is the COO's to write.**
+
+## In flight
+
+- **[#85](https://github.com/MikePaNtZ/overboard/issues/85) — `reconciled:` never advances.**
+  Five of eight manifests carry a stamp older than the doc's own last edit. Nothing is escaping
+  (the gate compares against code, not the stamp), so no urgency — but it is a field that looks
+  checkable and is not. Four options in the issue; the gate half is the COO's.
+  **Default if unanswered by the 2026-08-05 board: implement report-only.**
+- **`overboard-web#14` is still live** and only the CEO can clear it. Deleting the issue is the
+  only fix; carried two boards. Re-verify each sweep rather than assuming.
+
+## Known dead ends
+
+- **`python3 .github/policy_check.py` on a branch does not run the checks that fail you.**
+  `turf`, `doc-drift` and `role-log` are diff-based and skip silently outside CI, so a local
+  "all hard checks pass" means almost nothing. This is how PR #90 shipped red into the COO's
+  inbox, where review latency is their worst number. Always verify with:
+  `GITHUB_ACTIONS=1 POLICY_BRANCH=<branch> POLICY_BASE_REF=origin/master python3 .github/policy_check.py`
+
+- **Notion cannot be reached from CI**, and no scheduled cloud run has the connector. Any
+  vocabulary enforcement must therefore read a term list from **git**, not from Notion. That
+  constraint is why `docs/vocabulary/` exists at all.
+- **Renaming or editing anything on GitHub does not un-publish it.** The timeline serves the
+  original issue title, and body edits keep their history. Only deletion works, and deletion is
+  the CEO's.
+- **The incident report is part of the public surface.** `sweep_public.py` flags this role's own
+  [PR #80](https://github.com/MikePaNtZ/overboard/pull/80) because its description quotes the
+  leaked title verbatim while explaining the leak. Learned the expensive way: **quote leaked
+  strings by reference, never verbatim, in anything public** — including the write-up about the
+  leak.
+- **A hardcoded literal in a metrics script is drift with better manners.** `ops/metrics.py`
+  printed `0 (nothing ordered to date)` long after $977 had been spent. When pre-filling the
+  board, the standing question is *which of these numbers would still print if the world had
+  moved?*
 
 ## Decisions made (edit in place — completed work goes in log/, not here)
 
 - **2026-07-27 — ratified, Option A plus `docs/vocabulary/`.** The COO granted the term-list
   directory but not `docs/decisions/INDEX.md`: ratification is the COO's to close under
   ADR-0001, and splitting that authority would defeat the record.
-
-## Known dead ends
-
-- **Notion cannot be reached from CI**, and no scheduled cloud run has the connector. Any
-  vocabulary enforcement must therefore read a term list from **git**, not from Notion. That
-  constraint is why `docs/vocabulary/` exists at all.
+- **2026-07-29 — one dated doc per board, created at the close of the previous one.** Stated as
+  a default, unopposed, endorsed by the COO. Recorded as *went unopposed*, not *agreed*.

--- a/roles/archivist/log/2026-07-29-board-frame-first-dated-doc.md
+++ b/roles/archivist/log/2026-07-29-board-frame-first-dated-doc.md
@@ -1,0 +1,51 @@
+# 2026-07-29 — First dated board doc; two false-metric findings
+
+**Board:** [🗓️ Board — 2026-07-29](https://app.notion.com/p/3ad472a5fb6981e49dc7ca6151b95fbc)
+
+## What shipped
+
+**The board-frame duty ran for the first time.** Created the dated doc, stubbed all three
+role sections on the five standard headings, pre-filled every script-backed metric row from
+`ops/metrics.py` and `ops/usage.py`, and carried forward last board's items **re-derived
+rather than re-pasted**. Marked the running page frozen and repointed *Board level
+management* at the dated doc, so a role that follows the teardown prompt cannot publish into
+the wrong place.
+
+The carry-forward pass is the part that paid. Of eleven items carried from 2026-07-28,
+**seven were already resolved** — six by CEO comments left between 05:16 and 05:38 that
+morning, which no role had seen. Re-pasting them would have spent CEO decision slots on
+settled questions for the fourth consecutive board.
+
+**Surfaced ten unanswered CEO asks.** The CEO's replies live as inline Notion comments. A
+comment is a *poll, not a push*: it lands only if a role happens to re-open the page. They
+are now a table in the frame, each with an owning role.
+
+## Findings
+
+**① `ops/metrics.py` printed a false number, and I was required to publish it.**
+`Hardware ordered ($)  0  (nothing ordered to date)` was a string literal, never computed.
+Purchasing then happened — $977 across 10 orders — and the literal kept printing 0. Because
+the frame duty says *pre-fill metric rows from the script*, an unfixed hardcode publishes a
+false figure to the board every day under the authority of "script-backed".
+Fixed in [PR #84](https://github.com/MikePaNtZ/overboard/pull/84); flagged rather than
+propagated on today's board.
+
+**② `reconciled:` in the ADR-0008 manifests never advances.** Five of eight docs carry a
+stamp older than the doc's own last edit. Nothing is escaping today — `check_doc_drift()`
+compares against the code, not the stamp — but it is a field that *looks* checkable and is
+not. Filed as [#85](https://github.com/MikePaNtZ/overboard/issues/85) with four options; the
+gate half is the COO's.
+
+**③ The write-up about the leak re-published the leak.** `sweep_public.py` now reports two
+errors, not one. The second is my own [PR #80](https://github.com/MikePaNtZ/overboard/pull/80)
+description, which quotes the exposed `overboard-web#14` title verbatim while explaining that
+exposing it was the problem. Same phrase, same origin — nothing new is disclosed — but
+editing the body will not clear it either, because GitHub serves edit history. **The incident
+report is part of the public surface.** Quote leaked strings by reference from here on.
+
+## Note for whoever runs the next frame
+
+Both ① and ② are the same shape, and it is the shape this org keeps producing: **a value that
+carries the authority of having been checked, which nothing checks.** A hardcoded `0`, a
+`reconciled:` sha, a carried-forward decision row. Worth treating as a standing question at
+each frame pass — *which numbers on this board would still print if the world had moved?*


### PR DESCRIPTION
## What changed

The Archivist's board-frame duty ran for the first time today. This lands the durable half of it:

- **`roles/archivist/CONTEXT.md`** — the frame becomes a **standing duty** with its cadence, its frame/content boundary, and the two habits that made the pass worth anything. Edited, not appended: the surface list, in-flight items and dead ends were rewritten to current state.
- **`roles/archivist/log/2026-07-29-board-frame-first-dated-doc.md`** — one file, one entry, per ADR-0001.

Today's board: [🗓️ Board — 2026-07-29](https://app.notion.com/p/3ad472a5fb6981e49dc7ca6151b95fbc). The running page is marked frozen and *Board level management* now points at the dated doc, so a role following the teardown prompt cannot publish into the wrong place.

## Why the carry-forward pass earns its cost

Of **eleven** items carried from 2026-07-28, **seven were already resolved** — six of them by CEO comments left between 05:16 and 05:38 that morning which no role had seen. A Notion comment is a **poll, not a push**. Re-pasting them would have spent CEO decision slots on settled questions for the fourth consecutive board.

Ten unanswered CEO asks are now a table in the frame with an owning role against each.

## Two findings, recorded as dead ends so they are not relearned

**A hardcoded literal in a metrics script is drift with better manners.** `ops/metrics.py` printed `Hardware ordered ($)  0  (nothing ordered to date)` long after $977 had been spent — and the frame duty says to pre-fill board metrics *from that script*. Fixed separately in [#84](https://github.com/MikePaNtZ/overboard/pull/84); flagged rather than propagated on today's board.

**The incident report is part of the public surface.** `sweep_public.py` flags this role's own [#80](https://github.com/MikePaNtZ/overboard/pull/80), whose description quotes the leaked `overboard-web#14` title verbatim while explaining that publishing it was the problem. Nothing new is disclosed, and editing will not clear it — GitHub serves edit history. Quote leaked strings by reference from here on.

Also filed [#85](https://github.com/MikePaNtZ/overboard/issues/85) — the ADR-0008 `reconciled:` stamp never advances; five of eight manifests carry a sha older than the doc's own last edit.

## Acceptance criteria touched

None. Role-context and log files only; `policy` passes.