### PR TITLE
ops: enforce the role work-log convention instead of just documenting it

### DIFF
--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -50,8 +50,22 @@ CAPABILITY = re.compile(
     re.I,
 )
 
-TURF_OVERRIDE = re.compile(r"TURF-OVERRIDE:\s*(\S.*)")
-DOC_OK = re.compile(r"DOC-OK:\s*(\S.*)")
+# Anchored to the START OF A LINE, deliberately. Unanchored, a commit message
+# that merely QUOTES the token activates it: the commit introducing the role-log
+# check explained its own escape hatch in prose -- "'CONTEXT-OK: <reason>' in a
+# commit message is the escape hatch" -- and thereby overrode the check it was
+# adding. An override has to be a declaration, not a mention, so it must be the
+# first thing on its line.
+TURF_OVERRIDE = re.compile(r"^[ \t]*TURF-OVERRIDE:\s*(\S.*)", re.MULTILINE)
+DOC_OK = re.compile(r"^[ \t]*DOC-OK:\s*(\S.*)", re.MULTILINE)
+CONTEXT_OK = re.compile(r"^[ \t]*CONTEXT-OK:\s*(\S.*)", re.MULTILINE)
+
+# A work-log entry appended to the shared CONTEXT.md is what makes every open PR
+# conflict every other one. An edit to standing context replaces text; an
+# appended log entry only adds. So: growth past this many lines with nothing
+# removed is an append, not an edit.
+CONTEXT_APPEND_LINES = 12
+LOG_ENTRY = re.compile(r"^\d{4}-\d{2}-\d{2}-[a-z0-9][a-z0-9-]*\.md$")
 
 # A doc declares what it describes in an HTML comment, so it stays invisible
 # when rendered:  <!-- covers: [glob, ...]  reconciled: <sha> -->
@@ -290,6 +304,82 @@ def check_turf(roles: dict, rules: list) -> None:
         )
 
 
+def check_role_log() -> None:
+    """Work-log entries go in roles/<role>/log/, never appended to CONTEXT.md.
+
+    This was ratified as prose in #77 and enforced by nothing, so it changed no
+    behaviour at all: within 24 hours PR #76 stalled on a conflict in
+    `roles/senior-controls/CONTEXT.md` and PR #78 was carrying another append to
+    the same file. Parallel agents all appending to one file means every PR
+    conflicts every other -- five at once on 2026-07-28, serialising a queue
+    that was otherwise entirely green.
+
+    The rule is mechanical because the failure is mechanical. Standing context
+    is EDITED -- stale entries come out as new ones go in, so a real edit roughly
+    breaks even. A log entry only ever grows the file. `CONTEXT-OK: <reason>` in
+    a commit message is the escape hatch, same shape as TURF-OVERRIDE and DOC-OK.
+
+    NET growth, not "added with no deletions". The first version of this check
+    skipped whenever a file had any deletion at all, and the very PR that
+    introduced it defeated it: a one-line heading fix elsewhere in the same file
+    supplied the deletion, so a 20-line append sailed through. One unrelated
+    edit anywhere in the file would have bought a free pass to append forever.
+    Caught by testing the check against the thing it exists to stop, which is
+    the only way anyone finds this class of bug.
+    """
+    base = os.environ.get("POLICY_BASE_REF", "origin/master")
+    merge_base = git("merge-base", base, "HEAD")
+    if not merge_base:
+        cannot_resolve("role-log", f"base {base!r}")
+        return
+
+    override_text = (os.environ.get("POLICY_PR_BODY", "") + "\n"
+                     + git("log", f"{merge_base}..HEAD", "--format=%B"))
+    om = CONTEXT_OK.search(override_text)
+
+    numstat = git("diff", "--numstat", f"{merge_base}...HEAD")
+    for line in numstat.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        added_s, removed_s, path = parts
+        m = re.fullmatch(r"roles/([^/]+)/CONTEXT\.md", path)
+        if not m or not added_s.isdigit() or not removed_s.isdigit():
+            continue
+        added, removed = int(added_s), int(removed_s)
+        net = added - removed
+        if net <= CONTEXT_APPEND_LINES:
+            continue  # an edit, or a small standing-context change
+        role_dir = m.group(1)
+        if om:
+            print(f"role-log: {path} grew by a net {net} lines (+{added}/-{removed}), "
+                  f"overridden -- {om.group(1).strip()}")
+            continue
+        fail(
+            "role-log",
+            f"{path} grew by a NET {net} lines (+{added}/-{removed}) -- that is an "
+            f"appended work-log entry, not an edit to standing context. Move it "
+            f"to roles/{role_dir}/log/YYYY-MM-DD-<slug>.md (one entry, one file) "
+            f"so it cannot conflict with every other open PR. If it really is "
+            f"standing context, edit the stale entry it replaces, or put "
+            f"'CONTEXT-OK: <reason>' in a COMMIT MESSAGE on this branch",
+        )
+
+    # The other direction: a log file that does not match the convention is a
+    # log directory drifting back into being a shared list.
+    for log_dir in sorted((REPO / "roles").glob("*/log")):
+        for entry in sorted(log_dir.iterdir()):
+            if entry.name == "README.md" or entry.name.startswith("."):
+                continue
+            if not LOG_ENTRY.fullmatch(entry.name):
+                fail(
+                    "role-log",
+                    f"{entry.relative_to(REPO)} is not named "
+                    f"YYYY-MM-DD-<slug>.md. One entry, one file, sortable by "
+                    f"date -- that is what stops the directory becoming a list",
+                )
+
+
 # ---------------------------------------------------------------------------
 # Documentation drift
 # ---------------------------------------------------------------------------
