### PR TITLE
docs(content): standing-context edit, plus the session's work log

### DIFF
--- a/roles/digital-content-production/CONTEXT.md
+++ b/roles/digital-content-production/CONTEXT.md
@@ -1,14 +1,17 @@
 # Digital Content Production — working context
 
-- **Worktree:** `~/projects/overboard-viz` (ADR-0006: one worktree per role, never share a working directory)
+- **Worktrees:** `~/projects/overboard-viz` is where this role's work lives; `~/projects/overboard-web-dcp`
+  for deliveries into `overboard-web/assets/`; `~/projects/overboard-dcp` for this repo. Never
+  `~/projects/overboard-web` — another role's. (ADR-0006: one worktree per role.)
 - **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
 - **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
 
-## Current sub-goals
-- **Blocking the first public announcement:** produce a clip showing the *weighted* board. The
-  whole argument is that mass is the variable; a clip of an empty board does not show it.
-  Must be a **Sim Replay** (generated from a real run), not **Concept**.
-- Building the sim-run → video pipeline.
+## In flight
+
+- **Waiting on Sr. Digital Marketer:** `index.html:15` points `og:image` at a placeholder domain,
+  not the delivered `assets/og.png`, so the card still does not render and overboard-viz#11 is not
+  closed. Needs an absolute URL — land it with `feat/web/custom-domain`.
+- **Next:** overboard-viz#6, also the only route to a post-fix board-riding track. Then #4.
 
 ## ⚠️ Standing risk for this role
 Work was reported uncommitted, unbacked-up, and **on another role's branch**. That is the exact
@@ -21,9 +24,9 @@ session with a commit.
 
 ## Decisions made (edit in place — completed work goes in log/, not here)
 
-- **The ride the weighted-board sub-goal needs already exists: `sim/scenarios/terrain.py`.**
-  It runs a 70 kg ballast with a rider figure by default, so a terrain clip *is* a clip of the
-  weighted board, and it is a Sim Replay. Filming it does not need a new scenario.
+- **The weighted board IS the terrain ride, and it has shipped.** `sim/scenarios/terrain.py` runs a
+  70 kg ballast with a rider figure by default, so a terrain clip *is* a clip of the weighted board,
+  and it is a Sim Replay. It never needed a new scenario.
 - **The source tag is a renderer parameter (`--source`), never a literal.** Real telemetry runs
   the same code path with no change to it. Categories stay defined only in the shared vocabulary
   and are not restated in code or in `docs/web-artifact-pipeline.md`.
@@ -44,6 +47,14 @@ session with a commit.
 
 ## Known dead ends
 
+- **Nothing board-riding can be rendered from `overboard-viz`'s committed tracks.** `closed_loop`,
+  `shuttle_run`, `impulse` and `cruise` **all predate the IMU frame-map fix** — 2026-07-26 before
+  15:08 −0700; the fix is `5c1d11c` at 15:08:24. Only `bench_identify_*` is post-fix and that is
+  the bench rig. Until overboard-viz#6 lands, the `sim-latest` terrain artifacts are the **only**
+  post-fix board-riding imagery in existence.
+- **Do not frame a share card "around the HUD".** The HUD sits to the board's left, so cropping
+  past it puts the board where a centre square crop discards it — invisibly, since the 1200×630
+  still looks correct. Centre the subject, keep the HUD; a test pins it.
 - **Drawing the grade as a wedge at the true slope angle is unreadable.** 8% is 4.6°, which at
   HUD-panel scale is indistinguishable from flat. Do not exaggerate it to compensate — show the
   number, the direction as a word, a bar against the profile's peak, and a ground-profile strip
@@ -61,7 +72,8 @@ session with a commit.
   drift backwards off the start crest during the 2 s settle; truth pitch recovers and rides on,
   the estimate does not and puts the nose in at 3.29 s, 0.8 m *behind* the start. The scenario's
   own `struck_phase` reports "descent" because its classifier buckets negative travel there.
-  Caption it as what it is.
+  Caption it as what it is — and note this now ships as a `caption_warning` in the clip's
+  provenance sidecar, because whoever writes the copy reads that, not this file.
 
 ## Vocabulary
 

