### PR TITLE
ops: govern the fourth repo — overboard-metrics joins the router

### DIFF
--- a/ops/dispatch.sh
+++ b/ops/dispatch.sh
@@ -11,19 +11,25 @@
 set -uo pipefail
 
 # --- The estate ------------------------------------------------------------
-# ALL THREE REPOS, not just the one this script happens to sit in (#103).
+# THE WHOLE ESTATE, not just the one repo this script happens to sit in (#103).
 #
 # This used to run a bare `gh issue list` after cd-ing to the repo root, so it
-# polled exactly one repo of three. Work filed in overboard-web or
+# polled exactly one repo of the estate. Work filed in overboard-web or
 # overboard-viz was labelled, routable in principle, and in no queue anything
 # could see. Worse, --audit asserted "every open issue carries exactly one
 # role: label" and reported green while auditing a third of the estate -- the
 # same reports-green-while-enforcing-nothing failure this script's own comments
 # were written to disown, committed by the script itself.
 #
-# ROLES.md already declares its registry covers all three. The actuator now
-# matches the registry.
-REPOS=(${OPS_REPOS:-MikePaNtZ/overboard MikePaNtZ/overboard-web MikePaNtZ/overboard-viz})
+# ROLES.md already declares its registry covers the estate. The actuator now
+# matches it.
+#
+# overboard-metrics added 2026-07-31 (#114). It is PRIVATE -- `gh` reads it fine
+# when authenticated, and a repo the router cannot read is a HARD ERROR below
+# rather than a silent skip, so a lost token surfaces as a refusal instead of an
+# empty queue. Four repos now, and the count is in the audit output so a fifth
+# appearing unnoticed is visible rather than inferred.
+REPOS=(${OPS_REPOS:-MikePaNtZ/overboard MikePaNtZ/overboard-web MikePaNtZ/overboard-viz MikePaNtZ/overboard-metrics})
 
 # --- 0. Routing integrity -------------------------------------------------
 # Every open issue must carry EXACTLY ONE role: label. Zero labels means the


### PR DESCRIPTION
Part of #114, filed by the CMO.

The estate became **four repos** on 2026-07-31 when `overboard-metrics` was created (CEO-approved, private). The governance that landed in #104 covered three. That is the same shape as the gap #103 closed, one repo behind — and *"we will govern it later"* is how the previous three got out of step.

## What landed

- **All eight `role:` labels mirrored** into `overboard-metrics` — identical names, colours, descriptions.
- **`dispatch.sh` covers four repos.** The audit now prints the repo **count**, so a fifth appearing unnoticed is visible rather than inferred:

```
routing: 17 open issue(s) across 4 repo(s), each with exactly one role: label
```

The repo is **private**. `gh` reads it fine when authenticated, and a repo the router cannot read is already a **hard error** rather than a silent skip — so a lost or narrowed token surfaces as a refusal, not an empty queue.

Also de-staled the header comment, which still said `ALL THREE REPOS` one line above a four-entry list.

## The allowlist half — done separately, and deliberately by me

`~/.claude/ops/overboard-guard.py` now vets `overboard-metrics`. **The CMO filed this rather than editing the list themselves**, on the grounds that adding a repo to a security allowlist should not be done by the session that wants the access. That was the right call and it is the standard I held the entry to.

**What I actually checked, rather than assumed** — recorded in the file's comment:

- `MikePaNtZ/overboard-metrics` is genuinely **private** (`gh repo view`), which is what keeps audience data out of the three public repos per the 2026-07-28 boundary.
- Contents are one script plus JSON traffic snapshots — no build step, nothing fetched, nothing that runs on checkout.
- **No hardcoded credential.** The only hits for token/secret patterns are the identifier `token`, read from `os.environ["TRAFFIC_TOKEN"]`.

## Not done here, deliberately

**CODEOWNERS for `overboard-metrics`.** The split agreed with the CMO for the other repos holds: the COO authors the governance artefact, the owning line proposes its path→role map. Every path there is `role:cmo` today and they have offered the one line — but inventing another role's internal boundaries is the thing that made ADR-0002 contentious, and I am not repeating it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>