### PR TITLE
ops: ratify Senior Digital Marketer, register Content Designer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -179,6 +179,8 @@
 /roles/senior-controls/         @MikePaNtZ
 # role: Archivist
 /roles/archivist/               @MikePaNtZ
+# role: Content Designer
+/roles/content-designer/        @MikePaNtZ
 
 # --------------------------------------------------------------------------
 # The canonical term list, in git so a machine can read it.

--- a/docs/decisions/ROLES.md
+++ b/docs/decisions/ROLES.md
@@ -39,7 +39,8 @@ All-three-or-none is the definition of `Ratified`. It is **not** a precondition 
 | `CEO` | Ratified | — | — | Direction, public claims, licence, money. Final arbiter |
 | `COO` | Ratified | `CEO` | `feat/ops/` | Cross-role operations, the decision record, the escalation queue for the engineering line |
 | `CMO` | Ratified | `CEO` | — | The marketing line. Peer of COO — neither escalates to the other. Owns nothing in this repo by design; brand lives in `overboard-web` |
-| `Senior Digital Marketer` | Provisional | `CMO` | `feat/web/` | Landing page, brand and visual identity, page copy, analytics — in `overboard-web` |
+| `Senior Digital Marketer` | Ratified | `CMO` | `feat/web/` | Landing page, brand and visual identity, page copy, analytics — in `overboard-web` |
+| `Content Designer` | Provisional | `Senior Digital Marketer` | `feat/copy/` | Public copy craft to the Style Guide, and UX fit-and-finish. **No exclusive path by design** — works in files the SDM owns, gated by SDM review |
 | `Digital Content Production` | Ratified | `Senior Digital Marketer` | `feat/content/` | Renders and published media. Explicitly **not** page markup or CSS |
 | `Sr. Mechanical & Systems` | Ratified | `COO` | `feat/mech/` | BoM, platform selection, the bench rig, the sim-to-hardware fidelity contract |
 | `Senior Controls` | Ratified | `COO` | `feat/controls/` | The control law and its harness |
@@ -52,9 +53,13 @@ skipped** every branch those two roles pushed: it fails open for roles with no d
 so the two most active engineering roles had no turf enforcement at all. Caught by a dispatched
 agent, not by me.
 
+✅ **`Senior Digital Marketer` is RATIFIED as of 2026-07-31**, and its `feat/web/` prefix is
+observed rather than inferred. It could not be ratified before now for a concrete reason:
+`overboard-web` had **no CODEOWNERS at all**, so the second of the three legs did not exist to
+point at. Ported in overboard-web#35; the flag follows the artefact, not the other way round.
+
 ⚠️ **Still unverified.** Escalation targets for `Sr. Mechanical & Systems` and
-`Senior Controls`, the branch prefixes for `Digital Content Production` and
-and the branch prefix for `Senior Digital Marketer` are **inferred** — from the
+`Senior Controls`, and the branch prefix for `Digital Content Production`, are **inferred** — from the
 COO's own charter ("receives from Sr. Mechanical and Systems Engineering"), from branch
 conventions observed in sibling repos. The `Archivist` is no longer among them — the CEO
 declared its surface on 2026-07-27 and it was ratified the same day. Inferring turf from a branch prefix is guessing, which is the thing this registry

