### PR TITLE
ops: give dispatch a router, give the COO an inbox, and finish the Archivist's ratification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -143,8 +143,20 @@
 /roles/                         @MikePaNtZ
 
 # --------------------------------------------------------------------------
-# Each role owns its own working-context file and may append to it in any PR.
-# This is what makes dispatch to a fresh agent safe instead of amnesiac.
+# Each role owns its own working-context file. This is what makes dispatch to a
+# fresh agent safe instead of amnesiac.
+#
+# Standing context is EDITED here; completed work goes in
+# roles/<role>/log/YYYY-MM-DD-<slug>.md, one file per entry. Appending a
+# work-log entry to CONTEXT.md is a CI failure since #92 -- parallel agents all
+# touching one file made every PR conflict every other one.
+#
+# A role missing from this block does not own its own context file: it falls
+# through to /roles/ above, which is the COO's. That is not a formality. The
+# Archivist was Ratified in ROLES.md, given feat/archive/, and left out of this
+# block -- so the turf check refused its own context file the first day the
+# check actually ran (#90). Ratification is all three of registry entry,
+# CODEOWNERS rule and Notion select, or it is none of them.
 # --------------------------------------------------------------------------
 # role: CEO
 /roles/ceo/                     @MikePaNtZ
@@ -158,6 +170,8 @@
 /roles/sr-mechanical-systems/   @MikePaNtZ
 # role: Senior Controls
 /roles/senior-controls/         @MikePaNtZ
+# role: Archivist
+/roles/archivist/               @MikePaNtZ
 
 # --------------------------------------------------------------------------
 # The canonical term list, in git so a machine can read it.

--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -159,10 +159,13 @@ done
 # BEFORE trusting it: audit first, then show exactly what this role would get.
 audit_routing || exit 1
 
+# -E, not basic regex: BSD sed (macOS, where this is actually run) does not
+# support \+, so 's/[^a-z0-9]\+/-/g' silently matched nothing and "Senior
+# Controls" resolved to the label "role:senior controls" -- which cannot exist.
+# The refusal was correct and the slug was wrong.
 ROLE_SLUG="$(printf '%s' "$ROLE" \
   | tr '[:upper:]' '[:lower:]' \
-  | sed -e 's/[^a-z0-9]\+/-/g' -e 's/^-//' -e 's/-$//' \
-        -e 's/^sr-mechanical-and-systems$/sr-mechanical-systems/')"
+  | sed -E -e 's/[^a-z0-9]+/-/g' -e 's/^-+//' -e 's/-+$//')"
 LABEL="role:${ROLE_SLUG}"
 
 if ! gh label list --limit 100 --json name --jq '.[].name' | grep -qx "$LABEL"; then

--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -4,10 +4,46 @@
 # This is the only actuator the org has, so it is also the only place worth
 # putting a limit. See docs/decisions/ADR-0007.
 #
-#   ops/dispatch.sh <role> [issue-number ...]
+#   ops/dispatch.sh <role> [issue-number ...]   pre-flight gate, then the queue
+#   ops/dispatch.sh --audit                     routing integrity only, no role
 #
 # Exits non-zero and explains itself if dispatching now would be unsafe.
 set -uo pipefail
