### PR TITLE
fix(controls): sim-backend populates erpm, Rust-hosted seam runs mode 1 (#121)

### DIFF
--- a/crates/board-app-driverless/src/bin/impulse-response-rust.rs
+++ b/crates/board-app-driverless/src/bin/impulse-response-rust.rs
@@ -22,19 +22,19 @@
 //! Nothing here is a new control law -- it is the existing one, driven
 //! through the other seam.
 //!
-//! # Why `estimator_accel_aiding` mode 2 (command feedforward), not mode 1
-//! (wheel odometry)
+//! # Why `estimator_accel_aiding` mode 1 (wheel odometry), matching
+//! `RustController()`'s own default
 //!
-//! `hal::Observation` carries raw IMU and `motor_current_a` (DR-OBS-1) but no
-//! wheel-rate/ERPM channel yet -- `control_core::Controller`'s real wiring
-//! (a separate, later increment) is where that plumbing belongs, not a
-//! throwaway harness. Mode 2 needs only the current already on the
-//! observation, so it is the config this harness can host faithfully today.
+//! An earlier revision of this module's doc claimed `hal::Observation`
+//! "carries raw IMU and `motor_current_a` (DR-OBS-1) but no wheel-rate/ERPM
+//! channel yet" and used mode 2 (command feedforward) instead. **That claim
+//! was wrong** (issue #121): `Observation` has carried `erpm` since DR-OBS-1;
+//! `sim-backend` simply left it at its default. Issue #121 populates `erpm`
+//! from the plant's `wheel_hinge` joint velocity, so this harness now hosts
+//! the SAME mode `RustController()` defaults to and `test_closed_loop.py`
+//! gates on, rather than a mode chosen only because a field was empty.
 //! `tests/test_rust_hosted_impulse_response.py` configures its Python-hosted
-//! comparator identically (same mode, same gain, same gate), rather than
-//! reusing `test_closed_loop.py`'s wheel-odometry default -- the two are not
-//! interchangeable and comparing across the difference would not test this
-//! seam.
+//! comparator identically (same mode, same gain, same gate).
 //!
 //! # Output
 //!
@@ -42,8 +42,8 @@
 //! `peak_abs_pitch_deg`, `t_peak_s`, `settle_time_s` (`-1.0` means "never
 //! settled", mirroring the Python side's `None`), `final_pitch_deg`.
 
-use board_types::{Command, Faults, ImuSample, Params};
-use control_core::{CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator};
+use board_types::{Command, Faults, ImuSample, Params, DEFAULT_R_EFF_M, RAD_S_PER_ERPM};
+use control_core::{ComplementaryFilter, Estimator, PitchRegulator, WheelAccelEstimator};
 use hal::BoardObserve;
 use hal_actuate::BoardActuate;
 use safety::Envelope;
@@ -69,18 +69,18 @@ const FORCE_N: [f64; 3] = [-(NOMINAL_IMPULSE_NS / DURATION_S), 0.0, 0.0];
 // --- Controller config (issue #107 AC6). Kp/Kd/max_current_a/r_eff_m match
 // sim/scenarios/rust_controller.py's DEFAULT_* constants; com_above_axle
 // matches the driverless plant (mass below the axle); estimator_tau_s and
-// the feedforward gain fallback match control-ffi::ob_controller_new's own
-// defaults for these modes. See the module doc comment for why aiding mode 2
-// (command feedforward) is used instead of `RustController()`'s own default
-// (mode 1, wheel odometry).
+// wheel_accel_tau_s match control-ffi::ob_controller_new's own defaults /
+// RustController()'s own defaults (issue #121: mode 1, wheel odometry, is
+// now the mode both hosts run -- see the module doc comment).
 const KP_A_PER_RAD: f32 = 80.0;
 const KD_A_PER_RAD_S: f32 = 11.0;
 const MAX_CURRENT_A: f32 = 40.0;
 const ESTIMATOR_TAU_S: f32 = 1.0;
-/// `control-ffi::ob_controller_new`'s own fallback when
-/// `accel_ff_gain_m_s2_per_a <= 0.0` -- kept identical here so both hosts run
-/// the exact same numeric gain, not two independently-chosen ones.
-const ACCEL_FF_GAIN_M_S2_PER_A: f32 = 0.0584;
+/// `RustController()`'s own default (`sim/scenarios/rust_controller.py`,
+/// `wheel_accel_tau_s`) -- kept identical here so both hosts filter the wheel
+/// speed derivative with the same time constant, not two independently
+/// chosen ones.
+const WHEEL_ACCEL_TAU_S: f32 = 0.05;
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
@@ -114,8 +114,7 @@ fn main() -> ExitCode {
 
     let regulator = PitchRegulator::new(KP_A_PER_RAD, KD_A_PER_RAD_S);
     let mut estimator = ComplementaryFilter::with_trust_band(ESTIMATOR_TAU_S, 0.0);
-    let feedforward = CommandFeedforward::new(ACCEL_FF_GAIN_M_S2_PER_A);
-    let mut last_amps: f32 = 0.0;
+    let mut wheel_accel = WheelAccelEstimator::new(WHEEL_ACCEL_TAU_S);
 
     // dt used only to size the run and to mirror
     // sim/scenarios/impulse_response.py's `n_steps = round(sim_seconds/dt)`.
@@ -163,17 +162,19 @@ fn main() -> ExitCode {
 
         // Controller: raw IMU -> estimate -> regulate -> envelope, the same
         // chain control-ffi::ob_controller_update runs, reached here through
-        // hal instead of the C ABI.
+        // hal instead of the C ABI. Aiding (mode 1, wheel odometry, issue
+        // #121): `obs.erpm` round-tripped back through the same ICD-sourced
+        // ratio `sim-backend` used to produce it, into ground speed via
+        // `r_eff_m`, then differentiated -- the same
+        // `control-ffi::ob_controller_update` chain, `(None,
+        // wheel_accel.as_mut())` branch, just reached natively.
         let sample = obs.newest_imu().copied().unwrap_or(ImuSample::ZERO);
-        let aiding = feedforward.predict(last_amps);
+        let wheel_rate_rad_s = obs.erpm * RAD_S_PER_ERPM;
+        let aiding = wheel_accel.update(wheel_rate_rad_s * DEFAULT_R_EFF_M, dt_s as f32);
         let attitude = estimator.update(std::slice::from_ref(&sample), aiding);
         let proposed = regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
         let (bounded_cmd, _envelope_sat) =
             envelope.apply(Command::MotorCurrent { amps: proposed }, Faults::NONE);
-        last_amps = match bounded_cmd {
-            Command::MotorCurrent { amps } => amps,
-            Command::RemoteSpeed { .. } => 0.0,
-        };
 
         if let Err(e) = backend.apply(&bounded_cmd) {
             eprintln!("impulse-response-rust: apply failed: {e:?}");

--- a/crates/board-types/src/lib.rs
+++ b/crates/board-types/src/lib.rs
@@ -35,6 +35,24 @@ use serde::{Deserialize, Serialize};
 /// eventual bench-measured loaded rolling radius (ICD §10.5) supersedes it.
 pub const DEFAULT_R_EFF_M: f32 = 0.1454;
 
+/// Mechanical wheel rate, rad/s, per 1 ERPM. ICD §10.5: "1 ERPM = 6.98e-3
+/// rad/s" — the same ratio `sim/scenarios/imperfections.py` names
+/// `wheel_rate_quantum_rad_s` (the size of one ERPM step in the wheel-rate
+/// domain). The single Rust-side source for that conversion, so
+/// `erpm <-> wheel_rate_rad_s` round-trips read the same number everywhere
+/// rather than each site hand-copying the literal (issue #121).
+///
+/// **Not derived from an independently-known pole-pair count.** VESC ERPM is
+/// electrical RPM (`mechanical_rpm * pole_pairs`), so this ratio implicitly
+/// encodes the motor's pole-pair count — back-solving `(2*pi/60) / 0.00698`
+/// lands close to 15, a plausible pole-pair count for a hoverboard-class hub
+/// motor, but **that back-derivation has not been confirmed against the
+/// actual motor** and is not asserted as fact here. The ICD's ratio is used
+/// directly instead of an independently guessed pole-pair count, per the
+/// project rule against fabricating a protocol constant that cannot be
+/// verified.
+pub const RAD_S_PER_ERPM: f32 = 0.00698;
+
 // ---------------------------------------------------------------------------
 // Commands — ICD §7.5
 // ---------------------------------------------------------------------------
@@ -381,6 +399,15 @@ mod tests {
         // on the Python side. This crate has no MuJoCo binding to check
         // against the compiled model directly; that check lives in Python.
         assert_eq!(DEFAULT_R_EFF_M, 0.1454);
+    }
+
+    #[test]
+    fn rad_s_per_erpm_matches_the_icd_quantum_sim_scenarios_imperfections_uses() {
+        // Regression pin against sim/scenarios/imperfections.py's
+        // `wheel_rate_quantum_rad_s` (STAGE0_PLACEHOLDER / cutback profiles) --
+        // same ICD §10.5 ratio, so the two cannot silently drift apart. No
+        // Python binding here, so this crate can only pin the literal.
+        assert_eq!(RAD_S_PER_ERPM, 0.00698);
     }
 
     #[test]

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -41,7 +41,7 @@
 
 use board_types::{
     Applied, Command, DisarmReason, FaultCode, ImuSample, IoError, Observation, Params, Profile,
-    RunMetadata, Saturation, ValidityFlags, DEFAULT_R_EFF_M,
+    RunMetadata, Saturation, ValidityFlags, DEFAULT_R_EFF_M, RAD_S_PER_ERPM,
 };
 use hal::{BoardObserve, CallSequence};
 use hal_actuate::{BoardActuate, Disarm};
@@ -97,6 +97,11 @@ pub struct SimBackend {
     /// `(adr, dim)` into `mjData::sensordata`, resolved once in `open()`.
     gyro_sensor: (usize, usize),
     accel_sensor: (usize, usize),
+    /// `wheel_hinge`'s `jointvel` sensor (issue #121) -- already declared in
+    /// `overboard_onewheel.xml`, unread until now. Same joint and sign
+    /// convention the model's own motor sign comment and `ctrl` use, so no
+    /// extra sign flip is needed here.
+    wheel_vel_sensor: (usize, usize),
     /// `mjModel` body id of the `frame` body, resolved once in `open()`.
     /// Only used by [`SimBackend::apply_external_force`], not by `hal`.
     frame_body: usize,
@@ -230,6 +235,9 @@ impl BoardObserve for SimBackend {
         self.accel_sensor = plant
             .sensor_adr_dim("frame_accel")
             .expect("overboard_onewheel.xml must declare a frame_accel sensor");
+        self.wheel_vel_sensor = plant
+            .sensor_adr_dim("wheel_vel")
+            .expect("overboard_onewheel.xml must declare a wheel_vel sensor");
         self.frame_body = plant
             .body_id("frame")
             .expect("overboard_onewheel.xml must declare a frame body");
@@ -297,6 +305,20 @@ impl BoardObserve for SimBackend {
         let gyro_icd = [-gyro[0] as f32, gyro[1] as f32, -gyro[2] as f32];
         let accel_icd = [-accel[0] as f32, accel[1] as f32, -accel[2] as f32];
 
+        // Wheel rate (issue #121): same `wheel_hinge` joint and sign
+        // convention `ctrl` uses, read via the model's existing `wheel_vel`
+        // jointvel sensor -- read AFTER stepping, same ordering rule as the
+        // IMU sensors above. Converted to ERPM through the single
+        // ICD-sourced ratio (`RAD_S_PER_ERPM`), not quantised to the nearest
+        // integer ERPM: this backend has no imperfection-profile plumbing
+        // yet (see this crate's own header on the actuation-delay stub), so
+        // like `motor_current_a` this is the idealised, noiseless reading --
+        // integer ERPM quantisation is `imperfections.py`'s
+        // `wheel_rate_quantum_rad_s` row, which has no Rust-side home yet.
+        let wheel_rate_rad_s =
+            plant.read_sensor(self.wheel_vel_sensor.0, self.wheel_vel_sensor.1)[0];
+        let erpm = (wheel_rate_rad_s / RAD_S_PER_ERPM as f64) as f32;
+
         let mut obs = Observation::COLD_START;
         obs.cycle = self.cycle;
         obs.t_recv_ns = t_ns;
@@ -307,6 +329,20 @@ impl BoardObserve for SimBackend {
         };
         obs.imu_count = 1;
         obs.motor_current_a = self.applied_current_a;
+        obs.erpm = erpm;
+        // Honestly fresh, not a leftover default (issue #121 AC3): the sim
+        // has no ERPM transport lag to model, so every cycle's ERPM really is
+        // as fresh as the frame carrying it -- unlike hardware, where ICD
+        // §8.4 warns this can be far staler at low speed.
+        obs.erpm_effective_age_ns = 0;
+        // `tacho_raw` and `duty` are deliberately left at COLD_START's zero,
+        // not an oversight (issue #121 AC2): neither has an established,
+        // verifiable semantics to populate honestly yet. `tacho_raw` is a
+        // raw e-rev counter whose wrap/reset convention on the real VESC is
+        // not documented anywhere this project can check; `duty` depends on
+        // bus voltage and back-EMF, which this backend does not model at
+        // all. Inventing either would be presenting a fabricated protocol
+        // quantity as data, which this project rules out explicitly.
         obs.validity = ValidityFlags::ALL_FRESH;
 
         self.seq.on_observe();

--- a/roles/senior-controls/log/2026-07-31-sim-backend-populates-erpm.md
+++ b/roles/senior-controls/log/2026-07-31-sim-backend-populates-erpm.md
@@ -1,0 +1,67 @@
+# Issue #121: `sim-backend` populates `erpm`, and the Rust-hosted seam runs the default estimator config
+
+`#120`'s module doc claimed `hal::Observation` "carries raw IMU and `motor_current_a` (DR-OBS-1)
+but no wheel-rate/ERPM channel yet." **That was wrong** — `Observation` has carried `erpm`,
+`erpm_effective_age_ns` and `tacho_raw` since DR-OBS-1; `sim-backend` simply never populated them.
+The distinction mattered because the wrong reason pointed at the most expensive possible fix (an
+ICD field-set change, a cross-role Promise) when the real one was local and entirely Senior
+Controls' — populating a field inside a crate this role owns.
+
+**`crates/sim-backend`** (AC1–AC3): resolves the model's existing `wheel_vel` `jointvel` sensor
+(already declared in `overboard_onewheel.xml`, unread until now — a `<sensor>` element, already
+Senior Controls turf, no model edit needed) in `open()`, alongside `frame_gyro`/`frame_accel`.
+`wait_observe()` reads it after stepping (same ordering rule as the IMU sensors) and converts to
+ERPM through one new constant, `board_types::RAD_S_PER_ERPM` (0.00698 rad/s per ERPM, ICD §10.5 —
+the same ratio `sim/scenarios/imperfections.py` calls `wheel_rate_quantum_rad_s`). **Not derived
+from an independently-known pole-pair count**: back-solving the ratio lands near 15 pole pairs, a
+plausible figure for a hoverboard-class hub motor, but that back-derivation is not confirmed
+against the real motor and is not asserted as fact — the ICD's own ratio is used directly instead
+of guessing an independent pole-pair count, per the project's rule against fabricating a protocol
+constant. Not quantised to the nearest integer ERPM: this backend has no imperfection-profile
+plumbing yet (its own header already says so for the actuation-delay stub), so like
+`motor_current_a` this is the idealised, noiseless reading — integer ERPM quantisation is
+`imperfections.py`'s row, which has no Rust-side home yet.
+
+`erpm_effective_age_ns` is set to `0` explicitly with a comment stating it is honestly fresh (the
+sim has no ERPM transport lag to model), not a leftover default. `tacho_raw` and `duty` are left
+at `COLD_START`'s zero **on purpose, documented in place** (AC2): `tacho_raw`'s real-VESC
+wrap/reset convention is not documented anywhere this project can check, and `duty` depends on bus
+voltage and back-EMF this backend does not model at all — populating either would be presenting a
+fabricated protocol quantity as data.
+
+**`crates/board-app-driverless/src/bin/impulse-response-rust.rs`** (AC4–AC5): now runs
+`estimator_accel_aiding` mode 1 (wheel odometry, via `control_core::WheelAccelEstimator`) instead
+of mode 2 (command feedforward) — the mode `RustController()` defaults to and `test_closed_loop.py`
+gates on, no longer avoided only because a field was empty. Round-trips `obs.erpm` back through
+`RAD_S_PER_ERPM` into wheel rate, then `DEFAULT_R_EFF_M` into ground speed, matching
+`control-ffi::ob_controller_update`'s own `(None, wheel_accel.as_mut())` branch. The module doc's
+wrong rationale is replaced with the corrected one.
+
+**`tests/test_rust_hosted_impulse_response.py`**: Python-hosted comparator switched to
+`estimator_accel_aiding=1` to match; the tolerance section now accounts for the ERPM round-trip's
+extra `f32` rounding (algebraically cancels through the same ratio, smaller than the pre-existing
+summation-order noise budget) — same bounds, not loosened.
+
+## Testing
+
+- `python3 -m pytest tests/` — 266 passed, 2 xfailed (new `board-types` unit test included via
+  `cargo test`, not pytest).
+- `cargo test --workspace` — all green, including a new regression pin
+  (`rad_s_per_erpm_matches_the_icd_quantum_sim_scenarios_imperfections_uses`) so
+  `board_types::RAD_S_PER_ERPM` cannot silently drift from `imperfections.py`'s
+  `wheel_rate_quantum_rad_s`.
+- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
+- `cargo fmt --check` — clean.
+- `cargo run -p xtask -- gate` — passes.
+- `python3 .github/policy_check.py` — all hard checks pass (advisories unrelated to this change).
+
+## Deliberately left out
+
+- Any change to `Observation`'s field set — the issue's whole point is that none was needed.
+- Integer ERPM quantisation / update-rate modelling — that is `imperfections.py`'s
+  `wheel_rate_quantum_rad_s` row, and `sim-backend` has no imperfection-profile plumbing to hang it
+  on yet (a separate, larger increment, out of scope here).
+- The ridden/cascade plant's Rust-hosted seam — this issue and its harness are driverless-only, per
+  `sim-backend`'s own scope.
+
+Closes #121.

--- a/tests/test_rust_hosted_impulse_response.py
+++ b/tests/test_rust_hosted_impulse_response.py
@@ -20,17 +20,16 @@ bit-exact open-loop equivalence (`test_rust_python_plant_replay_equivalence.py`)
 is what rules that out, and it must be green for this test's result to mean
 anything.
 
-WHY THE CONTROLLER CONFIG DIFFERS FROM `test_closed_loop.py`'s DEFAULT
+WHY THE CONTROLLER CONFIG STILL DIFFERS FROM `test_closed_loop.py`'s DEFAULT
 --------------------------------------------------------------------------
-`hal::Observation` carries raw IMU and `motor_current_a` (DR-OBS-1) but no
-wheel-rate/ERPM channel yet -- that plumbing belongs to
-`control_core::Controller`'s real wiring, a separate, later increment, not a
-throwaway comparison harness. So both hosts here use
-`estimator_accel_aiding=2` (command feedforward, needs only the current
-already on the observation) rather than `RustController()`'s own default
-(mode 1, wheeled odometry). This is a DIFFERENT configuration from
-`test_closed_loop_prevents_the_nose_strike`'s 0.879 deg baseline and the two
-numbers are not comparable to each other.
+Both hosts here now run `estimator_accel_aiding=1` (wheel odometry) --
+`RustController()`'s own default, the same mode `test_closed_loop.py` gates
+on (issue #121; `sim-backend` now populates `erpm` from the plant, so this is
+no longer forced to mode 2 by a hal field nobody filled in). The two runs are
+still not directly comparable to `test_closed_loop_prevents_the_nose_strike`'s
+0.879 deg baseline: this scenario is the driverless plant / impulse response,
+that one is the ridden/cascade plant -- different mass, different disturbance,
+different everything except the mode number.
 
 WHY `profile=IDEAL`
 --------------------
@@ -48,11 +47,16 @@ THE TOLERANCE, STATED BEFORE THE COMPARISON RAN
 -------------------------------------------------
 Both hosts run the literal same compiled `control-core`/`safety` objects
 (one reached via `control-ffi`'s C ABI, one called natively) against the
-literal same `libmujoco.so` I1b already proved bit-identical open-loop. The
-only mechanism left that could make them diverge over a 4000-step, chaotic,
-contact-rich trajectory is floating-point summation-order noise -- utterly
-negligible relative to the control loop's own excursions. So the bound below
-is generous on purpose, not fitted to what was observed:
+literal same `libmujoco.so` I1b already proved bit-identical open-loop. Mode 1
+now round-trips wheel rate through ERPM on the Rust side (`sim-backend`
+divides by `RAD_S_PER_ERPM`, this binary multiplies back) where the
+Python-hosted comparator casts `data.qvel[6]` to `f32` directly -- an extra
+`f32` rounding through a ratio that otherwise cancels algebraically, smaller
+than the summation-order noise below it. So the only mechanism left that
+could make the two diverge over a 4000-step, chaotic, contact-rich trajectory
+is still floating-point noise -- utterly negligible relative to the control
+loop's own excursions. So the bound below is generous on purpose, not fitted
+to what was observed:
 
   * `peak_abs_pitch_deg`: absolute difference < 0.1 deg
   * `t_peak_s` / `settle_time_s`: absolute difference < 0.01 s (5 control
@@ -111,8 +115,7 @@ def _python_hosted_metrics() -> dict:
     model = load_model()
     with RustController(
         com_above_axle=False,
-        estimator_accel_aiding=2,
-        accel_ff_current_source=0,
+        estimator_accel_aiding=1,
     ) as controller:
         result = run(
             ImpulseParams(magnitude_ns=NOMINAL_IMPULSE_NS),


### PR DESCRIPTION
## What changed and why

Issue #121 caught a misdiagnosis in #120's own module doc: `hal::Observation` was said to carry
"raw IMU and `motor_current_a` (DR-OBS-1) but no wheel-rate/ERPM channel yet." **That was wrong.**
`Observation` has carried `erpm`, `erpm_effective_age_ns` and `tacho_raw` since DR-OBS-1;
`sim-backend` simply never populated them. The distinction mattered: as written, the wrong reason
sends the next reader to add a field to `Observation` — an ICD change, a cross-role Promise. The
actual fix is local and entirely Senior Controls' — populate an existing field inside a crate this
role owns.

### `crates/sim-backend` (AC1–AC3)

- Resolves the model's existing `wheel_vel` `jointvel` sensor (already declared in
  `overboard_onewheel.xml`, unread until now — a `<sensor>` element, already Senior Controls turf,
  **no model edit needed**) in `open()`, alongside `frame_gyro`/`frame_accel`.
- `wait_observe()` reads it after stepping and converts to ERPM through one new constant,
  `board_types::RAD_S_PER_ERPM` (0.00698 rad/s per ERPM — ICD §10.5, the same ratio
  `sim/scenarios/imperfections.py` calls `wheel_rate_quantum_rad_s`).
- **Not derived from an independently-known pole-pair count.** Back-solving the ratio lands near
  15 pole pairs — plausible for a hoverboard-class hub motor — but that back-derivation is not
  confirmed against the real motor and is not asserted as fact. The ICD's own ratio is used
  directly instead of guessing an independent pole-pair count, per the project's rule against
  fabricating an unverifiable protocol constant.
- Not quantised to the nearest integer ERPM: this backend has no imperfection-profile plumbing yet
  (its own header already says so for the actuation-delay stub), so — like `motor_current_a` —
  this is the idealised, noiseless reading. Integer ERPM quantisation is `imperfections.py`'s row,
  which has no Rust-side home yet.
- `erpm_effective_age_ns` set to `0` explicitly, commented as honestly fresh (no ERPM transport
  lag modelled), not a leftover default.
- `tacho_raw`/`duty` left at `COLD_START`'s zero **on purpose, documented in place** (AC2):
  `tacho_raw`'s real-VESC wrap/reset convention isn't documented anywhere this project can check,
  and `duty` depends on bus voltage/back-EMF this backend doesn't model at all. Populating either
  would be presenting a fabricated protocol quantity as data.

### `crates/board-app-driverless/src/bin/impulse-response-rust.rs` (AC4–AC5)

Now runs `estimator_accel_aiding` mode 1 (wheel odometry, via `control_core::WheelAccelEstimator`)
instead of mode 2 (command feedforward) — the mode `RustController()` actually defaults to and
`test_closed_loop.py` gates on, no longer avoided only because a field was empty. Round-trips
`obs.erpm` back through `RAD_S_PER_ERPM` into wheel rate, then `DEFAULT_R_EFF_M` into ground speed
— the same `control-ffi::ob_controller_update` branch, reached natively. Module doc's wrong
rationale replaced with the corrected one.

### `tests/test_rust_hosted_impulse_response.py`

Python-hosted comparator switched to `estimator_accel_aiding=1` to match. Tolerance section now
accounts for the ERPM round-trip's extra `f32` rounding (cancels algebraically through the same
ratio, smaller than the pre-existing summation-order noise budget) — **same bounds, not loosened**.

## Testing

- `python3 -m pytest tests/` — 266 passed, 2 xfailed.
- `cargo test --workspace` — all green, including a new regression pin
  (`rad_s_per_erpm_matches_the_icd_quantum_sim_scenarios_imperfections_uses`) so
  `RAD_S_PER_ERPM` can't silently drift from `imperfections.py`'s `wheel_rate_quantum_rad_s`.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo run -p xtask -- gate` — passes.
- `python3 .github/policy_check.py` — all hard checks pass (pre-existing advisories only,
  unrelated to this change).

## Deliberately left out

- Any change to `Observation`'s field set — the issue's whole point is that none was needed.
- Integer ERPM quantisation / update-rate modelling — that's `imperfections.py`'s
  `wheel_rate_quantum_rad_s` row, and `sim-backend` has no imperfection-profile plumbing to hang it
  on yet (a separate, larger increment).
- The ridden/cascade plant's Rust-hosted seam — this issue and its harness are driverless-only,
  per `sim-backend`'s own scope.

Closes #121.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxgE1ogFjUUexyJaQCuwnk)_