### PR TITLE
fix(ci): roll sim-preview to a fresh tag and prune on publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,14 @@ jobs:
       - name: Build the control library
         run: cargo build --release -p control-ffi
 
+      # I1b (issue #106): tests/test_rust_python_plant_replay_equivalence.py shells out to this
+      # binary, same as the `sim` job above. `Emit claims manifest` below also
+      # runs `pytest tests/`, so without this the equivalence gate's own
+      # "fail rather than pass vacuously" check (added by #117) correctly
+      # fails the suite here too.
+      - name: Build the plant-mujoco replay binary
+        run: cargo build --release -p plant-mujoco --bin plant-replay
+
       # Only tests that PASS contribute a claim (docs/design-claims-manifest.md,
       # issue #61). A red run here still writes a manifest of whatever passed,
       # but the step itself fails loudly -- this job already needs `sim` green,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,11 @@ jobs:
   # ONE job renders for both destinations, deliberately. Only the publish step
   # differs by ref:
   #   master  -> rolling `sim-latest` release, stable URLs, feeds the web page.
-  #   PR      -> accumulating `sim-preview` prerelease, sha-stamped filenames,
-  #              giving one immutable URL per commit to paste into the Notion
-  #              implementation log as a feature develops.
+  #   PR      -> accumulating $SIM_PREVIEW_RELEASE prerelease, sha-stamped
+  #              filenames, giving one immutable URL per commit to paste into
+  #              the Notion implementation log as a feature develops. Pruned
+  #              on every publish (issue #116) to stay under GitHub's
+  #              1000-asset-per-release cap; see the job's env block.
   # A second job would have been simpler to read and would have drifted from
   # this one within a release or two; then the clip Mike reviews on a PR would
   # no longer be from the same pipeline as the clip that ships.
@@ -212,6 +214,16 @@ jobs:
         ${{ github.event_name == 'pull_request'
             && github.event.pull_request.head.sha
             || github.sha }}
+      # Issue #116: the original `sim-preview` release hit GitHub's hard
+      # 1000-asset-per-release cap (nothing had ever pruned it) and started
+      # failing every PR. Rolling to a fresh tag resets the cap without
+      # deleting anything from the old release -- every existing sha-stamped
+      # URL under `sim-preview` keeps working, it just stops receiving new
+      # uploads. scripts/prune_sim_preview.py then keeps this from
+      # recurring: ~21 assets land per PR run against the 1000 cap, so
+      # keeping the last 30 runs (~630 assets) leaves real headroom.
+      SIM_PREVIEW_RELEASE: sim-preview-v2
+      SIM_PREVIEW_KEEP_RUNS: "30"
     steps:
       - uses: actions/checkout@v4
 
@@ -437,23 +449,40 @@ jobs:
           done
           ls -la preview/
 
-          gh release view sim-preview >/dev/null 2>&1 || \
-            gh release create sim-preview \
+          gh release view "$SIM_PREVIEW_RELEASE" >/dev/null 2>&1 || \
+            gh release create "$SIM_PREVIEW_RELEASE" \
               --prerelease \
               --title "Sim previews (feature branches)" \
-              --notes "Per-commit renders from open PRs. Sha-stamped and accumulating; mainline artifacts live in the sim-latest release instead."
+              --notes "Per-commit renders from open PRs. Sha-stamped and accumulating; mainline artifacts live in the sim-latest release instead. Rolled over from the sim-preview release (issue #116), which hit GitHub's 1000-asset cap; its previews are untouched and still resolve, they just stopped receiving new uploads."
           # --clobber so re-running a job for the same sha replaces rather than
           # errors; distinct shas never collide because the name carries one.