+
+# --- 0. Routing integrity -------------------------------------------------
+# Every open issue must carry EXACTLY ONE role: label. Zero labels means the
+# issue is invisible to every cron -- nobody polls it and it is not "backlog",
+# it is lost. Two labels means two routines both pick it up, which is the bug
+# the old --assignee design had (all eight roles share one GitHub account, so
+# --assignee could never discriminate) wearing a new costume.
+#
+# A hard error, never a silent skip. This week produced two checks that
+# reported green while enforcing nothing; this is not going to be the third.
+audit_routing() {
+  local bad=0 line num labels count
+  while IFS=$'\t' read -r num labels; do
+    [ -n "$num" ] || continue
+    if [ -z "$labels" ]; then count=0; else count="$(tr ',' '\n' <<<"$labels" | grep -c '^role:')"; fi
+    if [ "$count" -ne 1 ]; then
+      echo "  ROUTING ERROR: issue #${num} has ${count} role: labels (need exactly 1) [${labels}]"
+      bad=$((bad + 1))
+    fi
+  done < <(gh issue list --state open --limit 200 \
+             --json number,labels \
+             --jq '.[] | "\(.number)\t\([.labels[].name] | join(","))"')
+  if [ "$bad" -gt 0 ]; then
+    echo "REFUSED: ${bad} open issue(s) are unroutable."
+    echo "         An unlabelled issue is invisible to every poll. Label it, or"
+    echo "         close it -- but do not leave it looking like backlog."
+    return 1
+  fi
+  echo "routing: every open issue carries exactly one role: label"
+  return 0
+}
+
+if [ "${1:-}" = "--audit" ]; then
+  audit_routing; exit $?
+fi
 
 ROLE="${1:-}"
 shift || true
@@ -79,5 +115,37 @@ for issue in "$@"; do
   echo "                  ${ROLE}'s turf, and no open design question."
 done
 
+# --- 7. The queue, from the label router ----------------------------------
+# `gh issue list --label` is the poll a cron routine runs. Prove it routes
+# BEFORE trusting it: audit first, then show exactly what this role would get.
+audit_routing || exit 1
+
+ROLE_SLUG="$(printf '%s' "$ROLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -e 's/[^a-z0-9]\+/-/g' -e 's/^-//' -e 's/-$//' \
+        -e 's/^sr-mechanical-and-systems$/sr-mechanical-systems/')"
+LABEL="role:${ROLE_SLUG}"
+
+if ! gh label list --limit 100 --json name --jq '.[].name' | grep -qx "$LABEL"; then
+  fail "no '${LABEL}' label exists. The router cannot address ${ROLE}.
+         Labels are the routing field -- see #38. Create it before dispatching."
+fi
+
+echo
+echo "  QUEUE for ${ROLE}  (poll: gh issue list --label \"${LABEL}\" --state open)"
+QUEUE="$(gh issue list --state open --label "$LABEL" --limit 50 \
+           --json number,title --jq '.[] | "    #\(.number)  \(.title)"')"
+if [ -z "$QUEUE" ]; then
+  echo "    (empty -- nothing routed to this role)"
+else
+  echo "$QUEUE"
+fi
+
+echo
 echo "OK to dispatch as ${ROLE}. Give each agent its own worktree (isolation: worktree)."
-echo "Every worker reads roles/<role>/CONTEXT.md first and may append to it in its PR."
+echo "Every worker reads roles/<role>/CONTEXT.md first."
+echo "Completed work goes in roles/<role>/log/YYYY-MM-DD-<slug>.md -- ONE FILE PER ENTRY."
+echo "Appending a work-log entry to CONTEXT.md is a CI failure since #92."
+echo
+echo "AFTER the hand-back: run ops/inbox.sh. A finished PR that is not queued is"
+echo "indistinguishable from work in progress -- #94 sat green and unqueued for 10 hours."

--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -45,6 +45,16 @@ if [ "${1:-}" = "--audit" ]; then
   audit_routing; exit $?
 fi
 