@@ -471,6 +561,7 @@ def main(argv: list[str]) -> int:
     check_adr_index()
     check_ownership(roles, rules)
     check_turf(roles, rules)
+    check_role_log()
     check_doc_drift()
     check_doc_size()
     check_claims()

--- a/roles/archivist/CONTEXT.md
+++ b/roles/archivist/CONTEXT.md
@@ -28,7 +28,7 @@ owns the *data* — the retired-to-current term map — and the COO owns the *ga
 it. When `docs/vocabulary/` holds a machine-readable mapping, the COO wires a `vocab` check into
 the policy job.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 - **2026-07-27 — ratified, Option A plus `docs/vocabulary/`.** The COO granted the term-list
   directory but not `docs/decisions/INDEX.md`: ratification is the COO's to close under

--- a/roles/ceo/CONTEXT.md
+++ b/roles/ceo/CONTEXT.md
@@ -13,7 +13,7 @@ Inline comments on the board doc, and direct prompts to COO / CMO / Archivist. T
 **are** the instruction — each role picks up its own at the next board tick. This is the only
 mechanism that reliably reaches a session that was not already looking.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 _Nothing recorded yet by this role._
 

--- a/roles/cmo/CONTEXT.md
+++ b/roles/cmo/CONTEXT.md
@@ -18,7 +18,7 @@
 - Peer of the COO. Neither escalates to the other; both go to the CEO. A cross-line dispute
   reaches the CEO as ONE joint write-up with both positions in each other's terms.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 _Nothing recorded yet by this role._
 

--- a/roles/coo/CONTEXT.md
+++ b/roles/coo/CONTEXT.md
@@ -14,7 +14,7 @@
 - Ratify a cross-role Promise without a row, or ratify one-way/public work without the Oracle.
 - Build documentation where a CI check would do. Documentation is a polling surface.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 - **2026-07-27 — match the agent type to the work before dispatching.** `sonnet-executor`
   carries Read/Write/Edit/Bash/Grep/Glob only. A Notion + web-research task sent to it burned

