### PR TITLE
ops: derive per-role spend, gate on a percentage, and stop passing a floor off as a total

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ __pycache__/
 # macOS
 .DS_Store
 **/.DS_Store
+
+# Local plan-meter observations. Machine- and plan-specific, and a fabricated
+# value here would be silently trusted as a real reading. Never commit one.
+ops/usage-calibration.json

--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -128,8 +128,9 @@ if [ "$#" -gt "$MAX_CONCURRENT" ]; then
 fi
 
 # --- 4. Usage check -------------------------------------------------------
-python3 ops/usage.py --check || fail "daily usage ceiling reached -- do not dispatch.
-         Raise OPS_USAGE_CEILING_M deliberately, or wait."
+python3 ops/usage.py --check || fail "usage threshold reached -- do not dispatch.
+         Raise OPS_USAGE_THRESHOLD_PCT deliberately, or wait."
+echo "  (spend above is a FLOOR: cloud/scheduled agents are absent from it -- #79)"
 
 # --- 5. Agent-type fit ----------------------------------------------------
 # Learned the hard way: sonnet-executor has Read/Write/Edit/Bash/Grep/Glob and

--- a/ops/usage.py
+++ b/ops/usage.py
@@ -1,9 +1,26 @@
 #!/usr/bin/env python3
 """Claude usage sensor. Reads local transcripts. Costs zero model tokens.
 
-    python3 ops/usage.py                 # today + 7-day history + top sessions
-    python3 ops/usage.py --check         # exit 1 if today is over the ceiling
-    python3 ops/usage.py --ceiling 40    # ceiling in millions of weighted tokens
+    python3 ops/usage.py                 # history, by-role rollup, cost per turn
+    python3 ops/usage.py --calibrate 62  # "Settings -> Usage says 62% right now"
+    python3 ops/usage.py --check         # exit 1 if over OPS_USAGE_THRESHOLD_PCT
+
+THE GATE CANNOT BE A TOKEN COUNT
+--------------------------------
+Anthropic publishes NO absolute number for any subscription meter -- the UI is
+percentage bars only, and there is no endpoint to read them. So the ceiling is
+a percentage the CEO sets, and the conversion from weighted tokens to a
+percentage comes from `--calibrate`: a human reads the real bar once and tells
+this tool. Any absolute token ceiling written here would be a locally-inferred
+guess that later gets mistaken for an Anthropic figure.
+
+WHAT THIS TOOL CANNOT SEE
+-------------------------
+Cloud / scheduled agents execute on Anthropic's infrastructure and write their
+transcripts server-side. They are ABSENT from this output -- not undercounted,
+absent -- and every total here is therefore a FLOOR. Whether they even draw on
+the same meters is unverified. The report says so on every run, loudly, because
+a partial number passed off as a complete one is worse than no number.
 
 WHY THIS IS A SCRIPT AND NOT AN EVENT LOOP
 ------------------------------------------
@@ -28,6 +45,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -43,8 +61,76 @@ WEIGHTS = {
     "output_tokens": 5.0,
 }
 
-# Optional: {"<session-uuid>": "Senior Controls", ...}. Absent -> unattributed.
+# Optional OVERRIDE only: {"<session-uuid>": "Senior Controls", ...}. Attribution
+# is DERIVED (see attribute()); this file exists to correct a specific session
+# the derivation gets wrong, not to carry the mapping.
 ROLE_MAP = Path(__file__).parent / "session-roles.json"
+
+# Calibration observations for the percentage gate. See estimate_pct().
+CALIBRATION = Path(__file__).parent / "usage-calibration.json"
+
+ROLES_MD = Path(__file__).parent.parent / "docs" / "decisions" / "ROLES.md"
+
+# cwd fallback when the branch carries no lane -- one worktree per role
+# (ADR-0006), so the directory names the role. Only needed for work done on
+# master or a detached HEAD inside a role's worktree.
+WORKTREE_ROLE = {
+    "overboard-coo": "COO",
+    "overboard-controls": "Senior Controls",
+    "overboard-archivist": "Archivist",
+    "overboard-mech": "Sr. Mechanical & Systems",
+    "overboard-dcp": "Digital Content Production",
+}
+
+
+def lane_roles() -> dict[str, str]:
+    """{lane: role} from the registry -- 'feat/ops/' -> {'ops': 'COO'}.
+
+    Keyed on the LANE, not the whole prefix, because the registry records
+    `feat/ops/` while real branches are also `fix/ops/...` and `docs/ops/...`.
+    Matching the literal prefix missed every one of those.
+    """
+    out: dict[str, str] = {}
+    if not ROLES_MD.is_file():
+        return out
+    for line in ROLES_MD.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 5 or cells[1] not in {"Ratified", "Provisional"}:
+            continue
+        role = re.fullmatch(r"`([^`]+)`", cells[0])
+        prefix = re.fullmatch(r"`([^`]+)`", cells[3])
+        if role and prefix:
+            lane = prefix.group(1).strip("/").split("/")[-1]
+            out[lane] = role.group(1)
+    return out
+
+
+def attribute(branch: str, cwd: str, session: str,
+              lanes: dict[str, str], override: dict[str, str]) -> str | None:
+    """Which role paid for this turn? DERIVED, not maintained.
+
+    The design doc recommended a hand-kept {session: role} file. Two facts
+    found while building it changed that call, and the deviation is deliberate:
+
+      1. Every usage-bearing transcript entry carries `gitBranch` and `cwd`
+         (511/511 on the sample checked), so the data is already there.
+      2. A session is NOT one role. This session alone spanned seven branches,
+         including reviewing and fixing work on another role's branch. A
+         session-level map would have booked all of that to one role and been
+         confidently wrong; per-turn branch attribution books it to the work.
+
+    Derived also means it applies RETROACTIVELY and costs nobody any ongoing
+    discipline -- the failure mode the design doc named as (b)'s main downside.
+    """
+    if session in override:
+        return override[session]
+    seg = branch.split("/")
+    if len(seg) >= 2 and seg[1] in lanes:
+        return lanes[seg[1]]
+    base = Path(cwd).name if cwd else ""
+    return WORKTREE_ROLE.get(base)
 
 
 def transcripts() -> list[tuple[Path, str, bool]]:
@@ -60,10 +146,15 @@ def transcripts() -> list[tuple[Path, str, bool]]:
     return out
 
 
-def scan() -> tuple[dict, dict, dict]:
+def scan() -> tuple[dict, dict, dict, dict, dict]:
     by_day: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     by_session: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     sub_share: dict[str, int] = defaultdict(int)
+    by_role: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    by_branch: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    day_attr: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    turn_cost: dict[str, list] = defaultdict(lambda: [0, 0.0])
+    lanes, override = lane_roles(), roles()
 
     for path, session, is_sub in transcripts():
         try:
@@ -82,14 +173,24 @@ def scan() -> tuple[dict, dict, dict]:
                 continue
             ts = d.get("timestamp") or ""
             day = ts[:10] or "unknown"
+            branch = d.get("gitBranch") or ""
+            role = attribute(branch, d.get("cwd") or "", session, lanes, override)
+            label = "dispatched subagent" if is_sub else "main-thread"
+            turn_cost[label][0] += 1
+            turn_cost[label][1] += weighted(usage)
             for k in WEIGHTS:
                 v = usage.get(k) or 0
                 if isinstance(v, int):
                     by_day[day][k] += v
                     by_session[session][k] += v
+                    by_role[role or "unattributed"][k] += v
+                    if role:
+                        day_attr[day][k] += v
+                    if branch:
+                        by_branch[branch][k] += v
                     if is_sub:
                         sub_share[day] += v
-    return by_day, by_session, sub_share
+    return by_day, by_session, sub_share, by_role, by_branch, day_attr, dict(turn_cost)
 
 
 def weighted(bucket: dict[str, int]) -> float:
@@ -105,30 +206,105 @@ def roles() -> dict[str, str]:
     return {}
 
 
+def rolling_week_m(by_day: dict) -> float:
+    """Weighted M over the trailing 7 days.
+
+    A PROXY for the weekly meter, not the meter. The real one resets on a fixed
+    per-plan cadence we cannot read, so a rolling window will disagree with the
+    dashboard near a reset boundary. Stated here so nobody reads it as the
+    actual meter later.
+    """
+    cutoff = (date.today() - timedelta(days=6)).isoformat()
+    return sum(weighted(b) for d, b in by_day.items() if d >= cutoff) / 1e6
+
+
+def calibration() -> list[dict]:
+    if CALIBRATION.is_file():
+        try:
+            return json.loads(CALIBRATION.read_text()).get("observations", [])
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    return []
+
+
+def estimate_pct(week_m: float) -> tuple[float, int] | None:
+    """Estimated % of the weekly meter consumed, from calibration.
+
+    Anthropic publishes NO absolute number for a subscription meter -- only a
+    percentage bar in Settings -> Usage (see the COO design doc). So the ceiling
+    cannot be a token count anybody can look up, and inventing one would be
+    worse than none: it would get wired into this gate and then believed.
+
+    Instead a human reads the real bar and tells this tool once:
+
+        ops/usage.py --calibrate 62
+
+    which records (trailing-7-day weighted M, observed %). Full scale is then
+    weighted_per_pct * 100, and today's estimate follows. More observations
+    average out; each is only as good as the moment it was read.
+    """
+    obs = [o for o in calibration() if o.get("percent", 0) > 0 and o.get("week_m", 0) > 0]
+    if not obs:
+        return None
+    per_pct = sum(o["week_m"] / o["percent"] for o in obs) / len(obs)
+    if per_pct <= 0:
+        return None
+    return week_m / per_pct, len(obs)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--check", action="store_true", help="exit 1 if today is over the ceiling")
+    ap.add_argument("--check", action="store_true", help="exit 1 if over the threshold")
     env = os.environ.get("OPS_USAGE_CEILING_M")
     ap.add_argument("--ceiling", type=float, default=float(env) if env else None,
                     help="daily ceiling, millions of weighted tokens")
+    tenv = os.environ.get("OPS_USAGE_THRESHOLD_PCT")
+    ap.add_argument("--threshold-pct", type=float, default=float(tenv) if tenv else None,
+                    help="refuse to dispatch above this %% of the weekly meter")
+    ap.add_argument("--calibrate", type=float, metavar="PCT",
+                    help="record the %% shown in Settings -> Usage right now")
     args = ap.parse_args()
 
-    by_day, by_session, sub_share = scan()
+    by_day, by_session, sub_share, by_role, by_branch, day_attr, turn_cost = scan()
     today = date.today().isoformat()
     today_w = weighted(by_day.get(today, {})) / 1e6
+    week_m = rolling_week_m(by_day)
+
+    if args.calibrate is not None:
+        obs = calibration()
+        obs.append({"observed_at": datetime.now().isoformat(timespec="seconds"),
+                    "percent": args.calibrate, "week_m": round(week_m, 2)})
+        CALIBRATION.write_text(json.dumps({"observations": obs}, indent=2) + "\n")
+        print(f"calibrated: {week_m:.1f}M trailing-7d == {args.calibrate:.0f}% of the weekly meter")
+        print(f"  implied full scale ~{week_m / args.calibrate * 100:.0f}M weighted")
+        print(f"  {len(obs)} observation(s) on file. This is a PROXY, not the meter.")
+        return 0
 
     if args.check:
-        # No invented ceiling. Until the CEO sets one from the real plan limit
-        # this reports and passes -- a fake gate is worse than none, because it
-        # would be tuned around rather than believed.
-        if args.ceiling is None:
-            print(f"usage: {today_w:.1f}M weighted today. NO CEILING SET "
-                  f"(export OPS_USAGE_CEILING_M) -- reporting only, not gating.")
+        est = estimate_pct(week_m)
+        # Percentage gate first: it is the one that can exist, because
+        # Anthropic publishes a percentage and never a number.
+        if args.threshold_pct is not None and est is not None:
+            pct, n = est
+            over = pct > args.threshold_pct
+            print(f"usage: ~{pct:.0f}% of the weekly meter (est. from {n} calibration"
+                  f"{'s' if n != 1 else ''}), threshold {args.threshold_pct:.0f}% "
+                  f"-- {'OVER, do not dispatch' if over else 'ok to dispatch'}")
+            return 1 if over else 0
+        if args.threshold_pct is not None and est is None:
+            print(f"usage: threshold {args.threshold_pct:.0f}% set but NO CALIBRATION "
+                  f"-- cannot convert {week_m:.1f}M weighted into a percentage.")
+            print("  Read Settings -> Usage and run: ops/usage.py --calibrate <pct>")
+            print("  NOT gating: refusing to invent the conversion.")
             return 0
-        over = today_w > args.ceiling
-        print(f"usage: {today_w:.1f}M weighted today, ceiling {args.ceiling:.0f}M "
-              f"-- {'OVER, do not dispatch' if over else 'ok to dispatch'}")
-        return 1 if over else 0
+        if args.ceiling is not None:
+            over = today_w > args.ceiling
+            print(f"usage: {today_w:.1f}M weighted today, ceiling {args.ceiling:.0f}M "
+                  f"-- {'OVER, do not dispatch' if over else 'ok to dispatch'}")
+            return 1 if over else 0
+        print(f"usage: {today_w:.1f}M today, {week_m:.1f}M trailing-7d. NO GATE SET "
+              f"(OPS_USAGE_THRESHOLD_PCT + --calibrate) -- reporting only.")
+        return 0
 
     cap = f"Ceiling {args.ceiling:.0f}M/day." if args.ceiling else "No ceiling set."
     print(f"Claude usage -- weighted tokens (millions). {cap}\n")
@@ -143,16 +319,69 @@ def main() -> int:
         print(f"{day:<12}{tot:>9.1f}{b.get('output_tokens',0)/1e6:>10.2f}"
               f"{b.get('cache_read_input_tokens',0)/1e6:>11.1f}{pct:>10.0f}%{flag}")
 
-    rmap = roles()
-    print(f"\nTop sessions (weighted M):")
-    top = sorted(by_session.items(), key=lambda kv: -weighted(kv[1]))[:8]
-    for sid, b in top:
-        role = rmap.get(sid, "unattributed")
-        print(f"  {weighted(b)/1e6:>7.1f}  {sid[:8]}  {role}")
+    est = estimate_pct(week_m)
+    if est:
+        pct, n = est
+        print(f"\nWeekly meter: ~{pct:.0f}% consumed "
+              f"({week_m:.1f}M trailing-7d, est. from {n} calibration{'s' if n != 1 else ''})")
+    else:
+        print(f"\nWeekly meter: NOT MEASURED -- {week_m:.1f}M trailing-7d, no calibration.")
+        print("  Anthropic publishes a percentage, never a number. Read Settings -> Usage")
+        print("  and run: ops/usage.py --calibrate <pct>")
 
-    if not rmap:
-        print(f"\n  NOTE: no {ROLE_MAP.name} -- per-role attribution is NOT MEASURED.")
-        print("  Add {\"<session-uuid>\": \"<role>\"} entries to attribute spend by department.")
+    total = sum(weighted(b) for b in by_role.values())
+    attributed = total - weighted(by_role.get("unattributed", {}))
+    print(f"\nBy role (weighted M, all time) -- attribution DERIVED from branch lane, "
+          f"then worktree:")
+    for role, b in sorted(by_role.items(), key=lambda kv: -weighted(kv[1])):
+        w = weighted(b) / 1e6
+        share = (weighted(b) / total * 100) if total else 0
+        print(f"  {w:>8.1f}  {share:>5.1f}%  {role}")
+    cov = (attributed / total * 100) if total else 0
+    print(f"  coverage: {cov:.0f}% attributed. Unattributed is mostly pre-worktree "
+          f"history, not a live gap -- see the trend below.")
+
+    print(f"\nAttribution coverage by day -- is the derivation actually working?")
+    for day in sorted(by_day):
+        dt = weighted(by_day[day])
+        da = weighted(day_attr.get(day, {}))
+        if dt <= 0:
+            continue
+        pc = da / dt * 100
+        bar = "#" * int(pc / 5)
+        print(f"  {day}  {dt/1e6:>7.1f}M  {pc:>5.1f}%  {bar}")
+    print("  Rising, because branch and worktree discipline is what makes a turn")
+    print("  attributable. Early history predates both and can never be recovered.")
+
+    # The optimisation, MEASURED and re-measured every run rather than asserted
+    # once in a design doc. Per-turn controls for scope: a cheap PR and an
+    # expensive one both pay the context tax on every single turn.
+    if turn_cost:
+        print("\nCost per turn -- the context-carry tax, measured:")
+        for label in ("main-thread", "dispatched subagent"):
+            n, w = turn_cost.get(label, (0, 0.0))
+            if n:
+                print(f"  {label:22} {n:>6} turns  {w/n/1000:>7.1f}k weighted/turn")
+        mt = turn_cost.get("main-thread", (0, 0.0))
+        ds = turn_cost.get("dispatched subagent", (0, 0.0))
+        if mt[0] and ds[0]:
+            ratio = (mt[1] / mt[0]) / (ds[1] / ds[0])
+            print(f"  -> delegating is {ratio:.1f}x cheaper PER TURN.")
+        print("  Weighted cost is ~90% cache read + cache creation, ~4-10% output:")
+        print("  cost is dominated by CARRYING CONTEXT, not by generating text.")
+        print("  NOTE: these weights model token CLASSES, not model prices. A")
+        print("  Sonnet subagent is additionally cheaper per token, so the real")
+        print("  saving is larger than the ratio above, by an amount not modelled.")
+
+    # THE BLIND SPOT, stated where it cannot be missed rather than in a footnote.
+    print("\n" + "=" * 68)
+    print("  THIS NUMBER IS A FLOOR, NOT A MEASUREMENT.")
+    print("  Cloud / scheduled agents run on Anthropic's infrastructure and")
+    print("  write their transcripts server-side. They never touch this disk, so")
+    print("  they are ABSENT here -- not undercounted, absent, with no signal.")
+    print("  Whether they draw on the same subscription meters is UNVERIFIED.")
+    print("  Report this caveat with the figure, every time.")
+    print("=" * 68)
     return 0
 
 


### PR DESCRIPTION
Closes #79.

## Why the ceiling is a percentage, not a number

**Anthropic publishes no absolute figure for any subscription meter** — the UI is percentage bars, and there is no endpoint to read them. So an absolute token ceiling could only ever be a locally-inferred guess that later gets mistaken for an Anthropic figure.

Instead the CEO sets `OPS_USAGE_THRESHOLD_PCT`, and weighted tokens convert to a percentage by calibration: a human reads the real bar once and runs `ops/usage.py --calibrate <pct>`.

With a threshold set and no calibration, **the gate refuses to invent the conversion** and says so:

```
usage: threshold 80% set but NO CALIBRATION -- cannot convert 513.2M into a percentage.
  Read Settings -> Usage and run: ops/usage.py --calibrate <pct>
  NOT gating: refusing to invent the conversion.
```

All four paths verified: no threshold → reports; threshold without calibration → refuses to gate, exit 0; calibrated and under → `ok to dispatch`, exit 0; calibrated and over → `do not dispatch`, exit 1.

## Attribution is derived — a deliberate departure from the design doc

The doc recommended **(b)**, a hand-maintained `{session: role}` file, and named its weakness: an ongoing discipline cost that decays without enforcement. Two facts found while building it changed the call:

1. **Every usage-bearing transcript entry already carries `gitBranch` and `cwd`** — 511/511 on the sample checked. The data was already there.
2. **A session is not one role.** This session alone spanned **seven branches**, including reviewing and fixing work on another role's branch. A session-level map would have booked all of that to one role and been confidently wrong.

So attribution is derived **per turn** from the branch lane, falling back to the worktree (ADR-0006 gives each role its own). No maintenance, applies retroactively, and keyed on the **lane** rather than the literal registry prefix — matching `feat/ops/` missed every `fix/ops/` and `docs/ops/` branch.

Coverage is reported so the derivation can be **checked rather than trusted**:

```
2026-07-26    164.5M   17.0%  ###
2026-07-27    113.8M   56.4%  ###########
2026-07-30     17.1M   63.0%  ############
2026-07-31     10.9M   94.6%  ##################
```

Rising as branch and worktree discipline took hold. Early history predates both and is honestly unrecoverable — 32% all-time, and I have not dressed that up.

## The optimisation, measured

**Delegating is 3.9x cheaper per turn** — 59.7k weighted/turn on the main thread against 15.3k in a dispatched subagent. Per-turn controls for scope: a cheap PR and an expensive one both pay the context tax on every turn.

Composition confirms the design doc's ranking with real numbers: **~90% of weighted cost is cache read + cache creation, only 4–10% is output.** Cost is dominated by *carrying context*, not by generating text — so context hygiene is the dominant lever and output-trimming is the smallest term.

Re-measured on every run rather than asserted once. **Stated limit:** these weights model token *classes*, not model *prices*, so the real saving is larger than 3.9x by an amount not modelled.

## The blind spot is now loud

Cloud/scheduled agents write transcripts server-side and are **absent** here — not undercounted, absent. Every total is a **floor**. A banner says so on every run, and `dispatch.sh` repeats it, because a partial number passed off as a complete one is worse than no number.

## One thing I nearly shipped

While testing the gate I calibrated with an invented `62%` — and that wrote a real-looking observation to disk. **Deleted, and `usage-calibration.json` is now gitignored**: it is machine- and plan-specific, and a fabricated value committed there would be silently trusted as a genuine reading. That is the precise failure this whole design is built to avoid, and I nearly committed it while building the defence against it.

## Acceptance criteria

- [x] Reported spend states at the board that it excludes cloud agents — banner on every run
- [x] A gate that works without an absolute number — CEO percentage + calibrated proxy
- [x] Per-role attribution with limits stated — derived, coverage reported, 94% current
- [x] At least one optimisation measured — 3.9x per-turn, with the confound named

**This unblocks #38's last criterion**, which was waiting on per-role cost before cron could be switched on.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
