### PR TITLE
docs: the claims-manifest design carried a wrong number in its own example

### DIFF
--- a/docs/design-claims-manifest.md
+++ b/docs/design-claims-manifest.md
@@ -11,8 +11,10 @@ covers:
 requirement backs it, and a claim that becomes false comes off in the same pass. This
 document designs the enforcement `SR-WEB-4` has never had.
 
-**Status: design only. Nothing here is implemented.** Closes the design half of
-[#61](https://github.com/MikePaNtZ/overboard/issues/61); implementation is Senior Controls'.
+**Status: steps 1–2 shipped in [#108](https://github.com/MikePaNtZ/overboard/pull/108)** —
+marker, fixture, `scripts/emit_claims.py`, one real claim, and `claims.json` published to the
+rolling `sim-latest` release. **Step 3 (the site-side check) is not started** and needs the
+Senior Digital Marketer's countersign.
 
 **Owner of this document:** COO. **Site-side half needs the Senior Digital Marketer's
 countersign** — it changes when their deploy is allowed to proceed, which is a Promise, not
@@ -26,9 +28,22 @@ says a claim may not appear unless a requirement backs it, and that a claim whic
 false comes off in the same pass. **That rule has no enforcement on the site side.**
 
 It has already failed once in the direction that matters. A published figure — the
-closed-loop peak pitch on the README — was generated from a simulation that knew its own
-tilt perfectly. The honest number is **0.2331 m**, worse than the 0.0648 m that was public.
-Nothing detected that; a person noticed.
+**shuttle-run return error** — was generated from a simulation that knew its own tilt
+perfectly. Run with the estimator in the loop it is **0.2331 m**, worse than the 0.0648 m
+that was public. Nothing detected that; a person noticed.
+
+> ⚠️ **This paragraph was wrong when first written, and the error is instructive.** It
+> attributed `0.2331 m` to "the closed-loop peak pitch." That figure is the estimator/shuttle
+> `return_error_m` — a *distance*, pinned in `tests/test_estimator.py`. The closed-loop peak
+> pitch is **0.879 deg**, an *angle*, from `test_closed_loop_prevents_the_nose_strike`. Two
+> unrelated metrics were conflated and the worked example below then carried a degrees value
+> labelled `unit: "m"`.
+>
+> It was caught by the engineer implementing this design, who refused to hardcode a number no
+> green test produces and said so instead (#108). **The document written to stop wrong numbers
+> reaching the public carried a wrong number in its own worked example** — which is the
+> argument for the mechanism, not against it: prose review did not catch this, and a person
+> reading against the code did.
 
 ## What already exists, and what it does not do
 
@@ -63,8 +78,8 @@ enforcing nothing (#83). The blast radius is one re-runnable deploy, not a block
   "generated_at": "2026-07-30T04:00:00Z",
   "claims": {
     "recovery.peak-pitch": {
-      "value": 0.2331,
-      "unit": "m",
+      "value": 0.879,
+      "unit": "deg",
       "requirement": "SR-SIM-5",
       "test": "tests/test_closed_loop.py::test_closed_loop_prevents_the_nose_strike",
       "gate": "peak_abs_pitch_deg < 3.0"
@@ -81,7 +96,8 @@ the site cannot state something engineering is not currently proving.
 **Generated, or it drifts.** Which means a test must be able to declare what it pins:
 
 ```python
-@pytest.mark.claim("recovery.peak-pitch", requirement="SR-SIM-5", unit="m")
+@pytest.mark.claim("recovery.peak-pitch", requirement="SR-SIM-5", unit="deg",
+                   gate="peak_abs_pitch_deg < 3.0")
 def test_closed_loop_prevents_the_nose_strike(record_claim):
     ...
     record_claim(metrics.peak_abs_pitch_deg)
@@ -104,7 +120,7 @@ gates every deploy — gains a claims step. It fails, and therefore blocks the d
 | Condition | Why |
 |---|---|
 | Page references a claim id absent from the manifest | The test is failing, was deleted, or never existed |
-| Page's stated number disagrees with the manifest value | The number went stale — the 0.0648 case |
+| Page's stated number disagrees with the manifest value | The number went stale — the 0.0648 m shuttle case |
 | Manifest cannot be fetched | Cannot verify, so do not publish |
 | Manifest `sha` is not an ancestor of the controls repo's `master` | A forged or stale artifact |
 
@@ -117,12 +133,12 @@ The page has **no build step and no dependencies** — vanilla HTML that must op
 `file://` — so the binding is a data attribute, invisible to rendering and readable by CI:
 
 ```html
-<span data-claim="recovery.peak-pitch">0.23 m</span>
+<span data-claim="recovery.peak-pitch">0.88 deg</span>
 ```
 
 The checker extracts the number from the element's **text content** and verifies it matches
-the manifest value *at the precision the page states*. `0.23` is valid for a manifest value
-of `0.2331`; `0.24` is not; `0.0648` is not.
+the manifest value *at the precision the page states*. `0.88` is valid for a manifest value
+of `0.879`; `0.89` is not.
 
 **The value is deliberately not duplicated into an attribute.** Two copies of a number in
 one tag drift apart, and then the check passes while the reader sees the wrong figure.
@@ -147,7 +163,8 @@ field is checked.
 ## Sequence
 
 1. **Marker + fixture + `scripts/emit_claims.py`, and one real claim end-to-end** — the
-   README's 0.2331 m figure. One claim proves the mechanism; ten prove nothing more.
+   closed-loop peak-pitch claim (`recovery.peak-pitch`, 0.879 deg). One claim proves the
+   mechanism; ten prove nothing more.
 2. **Publish `claims.json`** alongside the sim artifact on green `master`.
 3. **Site-side check** in `check_page.py`, plus `data-claim` on the page's existing numbers.
    Lands as a PR into `overboard-web` with review from the Senior Digital Marketer. **I do


### PR DESCRIPTION
My error, found by the engineer implementing the design (#108).

## What was wrong

I wrote **0.2331 m** into `docs/design-claims-manifest.md` as *"the closed-loop peak pitch on the README."* It is nothing of the kind:

| Figure | What it actually is |
|---|---|
| `0.2331 m` | the estimator/shuttle **`return_error_m`** — a **distance**, pinned in `tests/test_estimator.py` (`0.0226 m → 0.2331 m` under the corrected frame map) |
| `0.879 deg` | the **closed-loop peak pitch** — an **angle**, from `test_closed_loop_prevents_the_nose_strike` against a `< 3.0` gate |

Two unrelated metrics conflated. The worked JSON example then carried a degrees value labelled `unit: "m"`, so it was never internally consistent as something to copy. The figure also appears **nowhere in `README.md`**, which states no closed-loop peak-pitch number at all.

## Why this is worth a commit rather than a quiet fix

**The document written to stop wrong numbers reaching the public carried a wrong number in its own worked example.**

That is an argument *for* the mechanism, not against it. Prose review did not catch this — I wrote it, reviewed it, and shipped it in #95. A person reading the doc **against the code** caught it within an hour, which is exactly what the claims manifest automates.

The dispatched engineer refused to hardcode the number, recorded the real measured value off the exact test the example names, and said why in the PR rather than either quietly complying or quietly fixing it. Right call twice over.

## The correction

The motivating story is **true** and stays — a published shuttle figure really was generated from a sim that knew its own tilt perfectly. It was just attached to the wrong metric. Fixed in seven places: the motivating paragraph, the JSON example, the marker example, the `data-claim` example and its precision rule, the failure table, and the sequence step.

The marker example now also carries `gate=`, which the published schema requires and my three-argument version omitted — another inconsistency #108 had to work around.

**The error is recorded in the doc rather than silently repaired**, because *"how did a wrong number survive review"* is the more useful artefact than a clean diff.

Status line corrected too: steps 1–2 are shipped, not "design only".

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>