### PR TITLE
fix(controls): consolidate crates/ r_eff_m=0.14605 FFI literals onto 0.1454

### DIFF
--- a/crates/board-app-ridden/src/main.rs
+++ b/crates/board-app-ridden/src/main.rs
@@ -15,7 +15,9 @@
 //! clamp stage runs and its result is printed, then discarded — there is
 //! nowhere in this binary to send it.
 
-use board_types::{IoError, Observation, Params, Profile, RunMetadata, ValidityFlags};
+use board_types::{
+    IoError, Observation, Params, Profile, RunMetadata, ValidityFlags, DEFAULT_R_EFF_M,
+};
 use control_core::Controller;
 use hal::BoardObserve;
 use safety::Envelope;
@@ -66,7 +68,7 @@ impl BoardObserve for ShadowBackend {
             control_rate_hz: 1e9 / CYCLE_NS as f32,
             params: Params::default(),
             imu_mounting_rotation: [1.0, 0.0, 0.0, 0.0],
-            r_eff_m: 0.14605,
+            r_eff_m: DEFAULT_R_EFF_M,
             imperfection_profile_id: None,
             schema_hash: [0; 32],
             binary_hash: [0; 32],

--- a/crates/board-types/src/lib.rs
+++ b/crates/board-types/src/lib.rs
@@ -18,6 +18,23 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Loaded rolling radius, metres — the FFI-boundary / ridden-mode default for
+/// [`RunMetadata::r_eff_m`].
+///
+/// Must equal the sim model's compiled `wheel_geom` radius
+/// (`sim/models/overboard_onewheel.xml`) and the Python-side
+/// `sim.scenarios.rust_controller.DEFAULT_R_EFF_M`, which is checked directly
+/// against the compiled model by `tests/test_r_eff_matches_model.py`. This
+/// constant is the single Rust-side source — every `crates/` site that needs
+/// a default `r_eff_m` imports it rather than hand-copying the literal
+/// (issue #89; a stale `0.14605` m hand-copy, physically impossible as a
+/// *loaded* radius larger than the tyre's own unloaded geometry, is what
+/// #76/#89 replaced it for).
+///
+/// This is a sim-consistency placeholder, not a bench measurement — Stage-0's
+/// eventual bench-measured loaded rolling radius (ICD §10.5) supersedes it.
+pub const DEFAULT_R_EFF_M: f32 = 0.1454;
+
 // ---------------------------------------------------------------------------
 // Commands — ICD §7.5
 // ---------------------------------------------------------------------------
@@ -356,6 +373,15 @@ pub struct RunMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_r_eff_m_is_the_documented_145_4mm() {
+        // Regression pin mirroring
+        // tests/test_r_eff_matches_model.py::test_model_wheel_radius_is_the_documented_145_4mm
+        // on the Python side. This crate has no MuJoCo binding to check
+        // against the compiled model directly; that check lives in Python.
+        assert_eq!(DEFAULT_R_EFF_M, 0.1454);
+    }
 
     #[test]
     fn command_zero_is_zero_amps() {

--- a/crates/canary-ridden/src/main.rs
+++ b/crates/canary-ridden/src/main.rs
@@ -13,7 +13,9 @@
 //! compiles it (proving the graph edge is real, not just declared and
 //! unused), and `xtask` is what actually inspects it.
 
-use board_types::{Applied, Command, DisarmReason, IoError, Observation, RunMetadata};
+use board_types::{
+    Applied, Command, DisarmReason, IoError, Observation, RunMetadata, DEFAULT_R_EFF_M,
+};
 use hal::BoardObserve;
 use hal_actuate::{BoardActuate, Disarm};
 
@@ -47,7 +49,7 @@ impl BoardObserve for CanaryBackend {
             control_rate_hz: 500.0,
             params: Default::default(),
             imu_mounting_rotation: [1.0, 0.0, 0.0, 0.0],
-            r_eff_m: 0.14605,
+            r_eff_m: DEFAULT_R_EFF_M,
             imperfection_profile_id: None,
             schema_hash: [0; 32],
             binary_hash: [0; 32],

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -32,7 +32,7 @@
 //! state that produced it.
 
 use board_types::ImuSample;
-use board_types::{Command, Faults, Params, Saturation};
+use board_types::{Command, Faults, Params, Saturation, DEFAULT_R_EFF_M};
 use control_core::{
     Attitude, CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator, PlantCoupling,
     VelocityLoop, WheelAccelEstimator,
@@ -284,8 +284,11 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
                 if p.accel_ff_gain_m_s2_per_a > 0.0 {
                     p.accel_ff_gain_m_s2_per_a
                 } else {
-                    // kt 0.7 N·m/A / (r_eff 0.14605 m × 82.5 kg ridden).
-                    0.0581
+                    // kt 0.7 N·m/A / (r_eff 0.1454 m × 82.5 kg ridden).
+                    // Re-derived for #89: was 0.0581 against the stale
+                    // 0.14605 m r_eff, a 0.45% shift that does not change
+                    // which regime this feedforward gain lands in.
+                    0.0584
                 },
             ))
         } else {
@@ -306,7 +309,11 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
             None
         },
         outer,
-        r_eff_m: if p.r_eff_m > 0.0 { p.r_eff_m } else { 0.14605 },
+        r_eff_m: if p.r_eff_m > 0.0 {
+            p.r_eff_m
+        } else {
+            DEFAULT_R_EFF_M
+        },
         last_t_ns: None,
         last_saturated: false,
         envelope: Envelope::new(Params {
@@ -475,7 +482,7 @@ mod tests {
             kp_v_rad_per_m_s: 0.0,
             ki_v_rad_per_m: 0.0,
             max_pitch_ref_rad: 0.087,
-            r_eff_m: 0.14605,
+            r_eff_m: DEFAULT_R_EFF_M,
             com_above_axle: 1,
             use_estimator: 0,
             estimator_tau_s: 1.0,

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -28,8 +28,8 @@
 //! instead.
 
 use board_types::{
-    Applied, Command, DisarmReason, ImuSample, IoError, Observation, Params, Profile, RunMetadata,
-    Saturation, ValidityFlags,
+    Applied, Command, DEFAULT_R_EFF_M, DisarmReason, ImuSample, IoError, Observation, Params,
+    Profile, RunMetadata, Saturation, ValidityFlags,
 };
 use hal::{BoardObserve, CallSequence};
 use hal_actuate::{BoardActuate, Disarm};
@@ -139,7 +139,7 @@ impl BoardObserve for SimBackend {
             control_rate_hz: 1e9 / CYCLE_NS as f32,
             params: self.params,
             imu_mounting_rotation: [1.0, 0.0, 0.0, 0.0],
-            r_eff_m: 0.14605,
+            r_eff_m: DEFAULT_R_EFF_M,
             imperfection_profile_id: None,
             schema_hash: [0; 32],
             binary_hash: [0; 32],

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -28,8 +28,8 @@
 //! instead.
 
 use board_types::{
-    Applied, Command, DEFAULT_R_EFF_M, DisarmReason, ImuSample, IoError, Observation, Params,
-    Profile, RunMetadata, Saturation, ValidityFlags,
+    Applied, Command, DisarmReason, ImuSample, IoError, Observation, Params, Profile, RunMetadata,
+    Saturation, ValidityFlags, DEFAULT_R_EFF_M,
 };
 use hal::{BoardObserve, CallSequence};
 use hal_actuate::{BoardActuate, Disarm};

--- a/roles/senior-controls/log/2026-07-30-consolidate-r-eff-crates-literals.md
+++ b/roles/senior-controls/log/2026-07-30-consolidate-r-eff-crates-literals.md
@@ -1,0 +1,31 @@
+# Consolidate the four `crates/` r_eff_m=0.14605 FFI-boundary literals onto 0.1454
+
+Issue #89, the ridden/hardware-path half of #76's finding: `0.14605` m — a stale nominal-tyre-
+radius guess, physically impossible as a *loaded* rolling radius since it exceeds the tyre's own
+unloaded geometric radius (`0.1454` m, the sim model's actual `wheel_geom` size) — was hand-copied
+independently in six places across `crates/` (`sim-backend`, `control-ffi` ×3, `canary-ridden`,
+`board-app-ridden`).
+
+**One constant, one owner.** Added `board_types::DEFAULT_R_EFF_M` (`crates/board-types/src/lib.rs`)
+— `board-types` was already a shared dependency of all four affected crates, so no new dependency
+edge — and switched every site to import it instead of re-declaring the literal. A Rust unit test
+pins `DEFAULT_R_EFF_M == 0.1454`, mirroring the Python-side regression pin; a new Python test
+(`tests/test_r_eff_matches_model.py::test_rust_ffi_boundary_constant_matches_the_python_side`)
+parses the Rust source for the literal and asserts it against
+`sim.scenarios.rust_controller.DEFAULT_R_EFF_M`, so the two language boundaries cannot drift apart
+silently again — no Python-Rust interop existed to check this any more directly.
+
+**Re-derived, not just swapped:** `control-ffi`'s fallback feedforward gain (`kt 0.7 N·m/A / (r_eff
+× 82.5 kg ridden)`) recomputed against `0.1454` m: `0.0581` → `0.0584`, a 0.45% shift — the same
+magnitude #76 found on the sim side, and it does not change which regime the gain lands in.
+
+`cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D
+warnings`, full `pytest tests/` (257 passed, 2 xfailed, no regressions), and
+`python3 .github/policy_check.py` all pass clean.
+
+**Deliberately left out:** whether the BoardIo ICD §10.5 entry for `r_eff_m` agrees with `0.1454` —
+that document lives in Notion, unreachable from this session, and #76 already flagged the same gap
+on the sim side rather than guessing. Issue #88 (the earlier, less-specified duplicate of this same
+finding) is superseded by this PR closing #89.
+
+PR TBD, issue #89.

--- a/tests/test_r_eff_matches_model.py
+++ b/tests/test_r_eff_matches_model.py
@@ -15,15 +15,29 @@ should eventually be (Stage-0's job, ICD 10.5) -- it only pins the sim-side
 placeholder to be internally consistent with the one model every closed-loop
 metric in this repo is actually measured against, and fails loudly the next
 time either side drifts.
+
+Issue #89 found the same stale `0.14605` m independently hand-copied four
+more times, in `crates/` FFI-boundary defaults (`sim-backend`, `control-ffi`
+x2, `canary-ridden`, `board-app-ridden`) -- out of scope for #76, since that
+is ridden/hardware-path code, not sim scenarios. Those sites now import one
+Rust constant, `board_types::DEFAULT_R_EFF_M`; the last test below checks it
+against this file's Python-side constant so the two cannot drift apart again.
 """
 
 from __future__ import annotations
+
+import re
+from pathlib import Path
 
 from sim.scenarios.hill import R_EFF_M as HILL_R_EFF_M
 from sim.scenarios.plant import build_model
 from sim.scenarios.rust_controller import DEFAULT_R_EFF_M
 from sim.scenarios.shuttle_run import R_EFF_M as SHUTTLE_R_EFF_M
 from sim.scenarios.terrain import R_EFF_M as TERRAIN_R_EFF_M
+
+_BOARD_TYPES_SRC = (
+    Path(__file__).resolve().parent.parent / "crates" / "board-types" / "src" / "lib.rs"
+)
 
 
 def _model_wheel_radius_m() -> float:
@@ -46,3 +60,19 @@ def test_every_scenario_shares_the_one_r_eff_m_constant():
     assert HILL_R_EFF_M == DEFAULT_R_EFF_M
     assert TERRAIN_R_EFF_M == DEFAULT_R_EFF_M
     assert SHUTTLE_R_EFF_M == DEFAULT_R_EFF_M
+
+
+def test_rust_ffi_boundary_constant_matches_the_python_side():
+    """Issue #89: the four `crates/` FFI-boundary sites that independently
+    hand-copied a stale `0.14605` m now import `board_types::DEFAULT_R_EFF_M`
+    instead. Nothing on the Python side can read that Rust constant directly,
+    so this parses the source text for the pinned literal -- the same
+    grep-able, CI-enforceable shape this repo already relies on elsewhere --
+    and fails loudly if either side is edited without the other.
+    """
+    assert _BOARD_TYPES_SRC.is_file(), f"expected {_BOARD_TYPES_SRC} to exist"
+    src = _BOARD_TYPES_SRC.read_text()
+    match = re.search(r"pub const DEFAULT_R_EFF_M: f32 = ([0-9.]+);", src)
+    assert match, "DEFAULT_R_EFF_M declaration not found in board-types/src/lib.rs"
+    rust_value = float(match.group(1))
+    assert rust_value == DEFAULT_R_EFF_M


### PR DESCRIPTION
## What changed

Issue #89 — the ridden/hardware-path half of #76's finding, deliberately left out of that PR
because it scoped to `sim/scenarios/`. The same stale `0.14605` m rolling-radius literal
(physically impossible as a *loaded* rolling radius — it's larger than the tyre's own unloaded
geometric radius of `0.1454` m, which compression under load can only ever shrink) was
independently hand-copied six times across `crates/`:

- `crates/sim-backend/src/lib.rs`
- `crates/control-ffi/src/lib.rs` (×3: a fallback default, a comment + derived feedforward gain,
  and a test fixture)
- `crates/canary-ridden/src/main.rs`
- `crates/board-app-ridden/src/main.rs`

## Why

`board-types` was already a shared dependency of all four affected crates, so it's the natural
single owner. Added `pub const DEFAULT_R_EFF_M: f32 = 0.1454;` there and switched every site to
import it instead of re-declaring the literal — a mechanical fix, no behaviour change beyond the
0.45% radius correction itself.

## Acceptance criteria (from #89)

- [x] Every `0.14605` in `crates/` replaced with `0.1454`, sourced from one constant.
- [x] `control-ffi`'s derived feedforward gain re-derived against `0.1454`, not just the comment's
      number swapped: `kt 0.7 / (r_eff × 82.5 kg)` → `0.0581` becomes `0.0584` (0.45% shift, same
      regime as the sim-side finding — does not change behaviour meaningfully).
- [x] A test that fails if any site drifts from the Python-side constant again — added
      `tests/test_r_eff_matches_model.py::test_rust_ffi_boundary_constant_matches_the_python_side`,
      which parses the Rust source for the pinned literal and checks it against
      `rust_controller.DEFAULT_R_EFF_M` (no Python↔Rust interop exists to check this more
      directly). A Rust unit test also pins `board_types::DEFAULT_R_EFF_M == 0.1454` as a
      regression guard, mirroring the existing Python-side pin.
- [x] `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,
      `python3 .github/policy_check.py` all pass. Full `pytest tests/` also re-run clean (257
      passed, 2 xfailed, no regressions).

## Deliberately left out

Whether the BoardIo ICD §10.5 entry for `r_eff_m` agrees with `0.1454` — that document lives in
Notion, unreachable from this session. #76 flagged the identical gap on the sim side rather than
guessing; this PR does the same rather than fabricating a "confirmed."

Issue #88 is an earlier, less-specified duplicate of this same finding (filed ~20 seconds before
#89, no `Owner`/`Dispatch` markers) — this PR closes #89, which supersedes it.

Closes #89.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9dXT17hD1LK2CgP7mD6df)_