--- a/roles/digital-content-production/CONTEXT.md
+++ b/roles/digital-content-production/CONTEXT.md
@@ -19,7 +19,7 @@ session with a commit.
 - Owns `scripts/render_scenario.py` and `docs/web-artifact-pipeline.md` in this repo.
 - Does **not** own the landing page markup or CSS — that is the Senior Digital Marketer's.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 - **The ride the weighted-board sub-goal needs already exists: `sim/scenarios/terrain.py`.**
   It runs a 70 kg ballast with a rider figure by default, so a terrain clip *is* a clip of the

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -32,7 +32,7 @@
   Mass, inertia, geometry, contact and friction are Mechanical's and do.
 - `.github/workflows/ci.yml` is yours. `.github/policy_check.py` and `CODEOWNERS` are the COO's.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 - **Issue #24, AC3 — `r_eff` tyre-ground justification (PR TBD).** Could not be justified, so
   fixed rather than justified. `R_EFF_M`/`DEFAULT_R_EFF_M` (converts `wheel_hinge` angular rate

--- a/roles/senior-digital-marketer/CONTEXT.md
+++ b/roles/senior-digital-marketer/CONTEXT.md
@@ -18,7 +18,7 @@ design; the surface is `overboard-web`.
 - Lead with the measured surprise, not the ambition. Tag every link so we can tell which
   community sent people. End the post with an ask — the GitHub click-through is the conversion.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 _Nothing recorded yet by this role._
 

--- a/roles/sr-mechanical-systems/CONTEXT.md
+++ b/roles/sr-mechanical-systems/CONTEXT.md
@@ -17,7 +17,7 @@
 - A bench-fitted `kt` must never be written into the board model. What transfers from the bench
   is the **imperfection profile**, not motor numbers.
 
-## Decisions made (append as you go)
+## Decisions made (edit in place — completed work goes in log/, not here)
 
 **2026-07-26 — The BoM is delivered as a spreadsheet, not a document.** Four sheets (Read me /
 BoM / Tools / Inventory), clickable Status dropdowns, real vendor links, spares as a deliberate


### PR DESCRIPTION
Closes #86. Follows #83, which fixed the gate that has to run this.

## Why

#77 shipped the one-file-per-log-entry convention **as prose, enforced by nothing**, so it changed no behaviour. Within 24 hours #76 stalled on an append conflict in `roles/senior-controls/CONTEXT.md` and #78 was carrying another append to the same file. Parallel agents appending to one shared file means **every PR conflicts every other one** — five at once on 2026-07-28, serialising a queue that was otherwise entirely green.

That is my miss, and against my own standing rule not to build documentation where a check would do.

## The rule

Mechanical, because the failure is mechanical. **Standing context is edited** — stale entries come out as new ones go in, so a real edit roughly breaks even. **A log entry only grows the file.** So a `roles/*/CONTEXT.md` whose **net** growth exceeds 12 lines is an append, and the failure names the exact file to create instead. `CONTEXT-OK:` in a commit message is the escape hatch.

The other direction too: a file in `roles/*/log/` not named `YYYY-MM-DD-<slug>.md` fails, so the log directory cannot drift back into being a shared list.

## Two bugs found by testing the check against the thing it exists to stop

Both would have shipped a check that reported green and enforced nothing — the same failure #83 just fixed. Neither was reachable by reading the code.

**1. `removed > 0` was a free pass to append forever.** The first version skipped any file with *any* deletion. **This very PR defeated it:** the one-line heading fix supplied the deletion, and a 20-line append sailed straight through. One unrelated edit anywhere in the file would have permanently disabled the check for that file. Now measured as **net** growth: `+22/-1` fails, `+1/-1` passes.

**2. A commit message that *quoted* an override token activated it.** The regexes were unanchored, so my own commit message — which explains the escape hatch in prose — matched `CONTEXT-OK:` and overrode the check it was adding. Now **anchored to line start** for all three of `TURF-OVERRIDE`, `DOC-OK`, `CONTEXT-OK`: an override must be a *declaration*, not a mention. This one was latent in the two pre-existing overrides as well.

## Verified

| Case | Expected | Result |
|---|---|---|
| 20-line append, no deletions | fail | ✅ |
| 20-line append **plus** an unrelated deletion | fail | ✅ (silently passed before) |
| Heading-only edit ×8 (`+1/-1` each) | pass | ✅ |
| `CONTEXT-OK:` declared at line start | override | ✅ |
| Token merely quoted mid-sentence | **no** override | ✅ (overrode before) |
| Malformed `roles/*/log/` filename | fail | ✅ |

## The heading fix, and why it crosses turf

`## Decisions made (append as you go)` was a template artefact in **all eight** `roles/*/CONTEXT.md`, seven of them other roles' turf. **The heading literally instructs the behaviour this check now fails** — leaving it would ship a gate that punishes an agent for following its own context file. Changed to `(edit in place — completed work goes in log/, not here)`: one heading line per file, **no role's content touched.**

`TURF-OVERRIDE` in the commit message, with all six crossings itemised in the gate output rather than hidden. Each role's own CODEOWNERS rule is narrower than the COO's `/roles/` rule, which is why this crosses at all — the same coarse-ownership seam as #87.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