--- a/roles/content-designer/CONTEXT.md
+++ b/roles/content-designer/CONTEXT.md
@@ -1,0 +1,55 @@
+# Content Designer — working context
+
+Granted by the CEO 2026-07-31. Registered `Provisional` the same day.
+**`Provisional` is not probation** — it means shared/additive turf rather than
+exclusive paths, and here that is deliberate rather than temporary (see below).
+
+- **Worktree:** `~/projects/overboard-copy` (ADR-0006 — one worktree per role, never share a working directory)
+- **Branch prefix:** `feat/copy/`
+- **Escalates to:** Senior Digital Marketer
+- **Read first:** the Voice & Style Guide (Notion) · `overboard-web/CLAUDE.md` · [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+
+## Owns
+
+Public copy craft to the Style Guide, and UX fit-and-finish.
+
+## Does not own
+
+- **Adversarial review of its own work** — that is the SDM's, and it is the whole mechanism.
+  `overboard-web/CLAUDE.md` is explicit: the reviewer is never the author. Never self-clear,
+  and never queue your own copy with `--auto`.
+- The Voice & Style Guide itself — the CMO's.
+- Renders and published media — Digital Content Production's.
+- Markup structure decisions — the SDM's.
+
+## No exclusive path, by design
+
+This role works in files the SDM owns (`index.html`, page copy) and its PRs are gated by
+SDM review rather than by CODEOWNERS. **Adding a competing owner on `index.html` would create
+exactly the ambiguity CODEOWNERS exists to remove.** If a copy-only surface ever appears — a
+`content/` directory, a posts folder — the CMO proposes it as an exclusive path then.
+
+So `Provisional` costs this role nothing today. Do not read it as a queue to be cleared.
+
+## Standing rule
+
+**Every public piece names its Tier 1 persona before it is written, and carries something the
+reader can run, open or check.**
+
+## What this role must not do
+
+- Publish a capability claim the site cannot back. The lock-step rule (`SR-WEB-4`) is hard: a
+  claim may not appear unless a requirement backs it, and one that becomes false comes off in
+  the same pass.
+- Caption a **Concept** asset as though the thing happened, or attach figures to one. The
+  publication category fixes the tense and the numbers of the copy beside it.
+- Discuss strategy, funding, or role assignments in a public GitHub issue or PR. Cross-role
+  communication goes in Notion (CEO direction, 2026-07-28).
+
+## Decisions made (edit in place — completed work goes in log/, not here)
+
+_Nothing recorded yet._
+
+## Known dead ends
+
+_Nothing recorded yet._

--- a/roles/content-designer/log/README.md
+++ b/roles/content-designer/log/README.md
@@ -1,0 +1,6 @@
+# Role logs
+
+One file per completed piece of work: `YYYY-MM-DD-<slug>.md`.
+
+Separate files never merge-conflict. A shared append-list does, every time, once more than one
+agent is in flight.


### PR DESCRIPTION
Closes #118 — registry paperwork owed by the COO, one item of which was five days overdue.

## Ratified: Senior Digital Marketer

`Provisional` since 2026-07-26. **It could not be ratified before today for a concrete reason, not an oversight:** `ROLES.md` defines `Ratified` as *all-three-or-none*, and `overboard-web` had **no CODEOWNERS at all** — the second leg did not exist to point at.

Ported in [overboard-web#35](https://github.com/MikePaNtZ/overboard-web/pull/35), merged, and **only then** flipped here. The flag follows the artefact.

That ordering is the whole lesson from this morning: the Archivist was marked `Ratified` with no CODEOWNERS rule behind it, and it silently blocked them from writing their own context file until the turf check started actually running. **Flipping a flag ahead of its artefact is how a registry stops meaning anything.**

## Registered `Provisional`: Content Designer

CEO-granted 2026-07-31. Per `ROLES.md` the role **exists from the moment of the grant** — this is paperwork, not permission. Escalates to the SDM, prefix `feat/copy/`.

**No exclusive path, deliberately rather than temporarily.** It works in files the SDM owns and its PRs are gated by SDM review; a competing owner on `index.html` would create exactly the ambiguity CODEOWNERS exists to remove. So `Provisional` costs this role nothing and should not be read as a queue to be cleared.

## Registered *and usable*, which is the part that matters

- `roles/content-designer/CONTEXT.md` — the CMO's proposed content, plus the review rule that matters most: **the reviewer is never the author**, never self-clear, never queue your own copy with `--auto`.
- `roles/content-designer/log/` — one file per entry, per #92.
- **A CODEOWNERS rule so the role owns its own context directory from day one.** `--who` now answers `Content Designer [Provisional]` instead of falling through to `/roles/` and the COO. That is the Archivist defect, not repeated.

The `role:content-designer` label already existed in all four repos — the CMO created it ahead of registration, so routing worked the moment the row landed.

## The gate caught this PR three times, and two were fair

**Turf** — I edited `roles/content-designer/` which this same commit assigns to the Content Designer. Unavoidable: someone has to create a role's first files and it cannot be the role itself, which has no session and no context file to read until they exist. Overridden with the reason in git history.

**role-log** — `CONTEXT.md` grew `+55/-0`, which the check reads as an append. **It is a new file**, and the check cannot tell creation from appending because both look like additions with no deletions.

**That is a false positive, and the second one.** The rule I set when I shipped that check was that a *recurring* override is the signal to fix it rather than keep overriding. So the fix follows in its own PR: a file added in the diff has no prior content to conflict with, so the parallel-agent rationale does not apply and it should be exempt **by construction rather than by override**.

Not folded in here on purpose — registry paperwork and a CI-check change are different concerns, and bundling them would make the check's own diff harder to review.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