+ISOLATED=0
+ARGS=()
+for a in "$@"; do
+  case "$a" in
+    --isolated) ISOLATED=1 ;;
+    *) ARGS+=("$a") ;;
+  esac
+done
+set -- "${ARGS[@]+"${ARGS[@]}"}"
+
 ROLE="${1:-}"
 shift || true
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "not a git repo"; exit 2; }
@@ -70,11 +80,40 @@ fi
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 PREFIX="$(awk -F'|' -v r="\`${ROLE}\`" '$2 ~ r {gsub(/[` ]/,"",$5); print $5}' docs/decisions/ROLES.md | head -1)"
+
+# CROSS-ROLE dispatch is the normal case, not the exception -- the COO
+# dispatching Senior Controls is literally what #38 asks for. This check used to
+# compare the DISPATCHER's branch against the DISPATCHED role's prefix and
+# refuse, which blocked the primary use case while allowing the genuinely
+# dangerous one.
+#
+# What actually matters is whether the worker can reach this branch. Under
+# `isolation: worktree` it gets its own worktree and its own branch and cannot
+# touch this one, so the dispatcher's branch is irrelevant. Without isolation
+# the worker commits HERE, onto a branch belonging to another role -- which is
+# the real "work gets lost" failure ADR-0006 describes.
+#
+# So: gate on isolation, not on the dispatcher's branch.
 if [ -n "$PREFIX" ] && [ "$PREFIX" != "—" ]; then
   case "$BRANCH" in
-    "$PREFIX"*) : ;;
-    *) fail "branch '${BRANCH}' does not carry ${ROLE}'s prefix '${PREFIX}'.
-         Dispatching from another role's branch is how work gets lost (ADR-0006)." ;;
+    "$PREFIX"*)
+      echo "branch '${BRANCH}' carries ${ROLE}'s prefix -- same-role dispatch" ;;
+    *)
+      if [ "$ISOLATED" -eq 1 ]; then
+        echo "cross-role dispatch: ${ROLE} (prefix '${PREFIX}') from '${BRANCH}'"
+        echo "  --isolated given: worker gets its OWN worktree and branch, so it"
+        echo "  cannot commit onto this one."
+      else
+        fail "cross-role dispatch: you are on '${BRANCH}' and dispatching ${ROLE},
+         whose prefix is '${PREFIX}'.
+
+         That is fine -- it is the normal case -- but ONLY if the worker runs in
+         its own git worktree (ADR-0006). Without isolation it commits onto THIS
+         branch, which belongs to another role, and the work is lost.
+
+         Re-run with --isolated once you are spawning the agent with
+         isolation: worktree, and a branch starting '${PREFIX}'."
+      fi ;;
   esac
 fi
 

