### PR TITLE
feat(controls): plant-mujoco -- Rust can call mj_step (I1a, #91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # crates/plant-mujoco (issue #91) links libmujoco out of the pip
+      # 'mujoco' wheel -- MUJOCO_DIR is unset here, so its build.rs falls
+      # back to the wheel probe, which needs `python3 -c 'import mujoco'` to
+      # succeed. Installed from the SAME pin as requirements-sim.txt (not
+      # duplicated by hand) so the version this job links can never drift
+      # from the one `sim` tests against.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install MuJoCo (plant-mujoco's native dependency)
+        run: pip install "$(grep '^mujoco==' requirements-sim.txt)"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "board-types",
  "hal",
  "hal-actuate",
+ "plant-mujoco",
 ]
 
 [[package]]
@@ -98,6 +99,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -143,6 +154,12 @@ checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
 dependencies = [
  "nb",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hal"
@@ -258,6 +275,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "plant-mujoco"
+version = "0.1.0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +358,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sim-backend"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/board-app-driverless",
     "crates/canary-ridden",
     "crates/can-harness",
+    "crates/plant-mujoco",
     "crates/xtask",
 ]
 
@@ -31,5 +32,6 @@ vesc-tx = { path = "crates/vesc-tx" }
 control-core = { path = "crates/control-core" }
 safety = { path = "crates/safety" }
 sim-backend = { path = "crates/sim-backend" }
