### PR TITLE
fix(ci): build the Rust-hosted impulse-response binary in publish-sim-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,15 @@ jobs:
       - name: Build the plant-mujoco replay binary
         run: cargo build --release -p plant-mujoco --bin plant-replay
 
+      # I1c (issue #107, AC6): tests/test_rust_hosted_impulse_response.py shells
+      # out to this binary, same as the `sim` job above. Missing here since
+      # #120 added the binary and its test without updating this job -- the
+      # same "fail rather than pass vacuously" check meant `Emit claims
+      # manifest` below has been failing on every push since, silently,
+      # because this job is not a required status check.
+      - name: Build the Rust-hosted impulse-response binary
+        run: cargo build --release -p board-app-driverless --bin impulse-response-rust
+
       # Only tests that PASS contribute a claim (docs/design-claims-manifest.md,
       # issue #61). A red run here still writes a manifest of whatever passed,
       # but the step itself fails loudly -- this job already needs `sim` green,

--- a/roles/senior-controls/log/2026-07-31-publish-sim-artifact-missing-build-step.md
+++ b/roles/senior-controls/log/2026-07-31-publish-sim-artifact-missing-build-step.md
@@ -1,0 +1,28 @@
+# CI fix — publish-sim-artifact missing the Rust-hosted impulse-response build step (PR TBD)
+
+Found while watching PR #122's checks: `publish-sim-artifact` was failing on that PR, and on
+every push to master since #120 (I1c) merged — confirmed via `actions_list`/`get_job_logs`
+against the last three master runs (`d1dfddd`, `14559c4`, `32f4d71`), all `conclusion: failure`
+on this job specifically, while `sim` and `rust` stayed green.
+
+**Root cause:** #120 added `crates/board-app-driverless/src/bin/impulse-response-rust.rs` and
+`tests/test_rust_hosted_impulse_response.py`, and wired a "Build the Rust-hosted impulse-response
+binary" step into the `sim` job (`.github/workflows/ci.yml:158-163`) — but the `publish-sim-artifact`
+job's own "Emit claims manifest" step also runs `pytest tests/` (per its existing comment) and
+never got the equivalent build step. The new test file's own "fail rather than skip" binary-exists
+check (added by #117's precedent) correctly failed the suite there, silently, because
+`publish-sim-artifact` is deliberately not a required status check (CLAUDE.md) — so nothing
+blocked on it and nobody saw it.
+
+**Fix:** added the same `cargo build --release -p board-app-driverless --bin
+impulse-response-rust` step to `publish-sim-artifact`, mirroring the `sim` job's existing step
+and comment style. Verified locally: rebuilt all three binaries
+(`control-ffi`/`plant-replay`/`impulse-response-rust`) and ran `scripts/emit_claims.py` (the exact
+step that was failing) — 266 passed, 2 xfailed, `wrote 1 claim to sim/out/claims.json`.
+
+**Deliberately kept separate from PR #122** (the delay-budget work) rather than bundled in —
+this is a pre-existing, unrelated regression, not something #122's diff touches or caused.
+
+**Not fixed, flagged instead:** whether `publish-sim-artifact` should become a required check now
+that it would actually be green — that's a policy/CODEOWNERS-adjacent question outside a single
+CI-step fix, and not this PR's job to decide.


### PR DESCRIPTION
## What changed and why

Found while watching PR #122's checks: the `publish-sim-artifact` job has been failing on every
push to master since #120 (I1c) merged — confirmed against the last three master runs
(`d1dfddd`, `14559c4`, `32f4d71`), all `conclusion: failure` on this specific job while `sim` and
`rust` stayed green. Nobody saw it because `publish-sim-artifact` is deliberately not a required
status check (it renders with an offscreen GL stack that must not be able to block a merge whose
physics passed — see the job's own comment).

**Root cause:** #120 added `crates/board-app-driverless/src/bin/impulse-response-rust.rs` and
`tests/test_rust_hosted_impulse_response.py`, wiring a "Build the Rust-hosted impulse-response
binary" step into the `sim` job — but `publish-sim-artifact`'s own "Emit claims manifest" step
also runs `pytest tests/` (per its existing comment) and never got the equivalent build step. The
new test file's own "fail rather than skip if the binary is missing" check (the same discipline
#117 established for the plant-replay binary) correctly failed the suite there.

**Fix:** one line — add the same `cargo build --release -p board-app-driverless --bin
impulse-response-rust` step to `publish-sim-artifact`, mirroring the `sim` job's existing step
and comment style exactly.

## Why a separate PR from #122

This is a pre-existing regression already on master, unrelated to #122's (the delay-budget work)
diff — surfaced by watching that PR's CI, not caused by it. Keeping it separate keeps both PRs
reviewable on their own terms.

## Testing

Rebuilt all three binaries locally (`control-ffi`, `plant-mujoco::plant-replay`,
`board-app-driverless::impulse-response-rust`) and ran `scripts/emit_claims.py` — the exact step
that was failing: **266 passed, 2 xfailed**, `wrote 1 claim to sim/out/claims.json`.
`python3 .github/policy_check.py` passes (one `DOC-OK` recorded for two docs whose `covers:`
manifest lists `ci.yml` but whose described mechanisms this change doesn't touch).

Not fixed here, flagged instead: whether `publish-sim-artifact` should become a required check
now that it would actually be green — a policy/CODEOWNERS-adjacent question outside a one-line
CI fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xmkc47PdAswAU3mhqCxeBi)_