### PR TITLE
fix(ops): turf silently skipped every fix/ and docs/ branch

### DIFF
--- a/.github/policy_check.py
+++ b/.github/policy_check.py
@@ -259,8 +259,23 @@ def check_turf(roles: dict, rules: list) -> None:
     branch = os.environ.get("POLICY_BRANCH") or git("rev-parse", "--abbrev-ref", "HEAD")
     base = os.environ.get("POLICY_BASE_REF", "origin/master")
 
+    # Match on the LANE, not the literal registry prefix. The registry records
+    # `feat/ops/`, but real branches are also `fix/ops/...`, `docs/ops/...`,
+    # `fix/controls/...`. Matching the whole prefix meant the turf check
+    # SILENTLY SKIPPED every one of those -- seven live branches on origin at
+    # the time this was found, three of them the COO's from the same day, plus
+    # every `fix/`-prefixed branch already merged.
+    #
+    # That is the same failure this check was repaired for in #83: a gate that
+    # reports nothing to enforce is indistinguishable from a gate that passed.
+    # The literal-prefix match is kept as a fallback so a role whose prefix has
+    # no lane segment still resolves.
     prefixes = {m["prefix"]: r for r, m in roles.items() if m["prefix"]}
-    role = next((r for p, r in prefixes.items() if branch.startswith(p)), None)
+    lanes = {p.strip("/").split("/")[-1]: r for p, r in prefixes.items()}
+    seg = branch.split("/")
+    role = lanes.get(seg[1]) if len(seg) >= 2 else None
+    if role is None:
+        role = next((r for p, r in prefixes.items() if branch.startswith(p)), None)
     if role is None:
         # "HEAD" means the workflow did not pass POLICY_BRANCH and we are on a
         # detached checkout -- that is the wiring bug, not an unregistered role.


### PR DESCRIPTION
The registry records `feat/ops/`, but real branches are also `fix/ops/…`, `docs/ops/…`, `fix/controls/…`. `check_turf` matched the **literal prefix** with `startswith()`, so every one of those resolved to no role and **skipped the check entirely**:

```
turf: branch 'fix/ops/claims-doc-wrong-number' matches no registered branch prefix -- skipping
```

**Seven live branches on origin** at the time of writing — three of them mine from today — plus every `fix/`-prefixed branch already merged: `fix/motor-sign-convention`, `fix/estimator-closes-the-loop`, `fix/ops/runbook-linux-host`, and others. **None was ever turf-checked.**

## Same failure as #83, new costume

#83 fixed why this check could not resolve its **base**. This fixes why it could not resolve a **role**. Both produced a green run that had checked nothing, and both were invisible because a skip and a pass look identical from outside.

I found it in the output of my own PR two commits ago and nearly scrolled past it.

## The fix

Match on the **lane** segment — `branch.split('/')[1]` against the last segment of each registered prefix — with the literal-prefix match kept as a fallback so a role whose prefix has no lane segment still resolves.

This is **exactly the fix already applied to `usage.py`'s attribution** earlier today, for exactly the same reason. The gate had not caught up with its own sibling.

## Verified

| Branch | Result |
|---|---|
| `fix/controls/x` | resolves to Senior Controls, **flags** the trespass on the COO's `policy_check.py` |
| `fix/ops/x` | resolves to COO, passes on the COO's own file |
| `docs/ai-workflow-capture` | no lane segment, still skips — behaviour unchanged |

Verified **after committing**. The diff-based checks need a commit to have anything to diff; running them on staged work is the meaningless pass already recorded in the COO's dead-ends list, and it caught me for the third time today.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>