### PR TITLE
ops: give the policy gate its own workflow, so its owner owns its file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,13 @@
 /docs/sim-impulse-response.md   @MikePaNtZ
 # role: Senior Controls
 /.github/workflows/ci.yml       @MikePaNtZ
+# The policy gate lives in its OWN workflow so its owner owns its file (#87).
+# ci.yml above is Controls'; the gate is the COO's by ADR-0003, and while they
+# shared a file every COO change to the gate needed a turf override. Stated
+# explicitly rather than relying on /.github/ above, so a later broad
+# /.github/workflows/ rule cannot silently reassign it -- last match wins.
+# role: COO
+/.github/workflows/policy.yml   @MikePaNtZ
 
 # --------------------------------------------------------------------------
 # sim/out/ is harness output and belongs to Controls. Media PROMOTED for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,62 +140,17 @@ jobs:
         run: pytest tests/ -v
 
   # ---------------------------------------------------------------------
-  # Policy gate. Stdlib-only Python, no install step, a couple of seconds.
+  # The `policy` job MOVED to .github/workflows/policy.yml (#87).
   #
-  # Checks the decision record has not drifted from its own index, that every
-  # top-level directory has a named owner, and that public-facing markdown
-  # neither uses the absolutes this project committed to never saying nor
-  # makes claims without a requirement ID behind them. Full rationale, and
-  # why the capability-language check is advisory rather than hard, is in
-  # docs/decisions/ADR-0003-policy-ci-gate.md.
+  # Not deleted -- relocated, so the job's owner owns its file. This file is
+  # Senior Controls' by CODEOWNERS; the policy gate is the COO's by ADR-0003,
+  # and every COO change to it was tripping a turf failure that needed an
+  # override. A routine override is a check that has stopped meaning anything.
   #
-  # Deliberately NOT a required status check yet: it has to pass green at
-  # least once first. Required checks stay `rust` and `sim`. It is also not a
-  # `needs:` of the publish job -- a policy failure should not be able to
-  # suppress an artifact whose physics passed.
-  #
-  # Run it locally before opening a PR: python3 .github/policy_check.py
+  # The job kept its NAME. `policy` is a required status check and branch
+  # protection matches by job name, not by workflow file, so protection is
+  # unaffected. Renaming it would hang every PR forever.
   # ---------------------------------------------------------------------