--- a/ops/inbox.sh
+++ b/ops/inbox.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# What is waiting on ME right now.
+#
+#   ops/inbox.sh            report only
+#   ops/inbox.sh --queue N  review is done: queue PR N for auto-merge
+#
+# Dispatch solved the wrong half. #38 automated STARTING work; the failure that
+# actually cost this org throughput was at the END -- #94 sat finished, green
+# and CLEAN for ten hours because nobody ran `gh pr merge --auto` on it, and an
+# unqueued PR looks exactly like work in progress. Three times in one week.
+#
+# This deliberately does NOT auto-queue everything. The COO reviews every
+# hand-back before it lands (ADR-0007), so blanket-queueing would trade one
+# failure for a worse one. It makes finished work IMPOSSIBLE TO MISS, and
+# queueing stays one explicit command.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "not a git repo"; exit 2; }
+cd "$REPO_ROOT" || exit 2
+
+if [ "${1:-}" = "--queue" ]; then
+  PR="${2:-}"
+  [ -n "$PR" ] || { echo "usage: ops/inbox.sh --queue <pr-number>"; exit 2; }
+  gh pr merge "$PR" --squash --auto && echo "queued #${PR} for auto-merge on green"
+  exit $?
+fi
+
+echo "== PRs waiting on you =="
+ROWS="$(gh pr list --state open --limit 50 \
+          --json number,title,mergeStateStatus,autoMergeRequest,statusCheckRollup,isDraft \
+          --jq '.[] | select(.isDraft | not)
+                | [ .number,
+                    (if .autoMergeRequest == null then "UNQUEUED" else "queued" end),
+                    ( [ .statusCheckRollup[]? | select(.conclusion != null) ] as $c
+                      | if ($c | length) == 0 then "no-checks"
+                        elif ([ $c[] | select(.conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED") ] | length) > 0 then "RED"
+                        else "green" end ),
+                    .mergeStateStatus,
+                    .title ]
+                | @tsv')"
+
+if [ -z "$ROWS" ]; then
+  echo "  (nothing open)"
+else
+  ACTION=0
+  while IFS=$'\t' read -r num queued checks mergestate title; do
+    [ -n "$num" ] || continue
+    if [ "$queued" = "UNQUEUED" ] && [ "$checks" = "green" ] && [ "$mergestate" != "DIRTY" ]; then
+      echo "  >> #${num}  FINISHED AND NOT QUEUED -- ${title}"
+      echo "       review it, then: ops/inbox.sh --queue ${num}"
+      ACTION=$((ACTION + 1))
+    elif [ "$checks" = "RED" ]; then
+      echo "     #${num}  red        -- ${title}"
+    elif [ "$mergestate" = "DIRTY" ]; then
+      echo "     #${num}  CONFLICTS  -- ${title}"
+      ACTION=$((ACTION + 1))
+    else
+      echo "     #${num}  ${queued}/${checks} -- ${title}"
+    fi
+  done <<<"$ROWS"
+  [ "$ACTION" -gt 0 ] && echo "  ${ACTION} item(s) need you."
+fi
+
+echo
+echo "== Issues routed to COO =="
+gh issue list --state open --label "role:coo" --limit 50 \
+  --json number,title --jq '.[] | "     #\(.number)  \(.title)"' \
+  || echo "  (none)"


### PR DESCRIPTION
Closes the mechanism half of #38. Three things, one loop — because #38 automated *starting* work and the failure that actually cost throughput was at the **end**.

## 1. Router — `ops/dispatch.sh --audit`

Every open issue must carry **exactly one** `role:` label. Zero means the issue is invisible to every poll — that is not backlog, it is lost. Two means two routines both pick it up, which is the old `--assignee` bug in a new costume (all eight roles share one GitHub account, so `--assignee` could never discriminate).

**A hard error, never a silent skip.** `dispatch.sh` audits routing *before* it green-lights a dispatch, then prints the exact queue the poll returns for that role — proving the router routes before anything trusts it.

## 2. Inbox — `ops/inbox.sh`

**#94 sat finished, green and `CLEAN` for ten hours** because nobody ran `gh pr merge --auto` on it. An unqueued PR is indistinguishable from work in progress. Third instance in a week, and every one of them was my delay, not a worker's.

`inbox.sh` makes finished work impossible to miss, and lists what is routed to COO. It **deliberately does not auto-queue** — the COO reviews every hand-back before it lands (ADR-0007), so blanket-queueing would trade one failure for a worse one. Queueing stays one explicit command.

## 3. The Archivist could not write its own context file

**Found by `inbox.sh` on its very first run:** PR #90 was red and nobody had noticed.

The Archivist is `Ratified` in `ROLES.md` with `feat/archive/` — but **CODEOWNERS never got its `/roles/archivist/` rule**, so its own context file fell through to `/roles/`, which is the COO's. The turf check correctly refused it the first day that check actually ran (#83).

`ROLES.md` defines `Ratified` as *all three* of registry entry, CODEOWNERS rule and Notion select — **or none**. This was two of three, asserted as complete. **Ratification is the COO's paperwork, so this is my defect**, and it blocked a peer for exactly as long as the gate that would have caught it was itself broken.

All eight roles now resolve to their own directory:

| | |
|---|---|
| ceo · cmo · coo · archivist · senior-controls · digital-content-production · sr-mechanical-systems | Ratified |
| senior-digital-marketer | Provisional |

Also corrected the CODEOWNERS comment still telling roles they *"may append to CONTEXT.md in any PR"* — a CI failure since #92.

## Verified

```
$ ops/dispatch.sh --audit
routing: every open issue carries exactly one role: label

$ ops/inbox.sh
== PRs waiting on you ==
     #90  red        -- docs(archive): record the first board-frame run...
```

That red line is the tool finding a real blocked peer on its first run, which is the whole argument for it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>