### PR TITLE
feat(sim): terrain.run() gains capture_state, mirroring impulse_response

### DIFF
--- a/roles/senior-controls/log/2026-07-30-terrain-capture-state.md
+++ b/roles/senior-controls/log/2026-07-30-terrain-capture-state.md
@@ -1,0 +1,36 @@
+# Give `terrain.run()` a `capture_state` pose history, mirroring `impulse_response`
+
+Issue #81, filed by Digital Content Production from #69: `impulse_response.run()` takes
+`capture_state: bool = False` and appends `data.qpos.copy()` per step into `ImpulseResult.qpos`, so
+`render_scenario.py` can replay the exact trajectory the metrics describe rather than re-stepping the
+physics inside the renderer. `terrain.run()` had neither the flag nor the field, so a terrain ride
+could not be filmed the same way.
+
+**Mirrored the impulse signature exactly**, per the ask: `run(..., capture_state: bool = False)`
+appending to a new `TerrainResult.qpos`, same field name and shape (`np.asarray(states) if states
+else np.empty(0)`). Off by default — the append only happens inside `if capture_state:`, at the same
+point in the per-step loop where the other trajectory channels are recorded, so a pose is captured for
+every sample the metrics use and never for any other step (the loop can exit early on a strike or on
+reaching the crest; the capture point is on that same path, so the count can never drift from `len(t)`).
+`to_json_dict()` was already untouched — like impulse's, it only serialises `params`/`plant`/`metrics`,
+so the pose array was never at risk of landing in metrics.json.
+
+Added `test_capture_state_records_one_pose_per_sample` to `tests/test_terrain.py`: asserts `qpos` is
+empty when `capture_state=False` and that its row count equals `len(t)` when `True`. Existing
+`test_repeat_runs_are_bit_identical` (which never passes `capture_state`) is unchanged and still
+passes, pinning that the default path is untouched.
+
+`scripts/render_scenario.py` already inspects `terrain.run`'s signature and prefers `capture_state=`
+the moment it exists, falling back to its own `mj_step`-wrapping shim otherwise (that shim is marked
+for deletion in its own docstring). Per the issue, landing this closes that gap automatically —
+nothing in the renderer needed to change, and per the issue text ("nothing else in the renderer
+changes") I left `scripts/render_scenario.py` untouched, including the now-dead shim itself; deleting
+it is a separate, renderer-owned cleanup outside this issue's ask.
+
+Verified: `PATH="/usr/sbin:$PATH" .venv/bin/python3 -m pytest tests/ -q` → 258 passed, 2 xfailed (no
+regressions). `cargo build --release -p control-ffi` built clean first, per the closed-loop test
+dependency. `GITHUB_ACTIONS=1 POLICY_BRANCH=feat/controls/terrain-capture-state
+POLICY_BASE_REF=origin/master python3 .github/policy_check.py` passes (8 roles, 38 ownership rules;
+only pre-existing doc-drift advisories, unrelated to this change).
+
+PR #TBD, closes #81.

--- a/sim/scenarios/terrain.py
+++ b/sim/scenarios/terrain.py
@@ -208,6 +208,15 @@ class TerrainResult:
     pitch_est_deg: np.ndarray = field(default_factory=lambda: np.empty(0))
     motor_current_a: np.ndarray = field(default_factory=lambda: np.empty(0))
 
+    qpos: np.ndarray = field(default_factory=lambda: np.empty(0))
+    """Full state history, one row per step, when run(capture_state=True).
+
+    The renderer REPLAYS this rather than re-stepping the physics, so the film
+    is guaranteed to be of the same trajectory the metrics describe. It also
+    keeps GL out of the physics path entirely: the CI gate needs no graphics
+    stack, and a broken one can never change a pass/fail.
+    """
+
     def to_json_dict(self) -> dict:
         return {"params": asdict(self.params), "plant": self.plant,
                 "metrics": asdict(self.metrics)}
@@ -337,6 +346,7 @@ def run(
     params: TerrainParams | None = None,
     profile: ImperfectionProfile = STAGE0_CUTBACK,
     controller_factory=None,
+    capture_state: bool = False,
 ) -> TerrainResult:
     """Ride crest → dip → crest and measure whether control holds throughout."""
     params = params or TerrainParams()
@@ -387,6 +397,7 @@ def run(
     length = params.crest_to_crest_m
 
     ts, travels, vs, grades, pitches, ests, currents = [], [], [], [], [], [], []
+    states: list[np.ndarray] = []
     x0 = float(data.xpos[frame][0])
     flowing_a = 0.0
     m = TerrainMetrics()
@@ -427,6 +438,8 @@ def run(
             pitches.append(pitch_deg)
             ests.append(math.degrees(float(ctl.pitch_used_rad)))
             currents.append(current)
+            if capture_state:
+                states.append(data.qpos.copy())
 
             m.peak_abs_pitch_deg = max(m.peak_abs_pitch_deg, abs(pitch_deg))
             m.max_grade_seen_pct = max(m.max_grade_seen_pct, abs(grade))
@@ -501,6 +514,7 @@ def run(
         params=params, metrics=m, plant=summary, t=t_arr, travel_m=trav,
         v_m_s=v_arr, grade_pct=np.asarray(grades), pitch_deg=np.asarray(pitches),
         pitch_est_deg=np.asarray(ests), motor_current_a=np.asarray(currents),
+        qpos=np.asarray(states) if states else np.empty(0),
     )
 
 

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -236,3 +236,20 @@ def test_repeat_runs_are_bit_identical():
     assert np.array_equal(a.v_m_s, b.v_m_s)
     assert np.array_equal(a.travel_m, b.travel_m)
     assert a.to_json_dict() == b.to_json_dict()
+
+
+def test_capture_state_records_one_pose_per_sample():
+    """Mirrors `impulse_response.run(capture_state=...)`: same parameter name,
+    same shape, so the renderer treats both scenarios identically. Off by
+    default, so nothing that gates on this scenario pays for the pose history,
+    and `to_json_dict()` -- checked above -- never carries it into metrics.json.
+    """
+    p = TerrainParams(duration_s=6.0)
+    off = run(p, capture_state=False)
+    assert off.qpos.size == 0
+
+    on = run(p, capture_state=True)
+    assert on.qpos.shape[0] == len(on.t), (
+        "one qpos row per recorded sample -- a mismatch would let the renderer "
+        "silently film a trajectory that is not the one the metrics describe"
+    )

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -253,3 +253,10 @@ def test_capture_state_records_one_pose_per_sample():
         "one qpos row per recorded sample -- a mismatch would let the renderer "
         "silently film a trajectory that is not the one the metrics describe"
     )
+
+    # Capturing must not perturb the run: the count check above cannot catch a
+    # capture that changes sub-step or has a side effect, only that pinning the
+    # trajectory itself against the capture_state=False run can.
+    assert np.array_equal(off.t, on.t)
+    assert np.array_equal(off.pitch_deg, on.pitch_deg)
+    assert np.array_equal(off.travel_m, on.travel_m)


### PR DESCRIPTION
## What

`terrain.run()` now takes `capture_state: bool = False` and, when set, appends `data.qpos.copy()` per
recorded sample into a new `TerrainResult.qpos` -- same parameter name, same shape as
`impulse_response.run(capture_state=...)`, so the renderer treats both scenarios identically.

## Why

`scripts/render_scenario.py` replays a run by writing `result.qpos[i]` into `data.qpos` and calling
`mj_forward`. `terrain.run()` had no `capture_state` and no pose history, so a terrain ride could not
be filmed that way -- `render_scenario.py` currently works around it with a shim (marked for deletion
in its own docstring) that wraps `mujoco.mj_step` to reconstruct poses from outside the scenario. That
shim already inspects `terrain.run`'s signature and prefers `capture_state=` the moment it exists, so
landing this closes the gap with no renderer changes needed.

## Changes

- `sim/scenarios/terrain.py`: `TerrainResult.qpos` field (docstring copied verbatim from
  `ImpulseResult.qpos`); `run(..., capture_state: bool = False)`; capture happens at the same point in
  the per-step loop where the other trajectory channels (`t`, `travel_m`, etc.) are recorded, so a pose
  count mismatch against the sample count is structurally impossible, not merely unlikely -- the loop's
  early exits (strike, reached-crest) sit on the same path as the capture. `to_json_dict()` was already
  untouched, matching impulse's behaviour of never serialising the pose array into metrics.json.
- `tests/test_terrain.py`: new `test_capture_state_records_one_pose_per_sample`, asserting `qpos` is
  empty when off and has one row per `t` sample when on.
- `roles/senior-controls/log/2026-07-30-terrain-capture-state.md`: new work-log entry (per the
  post-#92 rule, `CONTEXT.md` itself is not touched).

## Scope notes

- Per the issue text ("nothing else in the renderer changes"), `scripts/render_scenario.py` is left
  untouched, including its now-dead capture shim -- deleting that shim is renderer-owned cleanup outside
  this issue's ask, flagging it here rather than doing it.
- No other file under Senior Controls' turf needed changes; the two "no action implied" observations in
  the issue (`fraction_completed` sign, `struck_phase` bucketing at negative travel) are noted in the
  issue itself as informational only and are not touched here.

## Verification

- `PATH="/usr/sbin:$PATH" .venv/bin/python3 -m pytest tests/ -q` -> `258 passed, 2 xfailed` (pre-existing
  xfails, no regressions).
- `cargo build --release -p control-ffi` built clean first, per the closed-loop test dependency.
- `GITHUB_ACTIONS=1 POLICY_BRANCH=feat/controls/terrain-capture-state POLICY_BASE_REF=origin/master
  python3 .github/policy_check.py` -> all hard checks pass (8 roles, 38 ownership rules); only
  pre-existing doc-drift advisories, unrelated to this change.

Closes #81.