### PR TITLE
fix(ops): inbox.sh called every in-flight PR red

### DIFF
--- a/ops/inbox.sh
+++ b/ops/inbox.sh
@@ -31,9 +31,19 @@ ROWS="$(gh pr list --state open --limit 50 \
           --jq '.[] | select(.isDraft | not)
                 | [ .number,
                     (if .autoMergeRequest == null then "UNQUEUED" else "queued" end),
-                    ( [ .statusCheckRollup[]? | select(.conclusion != null) ] as $c
-                      | if ($c | length) == 0 then "no-checks"
-                        elif ([ $c[] | select(.conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED") ] | length) > 0 then "RED"
+                    # Branch on .status, NOT on .conclusion being null. A check
+                    # that is still running reports conclusion "" (an empty
+                    # STRING, not null), so filtering on `!= null` kept it and
+                    # then `"" != "SUCCESS"` classified every in-flight PR as
+                    # RED. Caught within minutes of shipping, by this tool
+                    # calling a green PR red -- a report nobody can trust is
+                    # worse than no report.
+                    ( [ .statusCheckRollup[]? ] as $all
+                      | [ $all[] | select(.status == "COMPLETED") ] as $done
+                      | [ $done[] | select(.conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED") ] as $bad
+                      | if ($all | length) == 0 then "no-checks"
+                        elif ($bad | length) > 0 then "RED"
+                        elif ($done | length) < ($all | length) then "running"
                         else "green" end ),
                     .mergeStateStatus,
                     .title ]


### PR DESCRIPTION
A check that is still running reports `conclusion: ""` — an **empty string, not null**. `inbox.sh` filtered with `select(.conclusion != null)`, which kept those, and then `"" != "SUCCESS"` classified them **RED**.

So every PR with a job still running looked like a failure. It called #97 red while `gh` reported 3 pass / 1 pending — **minutes after I shipped it, while using it to check that very PR.**

```
{"conclusion":"SUCCESS","name":"rust","status":"COMPLETED"}
{"conclusion":"",       "name":"sim", "status":"IN_PROGRESS"}
```

## The fix

Branch on `.status` — the field that actually says whether a check finished — and report `running` as its own state rather than collapsing it into pass or fail.

Verified against `gh pr checks` for every open PR:

| PR | `gh` | inbox before | inbox after |
|---|---|---|---|
| #97 | 3 pass, 1 pending | ❌ RED | ✅ running |
| #90 | 1 fail, 4 pass | ✅ RED | ✅ RED |

## Why this mattered enough to fix immediately

**A report nobody can trust is worse than no report.** An inbox that cries wolf gets ignored inside a day — and the entire reason it exists is that #94 sat finished, green and unqueued for ten hours because finished work was indistinguishable from work in progress. A tool that marks healthy PRs as broken recreates that blindness with extra noise.

Third bug in this tooling found by **running** it rather than reading it — after the cross-role dispatch refusal and the BSD `sed` role slug. Consistent with the week's theme: #83's `turf` and `doc-drift` had reported green for their entire existence while executing nothing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>