+plant-mujoco = { path = "crates/plant-mujoco" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 socketcan = "3.6"

--- a/crates/canary-ridden/Cargo.toml
+++ b/crates/canary-ridden/Cargo.toml
@@ -8,10 +8,12 @@ license.workspace = true
 name = "canary-ridden"
 path = "src/main.rs"
 
-# NOT a template to copy. This crate exists to be a mistake --
-# `hal-actuate` should never be a dependency of a ridden-shaped binary --
-# and `crates/xtask`'s gate has to have something real to catch it on.
+# NOT a template to copy. This crate exists to be a mistake -- neither
+# `hal-actuate` NOR `plant-mujoco` should ever be a dependency of a
+# ridden-shaped binary -- and `crates/xtask`'s gate has to have something
+# real to catch each of them on.
 [dependencies]
 board-types = { workspace = true }
 hal = { workspace = true }
 hal-actuate = { workspace = true }
+plant-mujoco = { workspace = true }

--- a/crates/canary-ridden/src/main.rs
+++ b/crates/canary-ridden/src/main.rs
@@ -1,16 +1,18 @@
 //! Positive control for `crates/xtask`'s dependency-graph gate.
 //!
 //! This binary is deliberately shaped like `board-app-ridden` but links
-//! `hal-actuate` anyway — the exact mistake the real crate split exists to
-//! catch (issue #1: a copy-pasted `main.rs` that keeps the `BoardActuate`
-//! import, or a "just for now" dependency that never gets removed). The gate
-//! is required to flag this crate. If it stops flagging `canary-ridden` —
-//! because the marker crate was renamed and the gate wasn't updated, or the
-//! walk logic regressed — that is exactly the silent failure mode this
-//! canary is here to turn loud instead.
+//! `hal-actuate` AND `plant-mujoco` anyway — the exact mistakes the real
+//! crate split, and `hal`'s `#![no_std]`-ness, exist to catch (issue #1: a
+//! copy-pasted `main.rs` that keeps the `BoardActuate` import, or a "just
+//! for now" dependency that never gets removed; issue #91: a native physics
+//! dependency leaking into the ridden binary the same way). The gate is
+//! required to flag this crate for BOTH of them. If it stops flagging
+//! `canary-ridden` — because a marker crate was renamed and the gate wasn't
+//! updated, or the walk logic regressed — that is exactly the silent
+//! failure mode this canary is here to turn loud instead.
 //!
 //! Not built or run as part of the normal loop; `cargo build --workspace`
-//! compiles it (proving the graph edge is real, not just declared and
+//! compiles it (proving both graph edges are real, not just declared and
 //! unused), and `xtask` is what actually inspects it.
 
 use board_types::{
@@ -76,11 +78,19 @@ impl BoardActuate for CanaryBackend {
 
 fn main() {
     println!(
-        "canary-ridden: this binary links hal-actuate on purpose -- \
-         the gate in `cargo run -p xtask -- gate` must fail if it does not flag this crate."
+        "canary-ridden: this binary links hal-actuate AND plant-mujoco on purpose -- \
+         the gate in `cargo run -p xtask -- gate` must fail if it does not flag both."
     );
     let mut backend = CanaryBackend;
     let _ = backend.open();
     let _disarm = backend.arm();
     let _ = backend.apply(&Command::ZERO);
+
+    // Real use of plant-mujoco's linked symbol, not just a declared-but-dead
+    // dependency -- proves the graph edge is something the linker actually
+    // has to resolve.
+    println!(
+        "canary-ridden: linked libmujoco reports version {}",
+        plant_mujoco::mujoco_version_string()
+    );
 }

--- a/crates/plant-mujoco/Cargo.toml
+++ b/crates/plant-mujoco/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "plant-mujoco"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+build = "build.rs"
+
+# No `[dependencies]` on purpose. This crate's entire job (issue #91 / I1a) is
+# proving Rust can call `mj_step` at all through the ~60-line C shim in
+# src/shim.c -- pulling in more here would blur that.
+[dependencies]
+
+[build-dependencies]
+cc = "1"

--- a/crates/plant-mujoco/README.md
+++ b/crates/plant-mujoco/README.md
@@ -1,0 +1,36 @@
+# plant-mujoco
+
+I1a (issue #91): proves Rust can call `mj_step` at all.
+
+A ~60-line C shim over MuJoCo's C API (`src/shim.c`), compiled by `build.rs`
+with the `cc` crate against MuJoCo's own headers. `Plant`'s `extern "C"`
+surface binds only to the shim's opaque-handle functions (`*mut c_void` for
+both `mjModel*` and `mjData*`) -- there are no hand-written `#[repr(C)]`
+mirrors of either struct, on purpose: those layouts drift between MuJoCo
+minor versions, and a mismatch would be silent memory corruption rather than
+a build error.
+
+## Linking
+
+`build.rs` discovers libmujoco via a single `MUJOCO_DIR` env var, with a
+wheel-probe fallback (`python3 -c 'import mujoco'`) if it is unset. Either
+way it links the **same** `libmujoco.so.3.10.0` the pip-installed `mujoco`
+wheel ships and the `sim` CI job already installs from
+`requirements-sim.txt` -- not a system package, not a vendored copy. That is
+what makes the later Rust-vs-Python plant equivalence check (I1b, #106)
+meaningful: both sides load the identical shared object.
+
+The build fails loudly, not silently, if no MuJoCo install is found.
+
+## What this crate does NOT do
+
+No `hal` implementation, no comparison against the Python-hosted plant, no
+control-law change. `sim-backend` stays a stub until I1c (#107). See issue
+#91 for the full scope split.
+
+## Version check
+
+`Plant::open` asserts the linked `mj_versionString()` equals
+`plant_mujoco::REQUIRED_VERSION` ("3.10.0") -- the string, not
+`mj_version()`'s packed integer, which is ambiguous between e.g. `3.1.0` and
+`3.10.0`.

--- a/crates/plant-mujoco/build.rs
+++ b/crates/plant-mujoco/build.rs
@@ -1,0 +1,178 @@
+//! Locates and links libmujoco, then compiles `src/shim.c` against its
+//! headers (issue #91 / I1a).
+//!
+//! **Discovery is a single `MUJOCO_DIR` env var with a wheel-probe
+//! fallback, and this build script panics -- loudly, with the exact thing it
+//! tried -- if neither finds a real install.** A build that silently degrades
+//! to "no plant" is the failure mode this project keeps hitting (see
+//! `crates/sim-backend`'s header), so there is no quiet "skip this crate"
+//! path here at all.
+//!
+//! Either source must point (directly, or via `MUJOCO_DIR/lib`) at a
+//! directory containing both `include/mujoco/mujoco.h` and a
+//! `libmujoco.so.*` / `libmujoco*.dylib`. The pip-installed `mujoco` wheel's
+//! own package directory satisfies this shape exactly -- which is also why
+//! the wheel-probe fallback works: `import mujoco` and read
+//! `os.path.dirname(mujoco.__file__)`.
+//!
+//! The wheel ships no unversioned `libmujoco.so` / `libmujoco.dylib` symlink
+//! for a plain `-lmujoco` to find, so this links the exact same
+//! `libmujoco.so.3.10.0` (or its macOS `.dylib` equivalent) via an
+//! unversioned symlink created in `OUT_DIR` at build time, rather than a raw
+//! linker path. That is deliberate, not cosmetic: `cargo:rustc-link-lib` (and
+//! a `cargo:rustc-link-search` pointed *inside* `OUT_DIR`) are what Cargo
+//! actually carries through to every crate that depends on this one --
+//! `canary-ridden`'s link and, crucially, its *runtime* dynamic-library
+//! search path too. `cargo:rustc-link-arg` looked simpler but silently does
+//! neither: it only affects this package's own targets, which is exactly the
+//! kind of "worked here, broke one hop downstream" failure this project
+//! keeps hitting.
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Relative path checked to confirm `MUJOCO_DIR` (or its wheel-probed
+/// equivalent) actually looks like a MuJoCo install. The *version* itself is
+/// not checked here -- `Plant::open`'s `mj_versionString()` assertion in
+/// `src/lib.rs` is what enforces that, at run time, against the string, not
+/// against anything this build script could infer from a path.
+const HEADER: &str = "include/mujoco/mujoco.h";
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=MUJOCO_DIR");
+    println!("cargo:rerun-if-changed=src/shim.c");
+
+    let mujoco_dir = locate_mujoco();
+    let include_dir = mujoco_dir.join("include");
+    if !mujoco_dir.join(HEADER).is_file() {
+        panic!(
+            "plant-mujoco: '{}' does not look like a MuJoCo install -- expected \
+             a header at '{}/{HEADER}' but found none. Set MUJOCO_DIR to a \
+             directory containing 'include/mujoco/mujoco.h' plus a \
+             'libmujoco.so.*' / 'libmujoco*.dylib' next to it (or under \
+             'lib/') -- the pip 'mujoco' wheel's own package directory \
+             satisfies both.",
+            mujoco_dir.display(),
+            mujoco_dir.display(),
+        );
+    }
+
+    let lib_dir = if mujoco_dir.join("lib").is_dir() {
+        mujoco_dir.join("lib")
+    } else {
+        mujoco_dir.clone()
+    };
+    let lib_path = find_shared_lib(&lib_dir).unwrap_or_else(|| {
+        panic!(
+            "plant-mujoco: found headers under '{}' but no libmujoco shared \
+             library in '{}' (looked for 'libmujoco.so.*' / 'libmujoco*.dylib'). \
+             A headers-only install cannot be linked against.",
+            mujoco_dir.display(),
+            lib_dir.display(),
+        )
+    });
+
+    cc::Build::new()
+        .file("src/shim.c")
+        .include(&include_dir)
+        .compile("plant_mujoco_shim");
+
+    // OUT_DIR gets TWO symlinks to the same real, versioned file:
+    //   - the unversioned name ("libmujoco.so" / "libmujoco.dylib"), which is
+    //     what a bare `-lmujoco` resolves against at LINK time;
+    //   - the real, versioned name again (e.g. "libmujoco.so.3.10.0"), which
+    //     is what the dynamic loader looks for at RUN time -- it resolves by
+    //     the library's own recorded SONAME, not by the name `-l` was given.
+    // Both matter because the search path below is INSIDE OUT_DIR, which is
+    // the one case Cargo documents as also adding to the dynamic-library
+    // search-path env var for every `cargo test`/`cargo run` in this
+    // invocation -- including a downstream crate's, like `canary-ridden`'s.
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is always set for build.rs"));
+    let target = lib_path.canonicalize().unwrap_or_else(|e| {
+        panic!(
+            "plant-mujoco: could not resolve '{}': {e}",
+            lib_path.display()
+        )
+    });
+    let unversioned_name = if lib_path.to_string_lossy().ends_with(".dylib") {
+        "libmujoco.dylib"
+    } else {
+        "libmujoco.so"
+    };
+    let real_name = lib_path
+        .file_name()
+        .expect("lib_path came from read_dir, so it always has a file name")
+        .to_string_lossy()
+        .into_owned();
+    for name in [unversioned_name.to_string(), real_name] {
+        let link = out_dir.join(&name);
+        let _ = std::fs::remove_file(&link); // stale symlink from a previous build
+        std::os::unix::fs::symlink(&target, &link).unwrap_or_else(|e| {
+            panic!(
+                "plant-mujoco: could not symlink '{}' -> '{}': {e}",
+                link.display(),
+                target.display()
+            )
+        });
+    }
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=dylib=mujoco");
+}
+
+/// `MUJOCO_DIR` if set (a hard requirement to satisfy, not a soft hint --
+/// an empty or wrong value fails loudly rather than falling through), else
+/// the wheel-probe fallback: ask whichever `python3`/`python` is on `PATH`
+/// where its installed `mujoco` package lives. That is the SAME libmujoco the
+/// `sim` CI job already installs from `requirements-sim.txt`.
+fn locate_mujoco() -> PathBuf {
+    if let Ok(dir) = env::var("MUJOCO_DIR") {
+        if dir.trim().is_empty() {
+            panic!("plant-mujoco: MUJOCO_DIR is set but empty");
+        }
+        return PathBuf::from(dir);
+    }
+
+    for python in ["python3", "python"] {
+        let output = Command::new(python)
+            .args([
+                "-c",
+                "import mujoco, os; print(os.path.dirname(mujoco.__file__))",
+            ])
+            .output();
+        if let Ok(out) = output {
+            if out.status.success() {
+                let dir = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if !dir.is_empty() {
+                    return PathBuf::from(dir);
+                }
+            }
+        }
+    }
+
+    panic!(
+        "plant-mujoco: no MuJoCo install found. Set MUJOCO_DIR to the 'mujoco' \
+         pip package directory (contains 'include/mujoco/*.h' and \
+         'libmujoco.*'), or `pip install -r requirements-sim.txt` so the \
+         wheel-probe fallback (`python3 -c 'import mujoco'`) can find it. This \
+         crate refuses to build headless rather than silently degrading to \
+         'no plant' -- that silent degrade is the failure mode this \
+         programme keeps hitting."
+    );
+}
+
+/// The versioned shared library in `dir`, if any.
+fn find_shared_lib(dir: &Path) -> Option<PathBuf> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                return false;
+            };
+            name.starts_with("libmujoco.so")
+                || (name.starts_with("libmujoco") && name.ends_with(".dylib"))
+        })
+}

--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -1,0 +1,224 @@
+//! I1a (issue #91): proves Rust can call `mj_step` at all.
+//!
+//! [`Plant`] is a thin owning wrapper around one `mjModel` + one `mjData`,
+//! reached only through `src/shim.c`'s ~60-line, 8-function C surface
+//! (`build.rs` compiles it against MuJoCo's own headers, so field offsets are
+//! resolved by the C compiler rather than hand-mirrored in Rust). Nothing
+//! here implements the `hal` seam, is compared against the Python-hosted
+//! plant, or changes the control law -- that is I1b (#106) and I1c (#107).
+//!
+//! `build.rs` links `libmujoco.so.3.10.0` (or the macOS `.dylib` of the same
+//! version) straight out of the pip-installed `mujoco` wheel, so
+//! [`REQUIRED_VERSION`] is asserted at [`Plant::open`] time as the STRING
+//! `mj_versionString()` returns -- not `mj_version()`'s packed integer, which
+//! is ambiguous between e.g. `3.1.0` and `3.10.0`.
+
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::fmt;
+use std::path::Path;
+
+/// The exact `mj_versionString()` this crate is built and tested against
+/// (`requirements-sim.txt`'s `mujoco==` pin). [`Plant::open`] refuses to
+/// proceed against any other linked version.
+pub const REQUIRED_VERSION: &str = "3.10.0";
+
+extern "C" {
+    fn plant_mujoco_version_string() -> *const c_char;
+    fn plant_mujoco_load_model(
+        path: *const c_char,
+        error: *mut c_char,
+        error_sz: c_int,
+    ) -> *mut c_void;
+    fn plant_mujoco_free_model(model: *mut c_void);
+    fn plant_mujoco_make_data(model: *mut c_void) -> *mut c_void;
+    fn plant_mujoco_free_data(data: *mut c_void);
+    fn plant_mujoco_step(model: *mut c_void, data: *mut c_void);
+    fn plant_mujoco_reset_data(model: *mut c_void, data: *mut c_void);
+    fn plant_mujoco_data_time(data: *mut c_void) -> f64;
+}
+
+/// The linked libmujoco's own `mj_versionString()`.
+pub fn mujoco_version_string() -> String {
+    // SAFETY: `mj_versionString` returns a pointer to a static,
+    // NUL-terminated string compiled into libmujoco -- valid for the whole
+    // program lifetime, never null.
+    unsafe { CStr::from_ptr(plant_mujoco_version_string()) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Why [`Plant::open`] failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenError {
+    /// The linked libmujoco reports a version other than [`REQUIRED_VERSION`].
+    VersionMismatch { found: String },
+    /// `mj_loadXML` rejected the model; the string is MuJoCo's own message.
+    LoadFailed(String),
+}
+
+impl fmt::Display for OpenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OpenError::VersionMismatch { found } => write!(
+                f,
+                "linked libmujoco is {found}, this crate requires exactly {REQUIRED_VERSION}"
+            ),
+            OpenError::LoadFailed(msg) => write!(f, "mj_loadXML failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for OpenError {}
+
+/// A live MuJoCo plant: one owned `mjModel` + one owned `mjData`.
+///
+/// `mjData` is not thread-safe -- `mj_step` mutates it in place with no
+/// internal locking -- and `Plant` holds it only behind raw pointers, which
+/// already makes this type neither `Send` nor `Sync` automatically (raw
+/// pointers implement neither). Stated here so the property is documented
+/// rather than merely incidental to the field types.
+#[derive(Debug)]
+pub struct Plant {
+    model: *mut c_void,
+    data: *mut c_void,
+}
+
+impl Plant {
+    /// Asserts the linked libmujoco is exactly [`REQUIRED_VERSION`], then
+    /// loads `model_path` (`mj_loadXML`) and allocates its `mjData`
+    /// (`mj_makeData`).
+    pub fn open(model_path: &Path) -> Result<Plant, OpenError> {
+        let found = mujoco_version_string();
+        if found != REQUIRED_VERSION {
+            return Err(OpenError::VersionMismatch { found });
+        }
+
+        let path_c = CString::new(model_path.to_string_lossy().into_owned())
+            .expect("model path must not contain a NUL byte");
+        let mut error_buf: [c_char; 1024] = [0; 1024];
+
+        // SAFETY: `path_c` is a valid NUL-terminated C string kept alive for
+        // the call; `error_buf` is a valid, writable buffer of the given size
+        // that `mj_loadXML` NUL-terminates on failure.
+        let model = unsafe {
+            plant_mujoco_load_model(
+                path_c.as_ptr(),
+                error_buf.as_mut_ptr(),
+                error_buf.len() as c_int,
+            )
+        };
+        if model.is_null() {
+            // SAFETY: `error_buf` was NUL-terminated by the failed call above.
+            let msg = unsafe { CStr::from_ptr(error_buf.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            return Err(OpenError::LoadFailed(msg));
+        }
+
+        // SAFETY: `model` was just checked non-null and owns a valid mjModel
+        // that outlives the `mjData` built from it, for as long as `Plant`
+        // (which owns both) exists.
+        let data = unsafe { plant_mujoco_make_data(model) };
+        assert!(
+            !data.is_null(),
+            "mj_makeData returned null for a model mj_loadXML just accepted"
+        );
+
+        Ok(Plant { model, data })
+    }
+
+    /// Advances the plant by exactly one `mj_step` and returns the new
+    /// simulation time (`mjData::time`, seconds) -- the one call this whole
+    /// crate exists to prove Rust can make.
+    pub fn step(&mut self) -> f64 {
+        // SAFETY: `self.model`/`self.data` are non-null and owned for the
+        // life of `self`, and `model` outlives `data` per `Plant::open`.
+        unsafe {
+            plant_mujoco_step(self.model, self.data);
+            plant_mujoco_data_time(self.data)
+        }
+    }
+
+    /// Resets state to the model's defaults (`mj_resetData`), including
+    /// simulation time back to zero.
+    pub fn reset(&mut self) {
+        // SAFETY: see `step`.
+        unsafe { plant_mujoco_reset_data(self.model, self.data) };
+    }
+
+    /// The current simulation time (`mjData::time`, seconds).
+    pub fn time(&self) -> f64 {
+        // SAFETY: `self.data` is non-null and owned for the life of `self`.
+        unsafe { plant_mujoco_data_time(self.data) }
+    }
+}
+
+impl Drop for Plant {
+    fn drop(&mut self) {
+        // SAFETY: `self.data` and `self.model` are the still-owned handles
+        // `Plant::open` allocated; freed in this order because `data` was
+        // built from `model` and must not outlive it.
+        unsafe {
+            plant_mujoco_free_data(self.data);
+            plant_mujoco_free_model(self.model);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn model_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sim/models/overboard_onewheel.xml")
+    }
+
+    /// The acceptance test for this whole crate (issue #91, AC1): load the
+    /// real onewheel model and prove `mj_step` actually ran, by observing the
+    /// one thing a no-op shim could not fake -- simulation time advancing.
+    #[test]
+    fn mj_step_advances_simulation_time() {
+        let mut plant = Plant::open(&model_path()).expect("the onewheel model should load");
+        assert_eq!(plant.time(), 0.0, "a freshly loaded model starts at t=0");
+
+        let t1 = plant.step();
+        assert!(t1 > 0.0, "mj_step must advance mjData::time");
+
+        for _ in 0..9 {
+            plant.step();
+        }
+        assert!(
+            plant.time() > t1,
+            "stepping repeatedly keeps advancing time"
+        );
+    }
+
+    #[test]
+    fn reset_returns_simulation_time_to_zero() {
+        let mut plant = Plant::open(&model_path()).expect("the onewheel model should load");
+        plant.step();
+        assert!(plant.time() > 0.0);
+
+        plant.reset();
+        assert_eq!(plant.time(), 0.0);
+    }
+
+    #[test]
+    fn linked_libmujoco_reports_the_required_version_string() {
+        // The trap this exists to catch: mj_version()'s packed integer
+        // encoding is ambiguous between e.g. 3.1.0 and 3.10.0. This checks
+        // the string.
+        assert_eq!(mujoco_version_string(), REQUIRED_VERSION);
+    }
+
+    #[test]
+    fn opening_a_nonexistent_model_fails_loudly_rather_than_panicking() {
+        let bogus = Path::new(env!("CARGO_MANIFEST_DIR")).join("no-such-model.xml");
+        match Plant::open(&bogus) {
+            Err(OpenError::LoadFailed(_)) => {}
+            Err(other) => panic!("expected OpenError::LoadFailed, got {other:?}"),
+            Ok(_) => panic!("expected OpenError::LoadFailed, but the nonexistent model opened"),
+        }
+    }
+}

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -1,0 +1,49 @@
+// ~60-line C shim over MuJoCo's C API (issue #91 / I1a).
+//
+// Rust's `extern "C"` surface (src/lib.rs) binds ONLY to the functions below,
+// every one of which passes mjModel*/mjData* around as an opaque `void*`.
+// Rust never mirrors either struct's layout -- the C compiler here resolves
+// every field offset from MuJoCo's own headers at build time, so a
+// version-skew field mismatch is a build error in this file, not silent
+// memory corruption on the Rust side.
+
+#include <mujoco/mujoco.h>
+
+const char* plant_mujoco_version_string(void) {
+  return mj_versionString();
+}
+
+// Ownership: the returned pointer, if non-NULL, is an mjModel the caller
+// must eventually pass to plant_mujoco_free_model. NULL means load failed;
+// `error` (size `error_sz`) then holds MuJoCo's own NUL-terminated message.
+void* plant_mujoco_load_model(const char* path, char* error, int error_sz) {
+  return (void*)mj_loadXML(path, NULL, error, error_sz);
+}
+
+void plant_mujoco_free_model(void* model) {
+  mj_deleteModel((mjModel*)model);
+}
+
+// Ownership: the returned mjData must outlive no call against `model` made
+// after it is freed, and must itself be freed with plant_mujoco_free_data
+// before `model` is freed with plant_mujoco_free_model.
+void* plant_mujoco_make_data(void* model) {
+  return (void*)mj_makeData((const mjModel*)model);
+}
+
+void plant_mujoco_free_data(void* data) {
+  mj_deleteData((mjData*)data);
+}
+
+// The one call this whole crate exists to prove Rust can make.
+void plant_mujoco_step(void* model, void* data) {
+  mj_step((const mjModel*)model, (mjData*)data);
+}
+
+void plant_mujoco_reset_data(void* model, void* data) {
+  mj_resetData((const mjModel*)model, (mjData*)data);
+}
+
+double plant_mujoco_data_time(void* data) {
+  return ((mjData*)data)->time;
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,6 +1,6 @@
-//! Dependency-graph gate for issue #1: proves `hal-actuate` (motion
-//! authority) is unreachable from `board-app-ridden` at build time, rather
-//! than trusting a reviewer to notice a stray import.
+//! Dependency-graph gate for issue #1 (and, since #91, issue #91 too):
+//! proves each crate in [`FORBIDDEN`] is unreachable from `board-app-ridden`
+//! at build time, rather than trusting a reviewer to notice a stray import.
 //!
 //! `cargo metadata`'s resolve graph already tells us, per edge, whether a
 //! dependency is `Normal`, `Development` (dev-dependency) or `Build`
@@ -19,8 +19,18 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::process::ExitCode;
 
 const RIDDEN: &str = "board-app-ridden";
-const MARKER: &str = "hal-actuate";
 const CANARY: &str = "canary-ridden";
+
+/// Crates that must never be reachable from `board-app-ridden` over a normal
+/// dependency edge, checked one at a time against the same resolve graph.
+///
+/// `hal-actuate` is motion authority (issue #1, DR-MODE-1). `plant-mujoco`
+/// is a native physics dependency wrapping a non-`no_std` C library
+/// (issue #91) — `hal` itself is `#![no_std]` precisely so nothing shaped
+/// like it can ever link into the ridden binary. `canary-ridden` depends on
+/// every entry here on purpose, so it is the positive control for all of
+/// them, not just the first one added.
+const FORBIDDEN: &[&str] = &["hal-actuate", "plant-mujoco"];
 
 /// True if at least one target (lib, bin, test, ...) links `dep` normally.
 /// The same package can appear with several `dep_kinds` when different
@@ -95,34 +105,42 @@ fn find_package_id(meta: &Metadata, name: &str) -> Result<PackageId, String> {
         })
 }
 
-/// Runs both halves of the gate against one resolve graph (one feature
-/// configuration): the real check, and its positive control.
+/// Runs both halves of the gate, for every crate in [`FORBIDDEN`], against
+/// one resolve graph (one feature configuration): the real check, and its
+/// positive control.
 fn check_boundary(meta: &Metadata, config_label: &str) -> Result<(), String> {
     let graph = Graph::from_metadata(meta)?;
 
     let ridden = find_package_id(meta, RIDDEN)?;
-    let marker = find_package_id(meta, MARKER)?;
     let canary = find_package_id(meta, CANARY)?;
 
     let from_ridden = graph.reachable_from(&ridden.repr);
-    if from_ridden.contains(&marker.repr) {
-        return Err(format!(
-            "[{config_label}] {RIDDEN} can reach {MARKER} over a normal dependency edge. \
-             The ridden binary must have zero motion authority (BoardIo ICD S6.3, DR-MODE-1)."
-        ));
-    }
-
-    // Positive control (issue #1): if `canary-ridden`, which depends on
-    // `hal-actuate` on purpose, is NOT flagged as reaching it, the checker
-    // itself is broken -- e.g. the marker name changed and this file was not
-    // updated -- and that is a worse failure than the boundary itself
-    // breaking, because it fails silently.
     let from_canary = graph.reachable_from(&canary.repr);
-    if !from_canary.contains(&marker.repr) {
-        return Err(format!(
-            "[{config_label}] positive control failed: {CANARY} does not reach {MARKER}, \
-             but it is supposed to depend on it directly. The gate is not working."
-        ));
+
+    for &marker_name in FORBIDDEN {
+        let marker = find_package_id(meta, marker_name)?;
+
+        if from_ridden.contains(&marker.repr) {
+            return Err(format!(
+                "[{config_label}] {RIDDEN} can reach {marker_name} over a normal dependency \
+                 edge. The ridden binary must have zero motion authority and no native \
+                 physics dependency (BoardIo ICD S6.3, DR-MODE-1; issue #91)."
+            ));
+        }
+
+        // Positive control (issue #1): if `canary-ridden`, which depends on
+        // every entry in FORBIDDEN on purpose, is NOT flagged as reaching
+        // this one, the checker itself is broken -- e.g. the marker name
+        // changed and this file was not updated -- and that is a worse
+        // failure than the boundary itself breaking, because it fails
+        // silently.
+        if !from_canary.contains(&marker.repr) {
+            return Err(format!(
+                "[{config_label}] positive control failed: {CANARY} does not reach \
+                 {marker_name}, but it is supposed to depend on it directly. \
+                 The gate is not working."
+            ));
+        }
     }
 
     Ok(())
@@ -162,9 +180,10 @@ fn main() -> ExitCode {
     match run_gate() {
         Ok(()) => {
             println!(
-                "xtask gate: {MARKER} is unreachable from {RIDDEN} \
+                "xtask gate: {} are unreachable from {RIDDEN} \
                  (checked under default features and --all-features); \
-                 {CANARY} was correctly flagged as reaching it."
+                 {CANARY} was correctly flagged as reaching all of them.",
+                FORBIDDEN.join(", ")
             );
             ExitCode::SUCCESS
         }


### PR DESCRIPTION
## What

New crate `crates/plant-mujoco`: a ~60-line C shim over MuJoCo's C API (`src/shim.c`), compiled by `build.rs` with the `cc` crate against MuJoCo's own headers. `Plant`'s `extern "C"` surface binds only to the shim's 8 opaque-handle functions (`*mut c_void` for `mjModel*`/`mjData*`) -- **no hand-mirrored `#[repr(C)]` structs**, per the settled architecture decision in #91. A version-skew field mismatch is a build error in the shim, not silent memory corruption in Rust.

Closes #91 (I1a). Does **not** touch `sim-backend` (stays a stub until I1c/#107), implement `hal` against the real plant, or compare Rust vs. Python (I1b/#106) -- all explicitly out of scope per the issue.

## Acceptance criteria (issue #91)

1. **`crates/plant-mujoco` loads `sim/models/overboard_onewheel.xml` and calls `mj_step`, proven by one test.** `mj_step_advances_simulation_time` asserts `mjData::time` is `0.0` on load and strictly increases after each `mj_step` -- the one thing a no-op shim could not fake.
2. **Discovery is a single `MUJOCO_DIR` env var with a wheel-probe fallback, fails loudly if neither finds a real install.** No `MUJOCO_DIR` + no `python3 -c 'import mujoco'` => `panic!` naming exactly what was tried (verified locally, see below).
3. **Startup assertion that `mj_versionString()` == `"3.10.0"`, the string, not the integer.** `Plant::open` checks this before doing anything else.
4. **Plant handle is `!Sync`.** `Plant` holds `mjModel`/`mjData` only behind `*mut c_void` fields, which are neither `Send` nor `Sync` by construction -- documented in the type's doc comment rather than left incidental.
5. **`cargo fmt/clippy/build/test --workspace` green in CI with a native dependency present.** `.github/workflows/ci.yml`'s `rust` job now installs the pinned `mujoco` wheel (extracted from `requirements-sim.txt`, not duplicated) before the Rust steps, so the wheel-probe fallback has something to find.
6. **`cargo build --release -p control-ffi` unchanged.** Verified: still produces `libcontrol_ffi.so`; `pytest tests/` still passes in full (258 passed, 2 xfailed -- pre-existing).
7. **`xtask`'s reachability gate extended, not duplicated, to cover `plant-mujoco`.** `FORBIDDEN = ["hal-actuate", "plant-mujoco"]`, both checked against `board-app-ridden` over the same walk. `canary-ridden` now depends on both on purpose and is the positive control for the whole list (same mechanism issue #1 built, reused verbatim).

## The one real wrinkle (flagged per the issue's "if you get stuck" note)

The first working version used `cargo:rustc-link-arg` (a full path to the versioned `.so`, plus `-Wl,-rpath,...`). That worked for `plant-mujoco`'s own tests but **silently failed one hop downstream**: `canary-ridden` (which depends on `plant-mujoco`) got an undefined-reference link error, because `rustc-link-arg` only applies to the emitting package's *own* targets -- it does not propagate to dependents, which is exactly the kind of "worked here, broke downstream" failure this project keeps hitting.

Fixed by switching to `cargo:rustc-link-lib` + `cargo:rustc-link-search` pointed *inside* `OUT_DIR` (which Cargo documents as the one case where a build script's search path also becomes every downstream `cargo test`/`cargo run`'s dynamic-library search path in the same invocation), with two symlinks created in `OUT_DIR` at build time: the unversioned name (`libmujoco.so`) for `-lmujoco` at link time, and the real, versioned name (`libmujoco.so.3.10.0`) for the dynamic loader at run time, since it resolves by the library's own recorded `SONAME`, not by the `-l` name.

## How this was verified

Local macOS linking hit a second, unrelated wrinkle: the mujoco wheel's `.dylib` embeds a macOS-framework-style install name (`@rpath/mujoco.framework/Versions/A/libmujoco.3.10.0.dylib`) that doesn't match its own filename, so plain rpath resolution doesn't work there. **CI is `ubuntu-latest`, so that's what matters**, and it does not have this quirk (`SONAME` == filename, confirmed via `objdump -p`). To verify the real target rather than trust that reasoning, I built and ran everything against a real Linux container (`ubuntu:24.04`, aarch64 -- same OS/toolchain family as `ubuntu-latest`, arch is the only difference) with the actual pip `mujoco==3.10.0` wheel installed via the wheel-probe path (no `MUJOCO_DIR` set):

- `cargo fmt --all -- --check` -- clean
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- `cargo build --workspace --all-targets` -- clean
- `cargo test --workspace` -- all green, including `plant-mujoco`'s 4 tests (the `mj_step` proof, version-string assertion, reset, and a bad-path load failure)
- `cargo run -p canary-ridden` -- ran for real, printed `linked libmujoco reports version 3.10.0` (proving the runtime link on the actual `main()` path, not just the test harness)
- `cargo run -p xtask -- gate` -- `hal-actuate, plant-mujoco are unreachable from board-app-ridden ... canary-ridden was correctly flagged as reaching all of them`
- `cargo build --release -p control-ffi` -- unchanged, `libcontrol_ffi.so` produced
- `pytest tests/ -q` -- `258 passed, 2 xfailed`
- Also verified the loud-failure path locally (macOS, no `MUJOCO_DIR`, no `mujoco` on `PATH`): clear `panic!` naming exactly what it tried, no silent degrade.

`python3 .github/policy_check.py` (run as CI does, against this branch/base) passes all hard checks. Five doc-drift advisories (docs describing `.github/workflows/ci.yml` / `crates/xtask/src/main.rs` in an unrelated context) are overridden via `DOC-OK:` in the commit message, since those docs are outside this role's turf and the changes they flag don't move anything they actually describe.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>