### PR TITLE
ops: dispatch reaches all three repos, so marketing's work is routable

### DIFF
--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -10,6 +10,21 @@
 # Exits non-zero and explains itself if dispatching now would be unsafe.
 set -uo pipefail
 
+# --- The estate ------------------------------------------------------------
+# ALL THREE REPOS, not just the one this script happens to sit in (#103).
+#
+# This used to run a bare `gh issue list` after cd-ing to the repo root, so it
+# polled exactly one repo of three. Work filed in overboard-web or
+# overboard-viz was labelled, routable in principle, and in no queue anything
+# could see. Worse, --audit asserted "every open issue carries exactly one
+# role: label" and reported green while auditing a third of the estate -- the
+# same reports-green-while-enforcing-nothing failure this script's own comments
+# were written to disown, committed by the script itself.
+#
+# ROLES.md already declares its registry covers all three. The actuator now
+# matches the registry.
+REPOS=(${OPS_REPOS:-MikePaNtZ/overboard MikePaNtZ/overboard-web MikePaNtZ/overboard-viz})
+
 # --- 0. Routing integrity -------------------------------------------------
 # Every open issue must carry EXACTLY ONE role: label. Zero labels means the
 # issue is invisible to every cron -- nobody polls it and it is not "backlog",
@@ -20,24 +35,35 @@ set -uo pipefail
 # A hard error, never a silent skip. This week produced two checks that
 # reported green while enforcing nothing; this is not going to be the third.
 audit_routing() {
-  local bad=0 line num labels count
-  while IFS=$'\t' read -r num labels; do
-    [ -n "$num" ] || continue
-    if [ -z "$labels" ]; then count=0; else count="$(tr ',' '\n' <<<"$labels" | grep -c '^role:')"; fi
-    if [ "$count" -ne 1 ]; then
-      echo "  ROUTING ERROR: issue #${num} has ${count} role: labels (need exactly 1) [${labels}]"
+  local bad=0 seen=0 repo num labels count out
+  for repo in "${REPOS[@]}"; do
+    # A repo we cannot read is a repo whose issues are invisible. That is the
+    # exact condition this audit exists to detect, so it is a hard error rather
+    # than a skipped line -- otherwise a typo'd repo name reads as "all clear".
+    if ! out="$(gh issue list --repo "$repo" --state open --limit 200 \
+                  --json number,labels \
+                  --jq '.[] | "\(.number)\t\([.labels[].name] | join(","))"' 2>&1)"; then
+      echo "  ROUTING ERROR: cannot read issues in ${repo} -- ${out%%$'\n'*}"
       bad=$((bad + 1))
+      continue
     fi
-  done < <(gh issue list --state open --limit 200 \
-             --json number,labels \
-             --jq '.[] | "\(.number)\t\([.labels[].name] | join(","))"')
+    while IFS=$'\t' read -r num labels; do
+      [ -n "$num" ] || continue
+      seen=$((seen + 1))
+      if [ -z "$labels" ]; then count=0; else count="$(tr ',' '\n' <<<"$labels" | grep -c '^role:')"; fi
+      if [ "$count" -ne 1 ]; then
+        echo "  ROUTING ERROR: ${repo}#${num} has ${count} role: labels (need exactly 1) [${labels}]"
+        bad=$((bad + 1))
+      fi
+    done <<<"$out"
+  done
   if [ "$bad" -gt 0 ]; then
-    echo "REFUSED: ${bad} open issue(s) are unroutable."
+    echo "REFUSED: ${bad} routing problem(s)."
     echo "         An unlabelled issue is invisible to every poll. Label it, or"
     echo "         close it -- but do not leave it looking like backlog."
     return 1
   fi
-  echo "routing: every open issue carries exactly one role: label"
+  echo "routing: ${seen} open issue(s) across ${#REPOS[@]} repo(s), each with exactly one role: label"
   return 0
 }
 
@@ -169,20 +195,44 @@ ROLE_SLUG="$(printf '%s' "$ROLE" \
   | sed -E -e 's/[^a-z0-9]+/-/g' -e 's/^-+//' -e 's/-+$//')"
 LABEL="role:${ROLE_SLUG}"
 
-if ! gh label list --limit 100 --json name --jq '.[].name' | grep -qx "$LABEL"; then
-  fail "no '${LABEL}' label exists. The router cannot address ${ROLE}.
-         Labels are the routing field -- see #38. Create it before dispatching."
+# The label has to exist in EVERY repo, not just this one. A role addressable
+# in overboard and not in overboard-web is a role whose marketing work can
+# never be routed -- which is the state #103 found: neither marketing repo had
+# role: labels at all until the CMO mirrored them.
+MISSING=()
+for repo in "${REPOS[@]}"; do
+  gh label list --repo "$repo" --limit 100 --json name --jq '.[].name' 2>/dev/null \
+    | grep -qx "$LABEL" || MISSING+=("$repo")
+done
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  fail "no '${LABEL}' label in: ${MISSING[*]}
+         The router cannot address ${ROLE} there, so any issue filed in those
+         repos is unroutable no matter how it is labelled. Labels are the
+         routing field -- see #38, #103. Create it before dispatching."
 fi
 
 echo