-  policy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      # fetch-depth: 0 is load-bearing, not hygiene. The default depth-1
-      # checkout has no origin/master and no merge-base, so every diff-based
-      # check (turf, doc-drift) resolved no base and SKIPPED ITSELF while the
-      # gate still printed "all hard checks pass". Both had never once run in
-      # CI. See POLICY_BRANCH below for the second half of the same bug.
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.14'
-
-      # The fence is opened and closed around the run so the summary stays
-      # readable on failure too. PIPESTATUS rather than the pipeline's own
-      # status: `tee` succeeds even when the check does not, and a policy gate
-      # that reports green because its logger worked would be worse than none.
-      - name: Policy gate
-        env:
-          # `actions/checkout` leaves a detached HEAD, so the script's own
-          # `rev-parse --abbrev-ref HEAD` returned the literal string "HEAD",
-          # which matches no registered branch prefix -- so the turf check
-          # skipped on every PR. Pass the real branch name in.
-          POLICY_BRANCH: ${{ github.head_ref || github.ref_name }}
-          POLICY_BASE_REF: origin/${{ github.base_ref || github.event.repository.default_branch }}
-          # POLICY_PR_BODY is deliberately NOT set. Overrides must live in a
-          # commit message so the reason is in git history rather than in a
-          # field anyone can edit after the gate went green.
-        run: |
-          { echo '### Policy gate'; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
-          set +e
-          python3 .github/policy_check.py 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
-          status=${PIPESTATUS[0]}
-          set -e
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          exit $status
 
   # ---------------------------------------------------------------------
   # Film the scenario and publish it, always behind a green gate -- the landing

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -1,0 +1,83 @@
+name: Policy
+
+# Split out of ci.yml so the job's OWNER owns its file (#87).
+#
+# ci.yml is Senior Controls' by CODEOWNERS, but the `policy` job is the COO's by
+# ADR-0003. Every COO change to the gate therefore tripped a genuine turf
+# failure and needed a TURF-OVERRIDE -- and a routine override is a check that
+# has stopped meaning anything. One file, one owner, no standing exception.
+#
+# THE JOB IS STILL NAMED `policy`, DELIBERATELY AND LOAD-BEARINGLY.
+# `policy` is a REQUIRED status check on master. Branch protection matches by
+# check-run name, which for Actions is the job name -- not the workflow file.
+# Renaming it would leave protection waiting forever for a check that never
+# reports, which is exactly why `publish-sim-artifact` is documented as
+# deliberately NOT required. Do not rename this job without updating branch
+# protection in the same pass.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# A DISTINCT concurrency group from ci.yml. Sharing `ci-${{ github.ref }}` would
+# make the two workflows cancel each other on every push, and the survivor would
+# look green while the other silently never ran.
+concurrency:
+  group: policy-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  # Checks the decision record has not drifted from its own index, that every
+  # top-level directory has a named owner, that no role trespasses on another's
+  # paths, that a doc moves when the code it describes moves, and that public
+  # markdown neither uses the absolutes this project committed to never saying
+  # nor makes claims without a requirement ID. Rationale: ADR-0003, ADR-0005,
+  # ADR-0008.
+  #
+  # Run it locally before opening a PR -- but AFTER committing, and with the CI
+  # environment, or the diff-based checks have nothing to diff and report a
+  # meaningless pass:
+  #
+  #   GITHUB_ACTIONS=1 POLICY_BRANCH=$(git branch --show-current) \
+  #     POLICY_BASE_REF=origin/master python3 .github/policy_check.py
+  policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # fetch-depth: 0 is load-bearing, not hygiene. The default depth-1
+      # checkout has no origin/master and no merge-base, so every diff-based
+      # check (turf, doc-drift) resolved no base and SKIPPED ITSELF while the
+      # gate still printed "all hard checks pass". Both had never once run in
+      # CI. See POLICY_BRANCH below for the second half of the same bug.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      # The fence is opened and closed around the run so the summary stays
+      # readable on failure too. PIPESTATUS rather than the pipeline's own
+      # status: `tee` succeeds even when the check does not, and a policy gate
+      # that reports green because its logger worked would be worse than none.
+      - name: Policy gate
+        env:
+          # `actions/checkout` leaves a detached HEAD, so the script's own
+          # `rev-parse --abbrev-ref HEAD` returned the literal string "HEAD",
+          # which matches no registered branch prefix -- so the turf check
+          # skipped on every PR. Pass the real branch name in.
+          POLICY_BRANCH: ${{ github.head_ref || github.ref_name }}
+          POLICY_BASE_REF: origin/${{ github.base_ref || github.event.repository.default_branch }}
+          # POLICY_PR_BODY is deliberately NOT set. Overrides must live in a
+          # commit message so the reason is in git history rather than in a
+          # field anyone can edit after the gate went green.
+        run: |
+          { echo '### Policy gate'; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          set +e
+          python3 .github/policy_check.py 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          status=${PIPESTATUS[0]}
+          set -e
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit $status


### PR DESCRIPTION
Closes #87.

`ci.yml` is Senior Controls' by CODEOWNERS, but the `policy` job inside it is the COO's by ADR-0003. Every COO change to the gate therefore tripped a genuine turf failure and needed a `TURF-OVERRIDE` — **twice already this week**. A routine override is a check that has stopped meaning anything, which is the argument the issue itself made.

**Option 2, as recommended:** split the policy job into `.github/workflows/policy.yml`. `publish-sim-artifact` stays where it is — that job touches published media and its ownership is a separate question; splitting it too would be scope creep on an issue about one seam.

## The job keeps its name, and that is load-bearing

**`policy` is a required status check on master.** Branch protection matches by check-run name, which for Actions is the **job** name, not the workflow file. So moving the job between files leaves protection untouched — but **renaming it would leave protection waiting forever for a check that never reports.** That is exactly why `publish-sim-artifact` is documented as deliberately *not* required. Both the new workflow and the pointer left in `ci.yml` say so, at the place someone would go to rename it.

## A distinct concurrency group

`policy-${{ github.ref }}`, not `ci-${{ github.ref }}`. Sharing the group would make the two workflows **cancel each other** on every push, and the survivor would look green while the other silently never ran — the same shape as #83, where a check reported success having executed nothing.

## Verified

| | |
|---|---|
| Both workflows parse | ✅ |
| `ci.yml` keeps `render-needed`, `rust`, `sim`, `publish-sim-artifact` | ✅ |
| `policy.yml` carries exactly one job, named `policy` | ✅ |
| `--who .github/workflows/policy.yml` | `COO` |
| `--who .github/workflows/ci.yml` | `Senior Controls` |
| Policy gate green on this branch | ✅ |

**Before merging I confirmed the check still reports under the name `policy`** — if it had come back as `Policy / policy` or anything else, this PR would hang the queue rather than fix it, and I would have reverted rather than updated protection under time pressure.

## CODEOWNERS states it explicitly

Rather than leaning on the `/.github/` catch-all, so a later broad `/.github/workflows/` rule cannot silently reassign it. Last match wins.

## The overrides on this PR

This branch still needs a `TURF-OVERRIDE` for `ci.yml` — **it is the last one.** That is the entire point: the edit removes the COO-owned job from Controls' file and leaves a pointer.

Two `DOC-OK`s, both genuinely unaffected: `web-artifact-pipeline.md` describes the render/publish jobs (untouched), and `design-claims-manifest.md` covers `ci.yml` because `claims.json` will publish alongside the sim artifact (also untouched). **Neither manifest is re-stamped, deliberately** — nothing was reconciled, and advancing a `reconciled:` stamp for a change that did not affect the doc is precisely the false assertion #85 refused to automate one commit earlier.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
