### PR TITLE
feat(claims-manifest): pytest marker/fixture, emit_claims.py, one real claim (#61 steps 1-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,14 @@ jobs:
       - name: Build the control library
         run: cargo build --release -p control-ffi
 
+      # Only tests that PASS contribute a claim (docs/design-claims-manifest.md,
+      # issue #61). A red run here still writes a manifest of whatever passed,
+      # but the step itself fails loudly -- this job already needs `sim` green,
+      # so a failure here means the suite is non-deterministic, not that a
+      # single claim quietly went missing.
+      - name: Emit claims manifest
+        run: python scripts/emit_claims.py
+
       - name: Render impulse scenario
         env:
           MUJOCO_GL: osmesa
@@ -381,7 +389,8 @@ jobs:
             sim/out/terrain_truth_metrics.json \
             sim/out/terrain_estimate_metrics.json \
             sim/out/terrain_render_manifest.json \
-            sim/out/sim-run.json
+            sim/out/sim-run.json \
+            sim/out/claims.json
 
       # Per-commit preview. Filenames are sha-stamped and the release is never
       # clobbered wholesale, so every commit on a long-lived feature branch

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,6 @@
 /sim/out/*
 !/sim/out/.gitkeep
 
-# Intermediate per-test claims file scripts/emit_claims.py writes during a
-# pytest run, before it is folded into sim/out/claims.json. Regenerated every
-# run, never a source of truth itself.
-/.claims_raw.json
-
 # Python
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 /sim/out/*
 !/sim/out/.gitkeep
 
+# Intermediate per-test claims file scripts/emit_claims.py writes during a
+# pytest run, before it is folded into sim/out/claims.json. Regenerated every
+# run, never a source of truth itself.
+/.claims_raw.json
+
 # Python
 __pycache__/
 *.py[cod]

--- a/roles/senior-controls/log/2026-07-31-claims-manifest-steps-1-2.md
+++ b/roles/senior-controls/log/2026-07-31-claims-manifest-steps-1-2.md
@@ -1,0 +1,78 @@
+# Claims manifest, steps 1-2: the marker/fixture, the generator, one real claim
+
+Issue #61, design `docs/design-claims-manifest.md` (COO, ratified). Implementation half is
+steps 1-2: the pytest plumbing that lets a test declare a public claim, and
+`scripts/emit_claims.py` that turns a green suite run into `claims.json`. Step 3 (the
+`overboard-web` site-side check and `data-claim` attributes) is explicitly not this — it
+needs the Senior Digital Marketer's countersign and lives in a different repo.
+
+**`tests/conftest.py`**: `@pytest.mark.claim(id, requirement=None, unit=None, gate=None)`
+plus a `record_claim` fixture. Both are required, hard-enforced two ways — a test marked
+`claim` that never even requests `record_claim` fails in `pytest_runtest_setup` before the
+body runs (no value coming either way); a test that requests it but never calls it fails in
+the fixture's teardown (`pytest.fail`, `pytrace=False`, once the test body has finished).
+Either way the suite goes red, not a soft skip — the AC is a marked-but-silent claim must
+fail, and both paths were verified to actually fail (see below), not just written to.
+`pytest_runtest_logreport`/`pytest_sessionfinish` write only claims whose test's "call" phase
+reported `passed` to `CLAIMS_RAW_PATH` (default `.claims_raw.json` at repo root, gitignored)
+at session end — a failing test's claim is absent from that file, not stale.
+
+**`scripts/emit_claims.py`**: runs `pytest` in a subprocess with `CLAIMS_RAW_PATH` pointed at
+a temp file, then folds whatever conftest wrote into the published schema (`schema`, `sha`,
+`generated_at`, `claims: {id: {value, unit, requirement, test, gate}}`), writing
+`sim/out/claims.json` by default. `sha` resolution mirrors `render_scenario.py`'s
+`source_commit()`: prefers `ARTIFACT_SHA`/`GITHUB_SHA` (a PR's `github.sha` is the ephemeral
+merge commit, not an ancestor of `master`), falls back to local `git rev-parse`. Exit code
+mirrors pytest's, so a chained `&&` step still fails on a red run even though the script
+itself always writes a (possibly smaller) manifest rather than crashing.
+
+**One real claim**: `recovery.peak-pitch` on `test_closed_loop_prevents_the_nose_strike`
+(`tests/test_closed_loop.py`) — `requirement="SR-SIM-5"`, `gate="peak_abs_pitch_deg < 3.0"`,
+recording `r.metrics.peak_abs_pitch_deg` via `record_claim`.
+
+**Assumption flagged, not silently made:** the issue text and design doc both cite this claim
+as "the README's 0.2331 m closed-loop peak pitch." That figure does not exist anywhere in
+this repo — not in `README.md` (which states no closed-loop peak-pitch number at all today),
+not in any test, not in `git log -S` history. It traces to the design doc's own illustrative
+backstory (`docs/design-claims-manifest.md`'s "problem" section), whose worked JSON example
+also labels the field `unit: "m"` while its own code sample records `peak_abs_pitch_deg` — a
+degrees value, so the example was never internally consistent as a literal number to copy.
+Fabricating `0.2331`/`"m"` into a real claim would have hardcoded exactly the failure mode
+this whole mechanism exists to prevent: a claim value not actually produced by a green test.
+Recorded the real, currently-measured value instead (`0.878 deg` at last run), with the
+honest unit (`deg`), off the exact test/metric the design doc's own example names
+(`test_closed_loop_prevents_the_nose_strike` / `peak_abs_pitch_deg`). `gate` is not in the
+issue's literal 3-arg marker spec (`id, requirement=, unit=`) but is in the published schema
+(the design doc's JSON example carries it); added it as a fourth optional marker kwarg rather
+than leaving the field permanently null.
+
+**CI**: `.github/workflows/ci.yml`'s `publish-sim-artifact` job (already Senior Controls'
+turf) gets one new step, "Emit claims manifest" (`python scripts/emit_claims.py`), placed
+after the control-ffi build the closed-loop tests need and before the render steps; and
+`sim/out/claims.json` was added to the existing `gh release upload sim-latest --clobber`
+file list. No second publish mechanism — same job, same rolling release, same pattern the
+sim artifact already uses, per the design doc's own instruction not to invent one.
+
+**Deliberate violation, shown failing, not asserted:** temporarily changed the gate's
+assertion to an impossible threshold (`< 0.0`) and re-ran `scripts/emit_claims.py`. Full
+before/after transcript in the PR body. Confirmed both: (1) the specific claim disappears
+from `claims.json` (`"claims": {}`) while 257 other tests still pass, and (2) the run's exit
+code goes non-zero, so a real CI step would go red. Also smoke-tested the
+"marked-but-never-requests-`record_claim`" path with a throwaway test file outside `tests/`
+— fails at setup with the expected message. Reverted the violation; re-ran clean (258 passed,
+2 xfailed, same as before touching anything).
+
+**Left out, flagged rather than fixed:** the requirement-register mirror (design doc's
+option 1, "follow-up not precondition") — untouched, per the design doc's own sequencing and
+this issue's scope (steps 1-2 only). `overboard-web`/`check_page.py`/`data-claim` (step 3) —
+untouched, different repo, needs the Senior Digital Marketer.
+
+Verified: `PATH="$HOME/.cargo/bin:/usr/sbin:/sbin:$PATH" .venv/bin/python -m pytest tests/ -q`
+→ 258 passed, 2 xfailed (no regressions). `cargo build --release -p control-ffi` built clean
+first. `cargo fmt --all -- --check` clean (no Rust files touched). `python3
+.github/policy_check.py --who` confirms every edited path (`tests/conftest.py`,
+`tests/test_closed_loop.py`, `scripts/emit_claims.py`, `.github/workflows/ci.yml`) is Senior
+Controls' turf; `docs/design-claims-manifest.md` (COO's) was read, not edited.
+
+PR #TBD, references #61 (does not close it — step 3 remains open, and #61 is not fully closed
+until that lands with the Digital Marketer's countersign).

--- a/scripts/emit_claims.py
+++ b/scripts/emit_claims.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Run the pytest suite and emit `claims.json` from what actually passed.
+
+Design: `docs/design-claims-manifest.md` (issue #61, steps 1-2). A "claim" is
+a `{value, unit, requirement, test, gate}` record a test pins with
+`@pytest.mark.claim(...)` and `tests/conftest.py`'s `record_claim` fixture.
+**A claim with no green test is not in the file.** That absence is the whole
+mechanism -- the site cannot state something engineering is not currently
+proving, and a failing (or deleted, or never-existing) test drops its claim
+silently rather than publishing a stale number.
+
+    scripts/emit_claims.py                          # runs `pytest tests/`, writes sim/out/claims.json
+    scripts/emit_claims.py --output claims.json      # write somewhere else
+    scripts/emit_claims.py -- -k test_closed_loop    # extra args pass through to pytest
+
+Exit status mirrors pytest's: a red suite still emits a manifest (of whatever
+passed), but the script's own exit code stays non-zero so a CI step chaining
+on `&&` will not treat a partially-red run as success.
+
+CI cannot verify a `requirement` id resolves to anything -- the requirement
+register lives in Notion and ADR-0003 forbids the gate from querying it. That
+field is carried through as a label, not checked here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = REPO_ROOT / "sim" / "out" / "claims.json"
+DEFAULT_RAW_PATH = REPO_ROOT / ".claims_raw.json"
+SCHEMA_VERSION = 1
+
+
+def resolve_sha() -> str | None:
+    """The commit the manifest was generated from, short form.
+
+    Preference order matches `scripts/render_scenario.py::source_commit`: CI
+    passes the head sha explicitly (a `pull_request` build's `github.sha` is
+    the ephemeral merge commit, which is not an ancestor of anything), and
+    only falls back to a local `git rev-parse` off that.
+    """
+    sha = os.environ.get("ARTIFACT_SHA") or os.environ.get("GITHUB_SHA")
+    if not sha:
+        try:
+            sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except Exception:
+            return None
+    return sha[:7] if sha else None
+
+
+def run_suite(raw_path: Path, pytest_args: list[str]) -> int:
+    """Runs pytest in a subprocess with CLAIMS_RAW_PATH pointed at `raw_path`,
+    so `tests/conftest.py` writes the passing claims there at session end."""
+    raw_path.unlink(missing_ok=True)
+    env = dict(os.environ)
+    env["CLAIMS_RAW_PATH"] = str(raw_path)
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", *pytest_args],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    return result.returncode
+
+
+def build_manifest(raw_path: Path) -> dict:
+    raw: dict = json.loads(raw_path.read_text()) if raw_path.exists() else {}
+    claims = {}
+    for data in raw.values():
+        claims[data["id"]] = {
+            "value": data["value"],
+            "unit": data["unit"],
+            "requirement": data["requirement"],
+            "test": data["test"],
+            "gate": data["gate"],
+        }
+    return {
+        "schema": SCHEMA_VERSION,
+        "sha": resolve_sha(),
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "claims": claims,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output", type=Path, default=DEFAULT_OUTPUT,
+        help=f"where to write claims.json (default: {DEFAULT_OUTPUT.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--raw-path", type=Path, default=DEFAULT_RAW_PATH,
+        help="intermediate per-test claims file the pytest run writes (default: repo-root .claims_raw.json)",
+    )
+    parser.add_argument(
+        "pytest_args", nargs=argparse.REMAINDER,
+        help="extra args forwarded to pytest (default: tests/ -q)",
+    )
+    args = parser.parse_args()
+
+    pytest_args = [a for a in args.pytest_args if a != "--"] or ["tests/", "-q"]
+
+    suite_exit = run_suite(args.raw_path, pytest_args)
+
+    manifest = build_manifest(args.raw_path)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    n = len(manifest["claims"])
+    print(f"wrote {n} claim{'s' if n != 1 else ''} to {args.output}")
+
+    return suite_exit
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/emit_claims.py
+++ b/scripts/emit_claims.py
@@ -29,12 +29,15 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT = REPO_ROOT / "sim" / "out" / "claims.json"
-DEFAULT_RAW_PATH = REPO_ROOT / ".claims_raw.json"
+# Outside the repo tree on purpose -- an intermediate handoff file, never a
+# source of truth, needs no .gitignore entry to avoid polluting `git status`.
+DEFAULT_RAW_PATH = Path(tempfile.gettempdir()) / "overboard-claims-raw.json"
 SCHEMA_VERSION = 1
 
 
@@ -102,7 +105,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--raw-path", type=Path, default=DEFAULT_RAW_PATH,
-        help="intermediate per-test claims file the pytest run writes (default: repo-root .claims_raw.json)",
+        help=f"intermediate per-test claims file the pytest run writes (default: {DEFAULT_RAW_PATH})",
     )
     parser.add_argument(
         "pytest_args", nargs=argparse.REMAINDER,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,112 @@
+import json
+import os
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# --------------------------------------------------------------------------
+# Claims manifest plumbing (issue #61, steps 1-2; design:
+# docs/design-claims-manifest.md).
+#
+# A test that backs a public capability claim declares it with
+# `@pytest.mark.claim(id, requirement=..., unit=..., gate=...)` and records
+# the measured value through the `record_claim` fixture. **Both are
+# required** -- a test that is marked but never calls `record_claim()` is a
+# claim with a silently missing value, which is exactly the failure mode
+# this mechanism exists to prevent, so it is a hard error, not a soft skip.
+#
+# Only tests that PASS contribute a claim. `scripts/emit_claims.py` runs the
+# suite in a subprocess and reads the file this module writes at session end
+# (`CLAIMS_RAW_PATH`, default `.claims_raw.json` at the repo root) to build
+# the published `claims.json` -- see that script for the manifest schema.
+# --------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAIMS_RAW_PATH = Path(os.environ.get("CLAIMS_RAW_PATH", _REPO_ROOT / ".claims_raw.json"))
+
+#: nodeid -> recorded claim data, populated by `record_claim`.
+_recorded_claims: dict[str, dict] = {}
+#: nodeids whose "call" phase reported "passed".
+_passed_nodeids: set[str] = set()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "claim(id, requirement=None, unit=None, gate=None): declare that this "
+        "test backs a claims-manifest entry. The test MUST call the "
+        "record_claim fixture with the measured value, or the suite fails.",
+    )
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Catch the marked-but-never-requests-the-fixture case up front, before
+    the test body even runs -- there is no value coming either way."""
+    marker = item.get_closest_marker("claim")
+    if marker is not None and "record_claim" not in item.fixturenames:
+        pytest.fail(
+            f"{item.nodeid} carries @pytest.mark.claim(...) but never requests "
+            "the record_claim fixture -- a claim must record a measured value, "
+            "it cannot be asserted silently",
+            pytrace=False,
+        )
+
+
+@pytest.fixture
+def record_claim(request: pytest.FixtureRequest):
+    """Records the measured value a `@pytest.mark.claim(...)`-marked test
+    pins. Fails the test if the marker is missing, or if the test finishes
+    without ever calling the returned function."""
+    marker = request.node.get_closest_marker("claim")
+    if marker is None:
+        raise RuntimeError(
+            f"{request.node.nodeid} requests record_claim but carries no "
+            "@pytest.mark.claim(...) -- mark the test first"
+        )
+    if not marker.args:
+        raise RuntimeError(
+            f"{request.node.nodeid}: @pytest.mark.claim(...) needs the claim "
+            "id as its first argument"
+        )
+    claim_id = marker.args[0]
+    state = {"called": False}
+
+    def _record(value) -> None:
+        state["called"] = True
+        _recorded_claims[request.node.nodeid] = {
+            "id": claim_id,
+            "value": value,
+            "unit": marker.kwargs.get("unit"),
+            "requirement": marker.kwargs.get("requirement"),
+            "gate": marker.kwargs.get("gate"),
+            "test": request.node.nodeid,
+        }
+
+    yield _record
+
+    if not state["called"]:
+        pytest.fail(
+            f"{request.node.nodeid} is marked @pytest.mark.claim({claim_id!r}, "
+            "...) but never called record_claim() -- a claim with a silently "
+            "missing value is not allowed",
+            pytrace=False,
+        )
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if report.when == "call" and report.outcome == "passed":
+        _passed_nodeids.add(report.nodeid)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Only claims from tests that actually passed make it out -- a failing
+    test's claim must be absent, not stale."""
+    passing = {
+        nodeid: data
+        for nodeid, data in _recorded_claims.items()
+        if nodeid in _passed_nodeids
+    }
+    CLAIMS_RAW_PATH.write_text(json.dumps(passing, indent=2) + "\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -20,12 +21,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 #
 # Only tests that PASS contribute a claim. `scripts/emit_claims.py` runs the
 # suite in a subprocess and reads the file this module writes at session end
-# (`CLAIMS_RAW_PATH`, default `.claims_raw.json` at the repo root) to build
-# the published `claims.json` -- see that script for the manifest schema.
+# (`CLAIMS_RAW_PATH`, default a system temp path -- deliberately outside the
+# repo tree, so this plumbing needs no .gitignore entry) to build the
+# published `claims.json` -- see that script for the manifest schema.
 # --------------------------------------------------------------------------
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-CLAIMS_RAW_PATH = Path(os.environ.get("CLAIMS_RAW_PATH", _REPO_ROOT / ".claims_raw.json"))
+CLAIMS_RAW_PATH = Path(
+    os.environ.get("CLAIMS_RAW_PATH", Path(tempfile.gettempdir()) / "overboard-claims-raw.json")
+)
 
 #: nodeid -> recorded claim data, populated by `record_claim`.
 _recorded_claims: dict[str, dict] = {}

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -77,14 +77,27 @@ def test_abi_version_is_the_one_this_glue_was_written_against(controller):
     assert controller.abi_version == 1
 
 
-def test_closed_loop_prevents_the_nose_strike(model, controller):
-    """The headline. Open-loop this exact impulse noses into the ground."""
+@pytest.mark.claim(
+    "recovery.peak-pitch",
+    requirement="SR-SIM-5",
+    unit="deg",
+    gate="peak_abs_pitch_deg < 3.0",
+)
+def test_closed_loop_prevents_the_nose_strike(model, controller, record_claim):
+    """The headline. Open-loop this exact impulse noses into the ground.
+
+    This is issue #61's one real claims-manifest entry end-to-end
+    (`recovery.peak-pitch`, docs/design-claims-manifest.md) -- the public
+    site's "closed-loop peak pitch" figure, backed by this gate rather than
+    hand-copied from a run and left to drift.
+    """
     r = run(ImpulseParams(magnitude_ns=NOMINAL_IMPULSE_NS), model=model, controller=controller)
     assert not r.metrics.nose_strike
     assert r.metrics.peak_abs_pitch_deg < 3.0, (
         f"peak |pitch| {r.metrics.peak_abs_pitch_deg:.2f} deg -- the strike angle is "
         "18.6 deg, so anything near it means the controller is barely helping"
     )
+    record_claim(r.metrics.peak_abs_pitch_deg)
 
 
 def test_closed_loop_beats_open_loop_on_the_same_disturbance(model, controller):


### PR DESCRIPTION
## What

Implements steps 1-2 of #61 per `docs/design-claims-manifest.md` (COO, ratified). Step 3 (the `overboard-web` site-side check + `data-claim` attributes) is **not** in this PR — different repo, needs the Senior Digital Marketer's countersign.

- **`tests/conftest.py`**: `@pytest.mark.claim(id, requirement=None, unit=None, gate=None)` plus a `record_claim` fixture. Both are required, enforced two ways so a marked-but-silent claim cannot slip through: a test that never even requests `record_claim` fails in `pytest_runtest_setup` (before the body runs); a test that requests it but never calls it fails in the fixture's teardown. Only claims whose test's "call" phase reported `passed` get written to the raw handoff file at session end.
- **`scripts/emit_claims.py`**: runs `pytest` in a subprocess, folds the passing claims into the published schema (`{schema, sha, generated_at, claims: {id: {value, unit, requirement, test, gate}}}`), writes `sim/out/claims.json`. `sha` resolution mirrors `render_scenario.py`'s `source_commit()` (prefers `ARTIFACT_SHA`/`GITHUB_SHA`, falls back to local `git rev-parse`). Exit code mirrors pytest's.
- **One real claim**: `recovery.peak-pitch` on `tests/test_closed_loop.py::test_closed_loop_prevents_the_nose_strike` (`requirement="SR-SIM-5"`, `gate="peak_abs_pitch_deg < 3.0"`), recording `metrics.peak_abs_pitch_deg`.
- **CI**: `.github/workflows/ci.yml`'s existing `publish-sim-artifact` job (already Senior Controls' turf) gets one new step, "Emit claims manifest", and `sim/out/claims.json` joins the existing `gh release upload sim-latest --clobber` file list. Same job, same rolling release, no second publish mechanism.

## Ambiguity flagged, and the call made

The issue text and design doc both cite the one real claim as **"the README's 0.2331 m closed-loop peak pitch."** I could not find that figure anywhere in this repo — not in `README.md` (which states no closed-loop peak-pitch number today), not in any test, and `git log -S "0.2331"` across all branches shows only the design doc itself introducing it as illustrative backstory. That backstory's own worked JSON example is internally inconsistent too: it labels the field `unit: "m"` while its own code sample records `metrics.peak_abs_pitch_deg` — a degrees value.

Hardcoding `0.2331`/`"m"` would have baked a fabricated value into the one thing this whole mechanism exists to prevent: a claim not actually backed by a green test. Instead I attached the marker to the exact test/metric the design doc's own example names (`test_closed_loop_prevents_the_nose_strike` / `peak_abs_pitch_deg`) and recorded the real, currently-measured value with the honest unit — **0.878 deg** at last run, `unit="deg"`. Flagging this for the COO to correct if a different claim/metric was actually intended.

Also added `gate` as a fourth, optional marker kwarg beyond the issue's literal 3-arg spec (`id, requirement=, unit=`) — the published schema requires a `gate` field and the design doc's own JSON example carries one, so it needed a place to come from.

## Deliberate violation, shown failing (not asserted)

Before:
```
$ python scripts/emit_claims.py
258 passed, 2 xfailed
wrote 1 claim to sim/out/claims.json
{
  "schema": 1, "sha": "bcc4176", "generated_at": "...",
  "claims": {
    "recovery.peak-pitch": {
      "value": 0.8784099671976145, "unit": "deg", "requirement": "SR-SIM-5",
      "test": "tests/test_closed_loop.py::test_closed_loop_prevents_the_nose_strike",
      "gate": "peak_abs_pitch_deg < 3.0"
    }
  }
}
```

Then changed the gate's own assertion to an impossible threshold (`< 0.0`) and re-ran:
```
$ python scripts/emit_claims.py
1 failed, 257 passed, 2 xfailed, 1 error
  FAILED test_closed_loop_prevents_the_nose_strike - AssertionError: peak |pitch| 0.88 deg ...
  ERROR at teardown: ...marked @pytest.mark.claim('recovery.peak-pitch', ...) but never called record_claim()...
wrote 0 claims to sim/out/claims.json
{"schema": 1, "sha": "bcc4176", "generated_at": "...", "claims": {}}
$ echo $?
1
```
The claim disappears and the script's exit code goes non-zero (a real CI step would go red), while the other 257 tests are untouched. Reverted immediately after; re-ran clean (258 passed, 2 xfailed, identical to before). Separately smoke-tested the "marked but never even requests `record_claim`" path with a throwaway test file outside `tests/` — fails at setup with the expected message, not committed anywhere.

## Verification

- `cargo build --release -p control-ffi` — clean, then `pytest tests/ -q` → **258 passed, 2 xfailed** (no regressions).
- `cargo fmt --all -- --check` — clean (no Rust files touched).
- `GITHUB_ACTIONS=1 POLICY_BRANCH=feat/controls/claims-manifest POLICY_BASE_REF=origin/master python3 .github/policy_check.py` → **all hard checks pass** (8 roles, 40 ownership rules; only pre-existing advisories unrelated to this change). Two `doc-drift` findings resolved with `DOC-OK:` commit messages (`docs/design-claims-manifest.md` and `docs/web-artifact-pipeline.md` are COO/CEO turf respectively — this PR implements what the design doc already specifies and is additive to the publish pattern the pipeline doc already describes, so neither doc needed a content change).

## Left out, deliberately

- The requirement-register mirror (design doc's recommended option 1) — explicitly a follow-up, not a precondition, per the design doc's own sequencing.
- `overboard-web`, `check_page.py`, `data-claim` attributes (step 3) — different repo, needs the Senior Digital Marketer's countersign.

References #61. **Not closing it** — step 3 is still open and is not this role's to land.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>