-echo "  QUEUE for ${ROLE}  (poll: gh issue list --label \"${LABEL}\" --state open)"
-QUEUE="$(gh issue list --state open --label "$LABEL" --limit 50 \
-           --json number,title --jq '.[] | "    #\(.number)  \(.title)"')"
-if [ -z "$QUEUE" ]; then
-  echo "    (empty -- nothing routed to this role)"
-else
-  echo "$QUEUE"
-fi
+echo "  QUEUE for ${ROLE}  (poll: gh issue list -R <repo> --label \"${LABEL}\" --state open)"
+# No `2>/dev/null` here, deliberately. The first version had one, plus a
+# `gh ... --jq --arg` that gh does not support -- gh has no --arg flag. The
+# error went to the suppressed stderr and every marketing queue printed
+# "(empty)" while two labelled issues sat in overboard-web. A silenced error
+# reported as an empty queue is indistinguishable from no work, which is the
+# whole failure #103 is about. The repo name is prefixed in bash instead.
+FOUND=0
+for repo in "${REPOS[@]}"; do
+  if ! Q="$(gh issue list --repo "$repo" --state open --label "$LABEL" --limit 50 \
+              --json number,title --jq '.[] | "#\(.number)  \(.title)"')"; then
+    fail "cannot read ${repo}'s queue. Refusing to report an empty queue for a
+         repo that failed to answer -- that is indistinguishable from no work."
+  fi
+  while IFS= read -r ln; do
+    [ -n "$ln" ] || continue
+    echo "    ${repo#*/}${ln}"
+    FOUND=$((FOUND + 1))
+  done <<<"$Q"
+done
+[ "$FOUND" -eq 0 ] && echo "    (empty -- nothing routed to this role in any of the ${#REPOS[@]} repos)"
 
 echo
 echo "OK to dispatch as ${ROLE}. Give each agent its own worktree (isolation: worktree)."


### PR DESCRIPTION
Closes #103, filed by the CMO. **Option (a)** — one script, one queue, spanning the whole estate.

## The gap

`dispatch.sh` ran a bare `gh issue list` after `cd`-ing to the repo root, so it polled **exactly one repo of three**. Work filed in `overboard-web` or `overboard-viz` was labelled, routable in principle, and in no queue anything could see.

Worse: **`--audit` asserted "every open issue carries exactly one `role:` label" and reported green while auditing a third of the estate.** That is the reports-green-while-enforcing-nothing failure this script's own comments were written to disown — committed by the script itself. Same shape as #83, where `turf` and `doc-drift` had never once executed while the gate printed success.

## Their half was already done, and I checked rather than assumed

The CMO mirrored all eight `role:` labels into both marketing repos and labelled every open issue. Verified: **8/8 labels in each**, and web #11/#16/#18 and viz #4/#6/#10 each carry exactly one.

They were also right not to build a second actuator alongside this one — three divergent copies of a dispatcher is worse than one, which is the same reasoning that put CODEOWNERS and the policy gate under a single owner.

## What changed

- **`REPOS` list**, overridable via `OPS_REPOS`. `ROLES.md` already declares its registry covers all three repos; the actuator now matches the registry.
- **`audit_routing()` spans every repo** and reports the issue count it actually checked, so "green" is no longer compatible with having looked at one repo.
- **A repo that cannot be read is a hard error**, not a skipped line. A typo'd repo name previously would have read as all-clear.
- **The label-existence check runs per repo.** A role addressable in `overboard` but not in `overboard-web` is a role whose marketing work can never be routed — precisely the state before the CMO's mirror.

## A bug this introduced, and then caught

The first version used `gh issue list --jq --arg r ...`. **`gh` has no `--arg` flag**, so the command failed — and a `2>/dev/null` I had put on the same line sent the error nowhere. Every marketing queue printed `(empty)` while two labelled issues sat in `overboard-web`.

**A silenced error reported as an empty queue is indistinguishable from no work**, which is exactly the failure this issue is about. I nearly shipped the bug I was fixing. The suppression is gone, the repo name is prefixed in bash, and a failing queue read now refuses rather than reporting nothing to do.

## Verified

```
audit: 11 open issue(s) across 3 repo(s), each with exactly one role: label

Senior Digital Marketer    -> overboard-web#18, overboard-web#11
Digital Content Production -> overboard-viz#10, overboard-viz#6, overboard-viz#4
CMO                        -> overboard-web#16
Senior Controls            -> overboard#91, overboard#61
```

| Failure path | Result |
|---|---|
| Unreadable repo in the list | hard error, exit 1 |
| Missing label in a repo | refusal path exercised directly against all three |

Those five marketing issues are visible to the router for the first time.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