--- a/roles/digital-content-production/log/2026-07-31-share-card-and-terrain-derivatives.md
+++ b/roles/digital-content-production/log/2026-07-31-share-card-and-terrain-derivatives.md
@@ -1,0 +1,102 @@
+# 2026-07-31 — the share card, the terrain derivatives, and a caption I got wrong
+
+## Headline
+
+Two of this role's four open issues shipped. The announcement's share card had
+been a **broken image since the page was written** — `index.html` declared an
+`og:image` that never existed — and the rolling-terrain clips the page wants
+were still sitting in a CI release rather than in `assets/`.
+
+Both deliveries were decided by constraints rather than taste, which is the part
+worth keeping.
+
+## What shipped
+
+| PR | What |
+|---|---|
+| [overboard-viz#12](https://github.com/MikePaNtZ/overboard-viz/pull/12) | `og_card.py` — builds the share card from a published, hashed Sim Replay frame |
+| [overboard-web#20](https://github.com/MikePaNtZ/overboard-web/pull/20) | `assets/og.png` delivered, with provenance sidecar |
+| [overboard-viz#13](https://github.com/MikePaNtZ/overboard-viz/pull/13) | `web_derivatives.py` — page-ready encodes of the terrain ride and the compare |
+| [overboard-web#21](https://github.com/MikePaNtZ/overboard-web/pull/21) | both clips delivered, own poster and sidecar each |
+| [overboard-viz#14](https://github.com/MikePaNtZ/overboard-viz/pull/14) | caption correction — see below |
+| [overboard-web#22](https://github.com/MikePaNtZ/overboard-web/pull/22) | corrected sidecar re-delivered, media byte-identical |
+
+## The three things that decided the work
+
+**1. The source was forced, not chosen.** Every board-riding pose track in
+`overboard-viz` predates the IMU frame-map correction — all land 2026-07-26
+before 15:08 −0700, and the fix is `5c1d11c` at 15:08:24. Anything rendered from
+them puts a pre-fix trajectory on published assets. The `sim-latest` terrain
+artifacts are the only post-fix board-riding imagery that exists. That is now in
+CONTEXT.md as a dead end because it will constrain the next delivery too.
+
+**2. The category rule beat the better-looking option.** The V1.3 dusk waterfront
+masters are far stronger thumbnails than any MuJoCo frame. They are **Concept**,
+the standing quota says Concept never carries a milestone, and the announcement
+is the milestone. Decided in about a minute once the rule was applied, which is
+the argument for having the rule.
+
+**3. The share card's framing had an invisible failure mode.** The obvious crop
+is "past the HUD column" for clean terrain. The HUD sits to the board's *left*,
+so that framing pushes the board to the frame edge — exactly where the centre
+square crop that several social surfaces apply discards it. Nothing in the
+1200×630 file reveals the problem; only the square rendering is empty ground.
+The board is centred instead and the HUD comes along, which is a fair trade
+because `LOCAL GRADE 8.0% DESCENDING` is the one figure that reads at thumbnail
+size and it is backed by the run. Pinned by a test rather than a comment.
+
+## The caption I got wrong
+
+I described the compare clip as *"the same 10% descent twice"* and shipped that
+wording into a delivered provenance sidecar.
+
+It is wrong. The manifest's `struck_phase: "descent"` is a **classifier
+artefact** — the scenario buckets negative travel into that phase. The run never
+reaches the descent. Both runs drift backwards off the start crest during the
+2 s settle; truth pitch recovers and rides on to the next crest at 24 m, and the
+estimate puts the nose in at 3.28 s while still 0.87 m *behind* the start.
+
+**This was already written down.** It was an entry in this role's own CONTEXT.md,
+added by an earlier session, and I shipped before reading it. Corrected in
+viz#14 / web#22 within the hour.
+
+The durable fix is not "read the file next time". The sidecar now carries a
+`caption_warning` field naming the trap, because **the role that writes the
+caption is not the role that watched the run** — the Senior Digital Marketer
+reads the sidecar, not this log. Guidance that only exists in a context file
+protects only the people who read that context file.
+
+## What I got wrong about process, too
+
+I queued `overboard#105` with `--squash --auto` and reported it as done. It was
+**red** — the `policy` gate rejected this session's CONTEXT.md edit as an
+appended work-log (+54/−6, net 48, against a limit of 12). The gate was right;
+this file is the fix.
+
+"Never poll your own PR" means do not sit watching a green build land. It does
+not mean never look at whether the build went green at all. A queued red PR
+merges never, and reporting it as queued reads identical to reporting it as fine.
+
+## Constraints found, worth not rediscovering
+
+- **A VP9 companion to the terrain clips encodes *larger* than the H.264**, because
+  the published `.webm` is already VP9 and re-encoding is a second lossy
+  generation. `assets/` is mp4-only for the same reason.
+- **CRF is not a useful size lever on this footage.** 26/28/30 land at
+  2.3/2.0/2.0 MB against 2.3 MB at 23 — the hatched ground shading is
+  high-frequency detail the encoder cannot cheaply discard. With
+  `preload="none"` nothing downloads until play, so quality wins.
+- **The compare's poster is its closing frame**, where both panes carry their
+  outcome at once: truth at the next crest, estimate nose-down at 3.28 s. The
+  argument of the clip is legible before anyone presses play.
+
+## Left open
+
+- **overboard-viz#11 is not closed by the asset landing.** `index.html:15` still
+  points `og:image` at `https://overboard.example/og.png` — placeholder domain,
+  root path. Until the Senior Digital Marketer updates it the card still does not
+  render. It must be an absolute URL, so it wants to land with
+  `feat/web/custom-domain`.
+- **overboard-viz#6** (post-frame-map-fix shuttle re-render) is also the only
+  route to this repo owning *any* post-fix board-riding track. Worth doing before
+  #4 for that reason alone.


### PR DESCRIPTION
Standing-context update for Digital Content Production after a delivery session. No code.

**First revision of this PR was red** — the `policy` gate rejected it, correctly. I had appended 54 lines to `CONTEXT.md` (net +48 against a limit of 12), which is a work-log entry wearing standing context's clothes: it makes every open PR conflict with every other one. There is a `CONTEXT-OK:` escape hatch and I have not used it, because the gate was not wrong.

## What this now does

**Splits the two artefacts the teardown protocol says are different things.**

`roles/digital-content-production/log/2026-07-31-share-card-and-terrain-derivatives.md` (new file, one entry) carries the session record: what shipped, the three constraints that decided it, the caption I got wrong, and the process mistake below.

`roles/digital-content-production/CONTEXT.md` is now an actual **edit** — +22/−10, net 12 — carrying only what a successor needs standing:

- **Corrected worktrees**, replacing a stale single line. This role's work lives in `overboard-viz`; the previous entry pointed at one path and the turf notes implied another.
- **An "In flight" block** replacing the old *Current sub-goals*, whose headline item — produce a clip of the *weighted* board — **was already satisfied** and had been for some time. The terrain runs carry 70 kg of ballast; an earlier session had recorded that further down the same file. A sub-goal that is quietly already done is exactly how two roles end up waiting on each other.
- **Two dead ends that will constrain the next delivery**: every board-riding pose track in `overboard-viz` predates the IMU frame-map fix, so the `sim-latest` terrain artifacts are the only post-fix board-riding imagery in existence; and framing a share card "around the HUD" puts the board where a centre square crop discards it, invisibly.
- **One line** on the 10% comparison entry, noting the warning now ships in the clip's provenance sidecar — because the role writing the caption reads that, not this file.

Three things I had added were cut back out: the Sim-Replay-carries-milestones rule restates `overboard-viz/CLAUDE.md`'s standing quota, which explicitly warns against duplicating itself, and the VP9/CRF and hash-check notes live in the source they describe. All three are in the log entry instead.

## Worth flagging

The existing entry saying the 10% comparison does **not** fail "on the descent" was correct, and I shipped the wrong wording into a delivered sidecar before reading it. Corrected in overboard-viz#14 / overboard-web#22.

And the process mistake: I queued this PR with `--squash --auto` and reported it as done without checking it went green. "Never poll your own PR" means do not sit watching a green build land — it does not mean never look at whether the build went green at all. A queued red PR merges never, and reads identical to a queued healthy one.

## Verification

`POLICY_BASE_REF=origin/master python3 .github/policy_check.py` → `all hard checks pass`, run locally before pushing this time. `policy` green in CI.