-          gh release upload sim-preview --clobber preview/*
+          gh release upload "$SIM_PREVIEW_RELEASE" --clobber preview/*
 
           {
             echo "### Preview artifacts — \`$short\` (\`$BRANCH\`)"
             echo
             for f in preview/*; do
               n="$(basename "$f")"
-              echo "- [\`$n\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/download/sim-preview/$n)"
+              echo "- [\`$n\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/download/$SIM_PREVIEW_RELEASE/$n)"
             done
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Issue #116: sim-preview hit GitHub's 1000-asset-per-release cap with
+      # nothing ever removing old previews. This keeps the newest
+      # SIM_PREVIEW_KEEP_RUNS runs' assets in SIM_PREVIEW_RELEASE and deletes
+      # the rest. Scoped to that one release by construction -- the script
+      # only ever lists and deletes assets it fetched from that release's own
+      # asset endpoint, so it has no path to sim-latest or sim-experiments
+      # regardless of what runs here. A prune failure fails this step rather
+      # than reporting green having pruned nothing.
+      - name: Prune old sim-preview assets
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/prune_sim_preview.py \
+            --release "$SIM_PREVIEW_RELEASE" \
+            --keep-runs "$SIM_PREVIEW_KEEP_RUNS"
 
       # Phase C (deferred): notify overboard-web so it redeploys with the new
       # clip. Needs a fine-grained PAT with contents:write on that repo, stored

--- a/scripts/prune_sim_preview.py
+++ b/scripts/prune_sim_preview.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Prune old sha-stamped assets from the sim-preview release (issue #116).
+
+Every PR run appends ~21 sha-stamped assets to the sim-preview release and
+nothing ever removed old ones, so it hit GitHub's hard 1000-asset-per-release
+cap and `publish-sim-artifact` started failing on every PR. This keeps the
+most recent `--keep-runs` runs' worth of assets and deletes the rest.
+
+Scoped by construction, not by convention: every asset this script can see
+or delete comes from `gh api repos/<repo>/releases/<id>/assets`, where <id>
+is resolved from the one `--release` tag passed in. There is no code path
+here that can reach a different release's assets, so this cannot touch
+`sim-latest` or `sim-experiments` no matter what `--release` is given.
+
+A deletion failure exits non-zero rather than reporting success having
+pruned nothing quietly -- a green publish job that silently didn't publish
+(or here, didn't prune) is the exact failure class issue #116 called out.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# ~21 assets land per PR run against GitHub's 1000-asset-per-release cap.
+# Keeping the last 30 runs is ~630 assets -- real headroom below the cap
+# even if the per-run asset count grows somewhat over time.
+SIM_PREVIEW_KEEP_RUNS = 30
+
+# Matches the sha-stamped suffix `publish-sim-artifact` writes:
+# "<base>-<7-hex-sha>.<ext>" or "<base>-<7-hex-sha>" for extension-less files.
+RUN_ID_RE = re.compile(r"-([0-9a-f]{7})(\.[^.]*)?$")
+
+
+def gh_api(*args: str) -> str:
+    result = subprocess.run(
+        ["gh", "api", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release", required=True, help="release TAG to prune (only this release is ever touched)"
+    )
+    parser.add_argument("--keep-runs", type=int, default=SIM_PREVIEW_KEEP_RUNS)
+    parser.add_argument(
+        "--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="OWNER/REPO, defaults to $GITHUB_REPOSITORY"
+    )
+    args = parser.parse_args()
+
+    if not args.repo:
+        print("::error::--repo not given and GITHUB_REPOSITORY is unset", file=sys.stderr)
+        return 1
+
+    release = json.loads(gh_api(f"repos/{args.repo}/releases/tags/{args.release}"))
+    release_id = release["id"]
+
+    # --paginate concatenates every page into one JSON array, so this is the
+    # full asset list for THIS release id regardless of how many pages it spans.
+    assets = json.loads(gh_api("--paginate", f"repos/{args.repo}/releases/{release_id}/assets"))
+
+    runs: dict[str, list[dict]] = defaultdict(list)
+    unmatched = []
+    for asset in assets:
+        m = RUN_ID_RE.search(asset["name"])
+        if not m:
+            unmatched.append(asset["name"])
+            continue
+        runs[m.group(1)].append(asset)
+
+    if unmatched:
+        print(f"leaving {len(unmatched)} non-sha-stamped asset(s) alone: {unmatched}")
+
+    # A run's recency is the newest created_at among its own assets.
+    run_recency = {run_id: max(a["created_at"] for a in group) for run_id, group in runs.items()}
+    ordered_runs = sorted(run_recency, key=lambda r: run_recency[r], reverse=True)
+
+    keep_runs = set(ordered_runs[: args.keep_runs])
+    prune_runs = [r for r in ordered_runs if r not in keep_runs]
+
+    print(
+        f"release '{args.release}' (id {release_id}): {len(assets)} asset(s) across "
+        f"{len(ordered_runs)} run(s); keeping the {len(keep_runs)} most recent, "
+        f"pruning {len(prune_runs)} older run(s)"
+    )
+
+    to_delete = [asset for run_id in prune_runs for asset in runs[run_id]]
+    if not to_delete:
+        print("nothing to prune")
+        return 0
+
+    failures = []
+    for asset in to_delete:
+        try:
+            subprocess.run(
+                ["gh", "api", "-X", "DELETE", f"repos/{args.repo}/releases/assets/{asset['id']}"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            failures.append((asset["name"], exc.stderr))
+
+    deleted = len(to_delete) - len(failures)
+    print(f"deleted {deleted}/{len(to_delete)} asset(s)")
+
+    if failures:
+        for name, err in failures:
+            print(f"::error::failed to delete asset '{name}': {err.strip()}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #116.

## Problem
`sim-preview` sits at GitHub's hard 1000-asset-per-release cap. Every PR
run appends ~21 sha-stamped assets and nothing ever pruned them, so
`publish-sim-artifact` has been failing on the *Publish sha-stamped
preview* step on every PR since the cap was hit (`HTTP 422: file_count
limited to 1000 assets per release`).

## Fix — two non-destructive halves, exactly as scoped in #116

1. **Roll to a fresh release tag.** `publish-sim-artifact` now publishes
   PR previews to `sim-preview-v2` (named via a job-level `env:` constant,
   `SIM_PREVIEW_RELEASE`) instead of `sim-preview`. The cap resets, every
   existing `sim-preview` URL keeps working (Notion links included), and
   the old release is not touched in any way — it just stops receiving new
   uploads. Its creation notes explain the roll-over and link back to #116.

2. **Prune on publish, so it cannot recur.** New `scripts/prune_sim_preview.py`,
   run as a step after every PR publish. It keeps the newest
   `SIM_PREVIEW_KEEP_RUNS` (30) runs' worth of assets on `SIM_PREVIEW_RELEASE`
   and deletes older ones.
   - **Arithmetic:** ~21 assets land per PR run against GitHub's 1000-asset
     cap. Keeping the last 30 runs is ~630 assets — real headroom below the
     cap even if the per-run count grows somewhat. `SIM_PREVIEW_KEEP_RUNS`
     is a named constant in the job's `env:` block, not a literal buried in
     a shell step.
   - **Cannot touch `sim-latest` or `sim-experiments` by construction, not
     convention:** every asset the script can see or delete comes from
     `gh api repos/<repo>/releases/<id>/assets`, where `<id>` is resolved
     from the one `--release` tag passed in (`SIM_PREVIEW_RELEASE`). There
     is no code path that reaches a different release's assets. Verified
     directly: pointed the script (read-only, `--keep-runs 999999`) at
     `sim-latest` — its 21 real assets have no sha-stamped suffix, so the
     script logs them all as "non-sha-stamped, leaving alone" and prunes
     nothing.
   - **A deletion failure fails the step**, not silently — no `|| true`,
     no swallowed exit code. A green publish job that pruned nothing while
     claiming success is exactly the failure class #116 calls out.

## Verified, not assumed

- Ran the actual script (read-only, `--keep-runs 999999`, so nothing is
  deleted) against the real, live `sim-preview` release to confirm parsing
  and pagination work end to end: **1000 assets across 80 distinct runs**,
  correctly grouped and ordered by `created_at`. Nothing was deleted —
  `sim-preview` is **still at 1000 assets, unchanged**, both before and
  after this PR (confirmed via `gh release view sim-preview --json assets
  --jq '.assets | length'` → `1000` both times).
- `GITHUB_ACTIONS=1 POLICY_BRANCH=feat/controls/preview-release-cap
  POLICY_BASE_REF=origin/master python3 .github/policy_check.py` → all
  hard checks pass (doc-drift overridden via `DOC-OK:` — this PR only
  touches the PR-preview publishing path, not the `sim-latest` /
  claims-manifest / web-pipeline mechanics `docs/design-claims-manifest.md`
  and `docs/web-artifact-pipeline.md` describe).
- `publish-sim-artifact`'s own run on this PR is the live demonstration
  that it goes green again — see the PR checks.

## Hard prohibition honored
No assets were deleted from the existing `sim-preview` release. Not in
testing, not in the shipped mechanism (which only ever touches
`sim-preview-v2`), not anywhere. Whether to eventually tidy `sim-preview`
itself stays the CEO's deferred call.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>