### PR TITLE
fix(controls): correct the delay budget's unstable pole, and measure its amplitude dependence

### DIFF
--- a/roles/senior-controls/log/2026-07-31-delay-budget-pole-correction.md
+++ b/roles/senior-controls/log/2026-07-31-delay-budget-pole-correction.md
@@ -1,0 +1,149 @@
+# Delay-budget corrections — the pole, and the amplitude it is quoted at (PR #134)
+
+**Follow-up to #122, which landed while this was in flight.** Additive: it does not restate
+the budget and does not re-litigate AC-6's 20 ms.
+
+**This is a HANDOFF.** The corrections below belong in `docs/design-delay-budget-stage0b.md`,
+which is COO turf (`CODEOWNERS:52`). They are written out here, in Senior Controls' own tree,
+rather than applied directly — the `policy` turf gate correctly refused the cross-turf edit,
+and `TURF-OVERRIDE` would have been me authorising myself, which is the thing that gate exists
+to stop. **The COO applies §A and §B, or rejects them.**
+
+Reproduce every number with:
+
+```
+.venv/bin/python scripts/analyse_estimator_phase.py --out-dir sim/out/experiments
+.venv/bin/python scripts/analyse_delay_budget.py    --out-dir sim/out/experiments
+```
+
+The second reads the first's saved sweep, so they cannot drift apart silently, and it exits
+non-zero rather than reporting a number if its cross-check on the plant fails.
+
+---
+
+## A. The unstable pole is 64% higher than §1 states
+
+§1 uses `p = sqrt(mgl/I)` — the pendulum on a **fixed** pivot — for **3.191 rad/s**, noting it
+deliberately ignores rolling coupling as *"the outer loop's job, not this pole's."*
+
+**That holds for the ride-away mode. It does not hold for the pole.** The axle rides on a wheel
+free to roll, so as the board pitches the support runs *out from under* the mass rather than
+reacting against it. Support translation therefore appears in the tipping mode's **own**
+characteristic equation, through the `(m·l)²` term below, whether or not any outer loop is
+closed.
+
+Linearizing the actual model with `mjd_transitionFD` about the settled upright trim (contact
+included), and cross-checking against the closed form for a translating support of effective
+mass `M` = wheel mass + `I_w/r²` = 7.31 kg:
+
+```
+p² = m·g·l·(M + m) / ( I·(M + m) − (m·l)² )
+```
+
+| Form | Value |
+|---|---|
+| `sqrt(mgl/I)`, fixed pivot (§1 today) | 3.191 rad/s |
+| **Identified from the model** | **5.238 rad/s** |
+| Closed form, translating support | 5.564 rad/s — agrees to **5.9%** |
+
+The 5.9% residual is a rigid two-body idealisation meeting a model with a compliant contact.
+
+### The consequence, which is the reason this is worth a correction
+
+§3 records that the textbook `0.2/p` robust target *"over-predicted the achievable margin by
+roughly 1.6×"*, and attributes that to the linearisation ignoring the current clamp and the
+estimator.
+
+**The attribution is wrong.** With the corrected pole:
+
+| | §1's pole | Identified pole | Measured |
+|---|---|---|---|
+| `0.2/p` robust target | 62.7 ms | **38.2 ms** | **39 ms** |
+| `1/p` fundamental ceiling | 313 ms | **191 ms** | — |
+
+`0.2/p` lands within **2%** of the measured ceiling. The rule was never loose — the pole was
+64% low, and a plausible physical effect got fitted to the resulting error. The clamp and the
+estimator are real and do matter (the estimator costs ~21 ms, exactly as §2 measured), but they
+are not what explains that gap, because with the right pole there is no gap to explain.
+
+**§3's actual conclusion is unchanged and still correct**: gate on the measured number. What
+changes is that the analytic bound becomes a sharp cross-check rather than expected slack — a
+future measurement drifting far from `0.2/p` should now read as a signal that something moved.
+
+### Proposed edit
+
+- §1: keep the `sqrt(mgl/I)` row, mark it superseded, add the identified pole and the closed
+  form above. Replace the two bounds with **191 ms** and **38.2 ms**.
+- §1 validity paragraph: the rolling-coupling sentence is right about ride-away, wrong about
+  the pole — narrow it to the former.
+- §3: replace the "over-predicted by 1.6×" paragraph with the table above.
+
+---
+
+## B. AC-6's 20 ms does not survive a 1.5× disturbance
+
+§3's limits list *"one disturbance magnitude, one disturbance shape"* as unmeasured. It is now
+measured, and it is the sharpest limit on the document. The ceiling is saturation-driven, so it
+is **not a plant constant**. Bisected to 1 ms, same harness as §2:
+
+| Impulse | Truth ceiling | Estimator ceiling | Peak pitch at zero delay |
+|---|---|---|---|
+| 10 N·s | 71 ms | 48 ms | 2.94° |
+| **20 N·s (`NOMINAL_IMPULSE_NS`)** | **60 ms** | **38 ms** | 5.95° |
+| 30 N·s | 37 ms | **15 ms** | 8.98° |
+| 40 N·s | — | — | **inverts at zero delay** |
+
+Ceiling = last surviving delay. The 20 N·s estimator figure reproduces §2's exactly; the
+truth-pitch figure lands 1 ms above §2's 59 ms — bisection-boundary sensitivity, not a
+disagreement.
+
+**At 30 N·s the estimator-in-loop ceiling is 15 ms — below AC-6's own 20 ms, before a
+microsecond of transport is charged.** The ceiling falls faster than linearly (~1.0 ms/N·s from
+10→20, ~2.3 ms/N·s from 20→30), so the 2× safety factor over 38 ms does not survive a 1.5×
+increase in disturbance.
+
+At 40 N·s — ~0.51 m/s of velocity change on a 78 kg system, i.e. a kerb — the board inverts
+with a **perfect, zero-delay** controller. Delay is not what fails there.
+
+**So the binding constraint on this vehicle is disturbance-rejection capability, not loop
+delay**, and AC-6's threshold is only meaningful with its reference disturbance attached.
+
+**§2's estimator line item holds up well:** its cost is ~22 ms at *every* amplitude (23/22/22),
+which is exactly what justifies charging it as a fixed line item rather than a fraction.
+Independently corroborated at **16.6 ms** from θ̂/θ phase at the derived crossover (two
+excitations agreeing to 0.13°, coherence ≈ 1.00).
+
+### Proposed edit
+
+Replace the "one disturbance magnitude" bullet with the table above, and attach the reference
+disturbance to AC-6's threshold wherever it is quoted.
+
+---
+
+## C. Not proposed as doc edits — filed as issues instead
+
+- **#132** — the loop crosses over at **4.48 rad/s**, *below* its corrected unstable pole
+  (5.238), with only **2.9 dB** of peak loop gain, on an unfitted `kt` that scales loop gain
+  directly. For an RHP-pole plant the low-gain failure is *instability*, not sluggishness.
+  **The comfortable delay margin and that marginal gain margin are not independent**: the loop
+  tolerates delay partly *because* it is weak, so the known fix (retune for `ω_c ≥ 2p`) would
+  reduce the very ceiling AC-6 gates on. AC-6 is valid only for the current gains at `kt = 0.7`.
+- **#133** — the estimator's share of the budget, and the reference disturbance nobody has yet
+  defended. 20 N·s is the scenario nominal, inherited, not derived; Sr. Mechanical & Systems
+  owns what a real kerb strike is worth in N·s.
+
+## D. Note on the stale crossover constant
+
+`scripts/analyse_estimator_phase.py:68` carries `OMEGA_C = 12.0`, sourced to the gain
+derivation "at the ridden inertia". That derivation is at the **driverless** inertia
+(`I ≈ 0.403 kg·m²`, `kp = 80`); the ridden plant is `I = 50.3` with `kp = 200`. The identified
+crossover is **4.48 rad/s**.
+
+This matters for anyone reading estimator phase: at 12 rad/s the two excitations disagree by 7°
+and the phase is a **lead**, so that script's `tau_lag = tan|φ|/ω` fit reports a lead as a 22 ms
+lag. At the real crossover the excitations agree to 0.13° and the lag is genuine. The 22 ms in
+`estimator-phase.json` should not be carried into a budget — that it happens to sit near the
+correct time-domain figure of 22 ms is a coincidence of two different quantities.
+
+Left as a note rather than fixed: that script is Senior Controls' turf and the fix is cheap, but
+it belongs with #133's re-measurement at the production `est_tau_s`, not bundled here.

--- a/scripts/analyse_delay_budget.py
+++ b/scripts/analyse_delay_budget.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""Identify the ridden plant, and check the delay budget's assumptions.
+
+**The delay budget itself is `docs/design-delay-budget-stage0b.md` (#122),
+which replaced AC-6's plant-ignorant threshold with a measured 20 ms. This
+script does not restate that budget and does not compete with it.** It supplies
+the two things that document could not, plus a correction to the one number in
+it that was assumed rather than identified:
+
+1.  **The unstable pole, identified from the model.** #122 used
+    `sqrt(mgl/I)` -- the pendulum on a FIXED pivot -- and got 3.191 rad/s. This
+    axle rolls, so the support runs out from under the mass and the plant is
+    faster than that: `mjd_transitionFD` about the settled upright trim gives
+    **5.238 rad/s**, 64% higher, cross-checked to 5.9% against the closed form
+    for a translating support.
+
+    That correction matters more than it looks. #122 recorded the textbook
+    `0.2/p` robust target as having "over-predicted the achievable margin by
+    roughly 1.6x", and blamed the current clamp and the estimator. With the
+    corrected pole `0.2/p` = 38.2 ms against a measured 39 ms ceiling -- a 2%
+    agreement. The rule was never loose; the pole was wrong.
+
+2.  **Whether AC-6's 20 ms survives a change of disturbance amplitude.** The
+    ceiling is saturation-driven, so it is not a plant constant. #122 flagged
+    this as unmeasured. It is now measured, and at 30 N*s the ceiling falls to
+    15 ms -- **below AC-6's own threshold**, before any transport is charged.
+
+Everything below comes from the model every other closed-loop metric in this
+repo is measured against, not from hand algebra over constants copied into a
+doc.
+
+Method, in order of how much it assumes:
+
+1.  **Linearize the real model.** `mjd_transitionFD` about the settled upright
+    trim state gives the discrete `(A, B)` at the 2 ms timestep, contact
+    included. The pitch output map `C` is finite-differenced the same way, in
+    the same tangent space, rather than hand-derived from the quaternion
+    layout. Nothing here is copied from a comment.
+2.  **Cross-check the pole analytically.** `p = sqrt(m*g*l / J)` from the
+    model's own masses and inertias, about the axle. If the identified pole and
+    the analytic pole disagree by more than a few percent, the linearization is
+    wrong and the script says so rather than reporting a number.
+3.  **Form the loop transfer** with the shipped inner-loop gains and read off
+    crossover, phase margin and delay margin. Then sweep injected pure delay
+    to find where the phase margin reaches zero -- the predicted break.
+4.  **Falsify.** The predicted break is compared against what the nonlinear sim
+    already measures: `tests/test_imperfections.py` records that 20 ms survives
+    and 80 ms strikes, "breaks between 40 and 60 ms". A linear prediction
+    landing outside that bracket is a finding, not a rounding error.
+
+    scripts/analyse_delay_budget.py --out-dir sim/out/experiments
+
+Note on scope: this is the INNER pitch loop, which is the loop that falls over.
+The outer velocity loop runs two orders of magnitude slower (kp_v = 0.05
+rad/(m/s)) and is not what a 2 ms transport spike threatens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+import mujoco  # noqa: E402
+
+from sim.scenarios.impulse_response import frame_pitch_rad  # noqa: E402
+from sim.scenarios.plant import KT_NM_PER_A, build_model  # noqa: E402
+
+#: The ridden plant. Same ballast as every closed-loop gate in
+#: `tests/test_closed_loop.py:167` -- 70 kg at 0.75 m, 40 A clamp.
+BALLAST_KG, BALLAST_M, CLAMP_A = 70.0, 0.75, 40.0
+
+#: Shipped inner-loop gains (`tests/test_closed_loop.py:168`). The controller
+#: speaks amps; the model's actuator takes torque, so the seam is `* KT`.
+KP_A_PER_RAD, KD_A_PER_RAD_S = 200.0, 30.0
+
+#: Where the NONLINEAR loop actually breaks, bisected to 1 ms against the same
+#: harness `tests/test_imperfections.py` uses (same model, profile, gains and
+#: impulse), sweeping injected `actuation_delay_s` to the nose-strike flip.
+#:
+#: Measured BOTH ways, and the pair is the most useful number in this file:
+#:
+#:   truth pitch      last safe 60 ms, first fatal 61 ms
+#:   estimator in loop last safe 38 ms, first fatal 39 ms
+#:
+#: The 22 ms gap between them IS the estimator's cost in delay margin, measured
+#: in the time domain, against a plant that saturates -- entirely independently
+#: of the frequency-domain phase measurement in `analyse_estimator_phase.py`.
+#: Two methods, one conclusion: the estimator is the dominant delay term.
+#:
+#: This also supersedes `test_imperfections.py:203`'s "breaks between 40 and
+#: 60 ms", which is stale: with the estimator in the loop it breaks at 39 ms.
+TRUTH_BREAK_S = 0.061
+ESTIMATOR_BREAK_S = 0.039
+
+#: The break is NOT a plant invariant. It is saturation-driven, so it is a
+#: function of disturbance amplitude, and the reference amplitude is a CHOICE.
+#: Swept at 10/20/30/40 N*s, bisected to 1 ms, both attitude sources:
+#:
+#:   N*s   truth   estimator   peak pitch at zero delay
+#:    10    72 ms     49 ms      2.94 deg
+#:    20    61 ms     39 ms      5.95 deg   <- NOMINAL_IMPULSE_NS
+#:    30    38 ms     16 ms      8.98 deg
+#:    40   strikes at ZERO delay -- beyond disturbance rejection entirely
+#:
+#: Two things fall out, and both matter more than anything about the transport:
+#:
+#: 1.  The slope STEEPENS: ~1.0 ms/N*s from 10->20, ~2.3 ms/N*s from 20->30.
+#:     A budget quoted at one amplitude and used at another is fiction.
+#: 2.  The estimator's cost is ~22 ms at EVERY amplitude (23/22/22). That is
+#:     what justifies charging it as a fixed line item rather than a fraction.
+AMPLITUDE_BREAKS_NS = {
+    10.0: {"truth_s": 0.072, "estimator_s": 0.049, "zero_delay_peak_deg": 2.942},
+    20.0: {"truth_s": 0.061, "estimator_s": 0.039, "zero_delay_peak_deg": 5.950},
+    30.0: {"truth_s": 0.038, "estimator_s": 0.016, "zero_delay_peak_deg": 8.984},
+    40.0: {"truth_s": None, "estimator_s": None, "zero_delay_peak_deg": 179.956},
+}
+
+#: The amplitude the budget is quoted at. `NOMINAL_IMPULSE_NS` in the scenario.
+REFERENCE_IMPULSE_NS = 20.0
+
+
+# ---------------------------------------------------------------------------
+# Trim state
+# ---------------------------------------------------------------------------
+
+
+def settle_upright(model, seconds: float = 2.0):
+    """Hold the board upright until the contact settles, then freeze it.
+
+    Upright is an equilibrium but an unstable one, so it cannot simply be
+    simulated into. A stiff PD holds pitch at zero while the normal force and
+    the tyre penetration come to rest; the velocities are then zeroed, which
+    makes the result an exact equilibrium candidate rather than a snapshot of
+    something still moving. `mj_forward` is called last so `qacc` reflects the
+    frozen state, and the caller checks it really is a trim point.
+    """
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    n = int(seconds / model.opt.timestep)
+    for _ in range(n):
+        pitch = frame_pitch_rad(model, data)
+        rate = float(data.qvel[4])
+        amps = -(KP_A_PER_RAD * pitch + KD_A_PER_RAD_S * rate)
+        amps = float(np.clip(amps, -CLAMP_A, CLAMP_A))
+        data.ctrl[0] = amps * KT_NM_PER_A
+        mujoco.mj_step(model, data)
+
+    data.qvel[:] = 0.0
+    data.ctrl[:] = 0.0
+    mujoco.mj_forward(model, data)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Linearization
+# ---------------------------------------------------------------------------
+
+
+def linearize(model, data, eps: float = 1e-6, dt_lin: float = 1e-5):
+    """Continuous `(A, B)` about the trim state, contact included.
+
+    `mjd_transitionFD` refuses to differentiate RK4, which is what the model
+    ships with, so the linearization is taken on an Euler copy at a timestep
+    two orders of magnitude below the control period. At `dt_lin = 1e-5` the
+    Euler discretization error is far smaller than the modelling error in the
+    plant itself, and the returned map is converted straight back to
+    continuous time -- so the integrator swap does not leak into the answer.
+
+    Continuous is also the form this analysis wants: sampling, hold, transport
+    and estimator lag then appear as EXPLICIT line items in the budget rather
+    than being silently baked into a discrete map, which is the whole point of
+    issue #113.
+    """
+    nv, na, nu = model.nv, model.na, model.nu
+    nx = 2 * nv + na
+
+    integ0, ts0 = model.opt.integrator, model.opt.timestep
+    model.opt.integrator = mujoco.mjtIntegrator.mjINT_EULER
+    model.opt.timestep = dt_lin
+    try:
+        Ad = np.zeros((nx, nx))
+        Bd = np.zeros((nx, nu))
+        mujoco.mjd_transitionFD(model, data, eps, 1, Ad, Bd, None, None)
+    finally:
+        model.opt.integrator, model.opt.timestep = integ0, ts0
+
+    return (Ad - np.eye(nx)) / dt_lin, Bd / dt_lin
+
+
+def pitch_output_map(model, data, eps: float = 1e-6):
+    """Row vector `Cp` with `pitch = Cp . dq`, by centred finite difference.
+
+    Derived in the same tangent space `mjd_transitionFD` perturbs, via
+    `mj_integratePos`, so it composes with `(A, B)` without a hand-written
+    assumption about where pitch lives in the free joint's quaternion.
+
+    Pitch depends only on configuration, so the same row read against the
+    velocity block gives pitch RATE -- which is exactly what the D term uses.
+    """
+    nv = model.nv
+    Cp = np.zeros(nv)
+    qpos0 = data.qpos.copy()
+    for i in range(nv):
+        vals = []
+        for sign in (+1.0, -1.0):
+            data.qpos[:] = qpos0
+            dv = np.zeros(nv)
+            dv[i] = sign * eps
+            mujoco.mj_integratePos(model, data.qpos, dv, 1.0)
+            mujoco.mj_forward(model, data)
+            vals.append(frame_pitch_rad(model, data))
+        Cp[i] = (vals[0] - vals[1]) / (2.0 * eps)
+    data.qpos[:] = qpos0
+    mujoco.mj_forward(model, data)
+    return Cp
+
+
+def analytic_pole(model) -> dict:
+    """The independent check on the identified pole, in BOTH forms.
+
+    The obvious form is the fixed-pivot pendulum, `p = sqrt(m*g*l/J)`. It is
+    also **wrong for this vehicle, and wrong in the unsafe direction.** The
+    axle is not fixed: it sits on a wheel that is free to roll, so as the board
+    pitches the support runs away from under the mass instead of reacting
+    against it. That makes the plant FASTER than the fixed-pivot intuition
+    says, not slower.
+
+    The right form for a pendulum of mass `m` and inertia `J` about the axle,
+    carried on a support free to translate with effective mass `M`:
+
+        p^2 = m*g*l*(M + m) / (J*(M + m) - (m*l)^2)
+
+    `M` is the wheel's mass plus its rotational inertia referred to the
+    contact patch, `I_wheel / r^2` -- a wheel that must spin up to move is
+    harder to shove than its mass alone suggests.
+
+    Both are returned because the GAP between them is a finding in its own
+    right: issue #113's back-of-envelope used the fixed-pivot form, and so
+    understated the pole this loop actually has to beat.
+    """
+    g = float(-model.opt.gravity[2])
+    wheel = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "wheel")
+
+    m_tot, m_l, J = 0.0, 0.0, 0.0
+    for b in range(model.nbody):
+        if b == 0 or b == wheel:
+            continue
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b)
+        if name == "world":
+            continue
+        m = float(model.body_mass[b])
+        if m <= 0.0:
+            continue
+        # Body frames are all expressed relative to the frame body, whose
+        # origin IS the axle (the wheel hinge sits at 0 0 0 inside it), so
+        # ipos is already a lever arm about the axle.
+        h = float(model.body_pos[b][2] + model.body_ipos[b][2])
+        m_tot += m
+        m_l += m * h
+        J += float(model.body_inertia[b][1]) + m * h * h
+
+    l = m_l / m_tot
+    mgl = m_tot * g * l
+
+    # Support: the wheel's mass plus its spin inertia referred to the contact
+    # patch. Spin axis is Y (`wheel_hinge` axis="0 -1 0"), radius from the
+    # wheel geom -- both read from the model, not from a doc.
+    geom = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "wheel_geom")
+    r = float(model.geom_size[geom][0])
+    M = float(model.body_mass[wheel]) + float(model.body_inertia[wheel][1]) / (r * r)
+
+    denom = J * (M + m_tot) - (m_tot * l) ** 2
+    p_rolling = math.sqrt(mgl * (M + m_tot) / denom) if denom > 0 else float("nan")
+
+    return dict(
+        p_fixed_pivot_rad_s=math.sqrt(mgl / J),
+        p_rolling_support_rad_s=p_rolling,
+        mgl_nm_per_rad=mgl, J_kg_m2=J, com_height_m=l,
+        support_eff_mass_kg=M, wheel_radius_m=r, pendulum_mass_kg=m_tot,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loop transfer
+# ---------------------------------------------------------------------------
+
+
+def loop_transfer(A, B, Cp, omega):
+    """`L(jw)` for the inner pitch loop, negative feedback, delay-free.
+
+    The controller is `amps = -(kp*theta + kd*theta_dot)` and the actuator
+    takes torque, so the loop is `KT*(kp + kd*s)` around the pitch output.
+    The D term is fed the RAW GYRO, not a differentiated estimate, so it is a
+    true derivative here and carries no dirty-derivative pole -- see
+    `WheelAccelEstimator`'s comment in `crates/control-core/src/lib.rs:256`
+    for what happens when a path in this loop does need differentiating.
+
+    Every delay -- sampling, hold, transport, estimator, CAN, current loop --
+    is applied OUTSIDE this function, as `exp(-jw*tau)`, so each one keeps its
+    own name in the budget.
+    """
+    nv = len(Cp)
+    nx = A.shape[0]
+    Cpos = np.zeros(nx)
+    Cpos[:nv] = Cp
+    Cvel = np.zeros(nx)
+    Cvel[nv:2 * nv] = Cp
+
+    out = np.zeros(len(omega), dtype=complex)
+    I = np.eye(nx)
+    for k, w in enumerate(omega):
+        x = np.linalg.solve(1j * w * I - A, B[:, 0])
+        out[k] = KT_NM_PER_A * (KP_A_PER_RAD * (Cpos @ x)
+                                + KD_A_PER_RAD_S * (Cvel @ x))
+    return out
+
+
+def margins(omega, L, extra_delay_s: float = 0.0):
+    """Crossover, phase margin and delay margin, with optional injected lag."""
+    Ld = L * np.exp(-1j * omega * extra_delay_s)
+    mag = np.abs(Ld)
+    idx = np.where((mag[:-1] >= 1.0) & (mag[1:] < 1.0))[0]
+    if len(idx) == 0:
+        return None
+    i = idx[0]
+    # Log-log interpolation onto |L| = 1.
+    lo, hi = math.log(mag[i]), math.log(mag[i + 1])
+    frac = lo / (lo - hi)
+    wc = math.exp(math.log(omega[i]) + frac * (math.log(omega[i + 1]) - math.log(omega[i])))
+    ph = np.interp(wc, omega, np.unwrap(np.angle(Ld)))
+    pm = math.degrees(math.pi + ph)
+    while pm > 180.0:
+        pm -= 360.0
+    while pm < -180.0:
+        pm += 360.0
+    return dict(omega_c_rad_s=wc, phase_margin_deg=pm,
+                delay_margin_s=math.radians(pm) / wc if pm > 0 else 0.0)
+
+
+def predicted_break(omega, L, hi_s: float = 0.5) -> float:
+    """Smallest injected pure delay that drives the phase margin to zero."""
+    lo = 0.0
+    if (m := margins(omega, L, hi_s)) is not None and m["phase_margin_deg"] > 0:
+        return float("inf")
+    for _ in range(60):
+        mid = 0.5 * (lo + hi_s)
+        m = margins(omega, L, mid)
+        if m is not None and m["phase_margin_deg"] > 0:
+            lo = mid
+        else:
+            hi_s = mid
+    return 0.5 * (lo + hi_s)
+
+
+# ---------------------------------------------------------------------------
+# The budget
+# ---------------------------------------------------------------------------
+
+
+def estimator_lag_s(omega_c: float, npz: Path) -> dict:
+    """The estimator's equivalent delay AT THE DERIVED CROSSOVER, measured.
+
+    Read from `analyse_estimator_phase.py`'s saved sweep rather than assumed,
+    because AC-2 of #113 makes this line item mandatory-and-measured. It is
+    read at the crossover THIS script derives, not at that script's
+    `OMEGA_C = 12.0` -- which is inherited from the driverless gain derivation
+    and is not where the ridden loop actually crosses over.
+
+    Both excitations are returned. At 12 rad/s they disagree by 7 degrees and
+    the phase is a LEAD, so `tan|phi|/w` there reports a lead as though it were
+    a lag. At the real crossover they agree to a fifth of a degree, which is
+    the condition under which "equivalent delay" is a meaningful summary at
+    all.
+    """
+    if not npz.exists():
+        return {"available": False, "reason": f"{npz} missing -- run "
+                f"scripts/analyse_estimator_phase.py first"}
+    d = np.load(npz)
+    out = {"available": True, "omega_read_rad_s": None, "excitations": {}}
+    worst = 0.0
+    for pre in ("force_sweep", "vref_sweep"):
+        if f"{pre}_w" not in d:
+            continue
+        w = d[f"{pre}_w"]
+        H = d[f"{pre}_H_real"] + 1j * d[f"{pre}_H_imag"]
+        i = int(np.argmin(np.abs(w - omega_c)))
+        phase = float(np.angle(H[i]))
+        out["omega_read_rad_s"] = float(w[i])
+        lag = -phase / w[i] if w[i] > 0 else float("nan")
+        out["excitations"][pre] = {
+            "phase_deg": math.degrees(phase),
+            "gain": float(np.abs(H[i])),
+            "coherence": float(d[f"{pre}_coh"][i]),
+            "equivalent_delay_s": lag,
+        }
+        worst = max(worst, lag)
+    out["worst_equivalent_delay_s"] = worst
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", type=Path, default=REPO / "sim/out/experiments")
+    args = ap.parse_args()
+
+    model = build_model(BALLAST_KG, BALLAST_M, CLAMP_A)
+    dt = float(model.opt.timestep)
+    data = settle_upright(model)
+
+    trim_pitch = frame_pitch_rad(model, data)
+    trim_qacc = float(np.max(np.abs(data.qacc)))
+
+    an = analytic_pole(model)
+    p_analytic = an["p_rolling_support_rad_s"]
+
+    A, B = linearize(model, data)
+    Cp = pitch_output_map(model, data)
+
+    lam = np.linalg.eigvals(A)
+    unstable = lam[lam.real > 1e-6]
+    p_identified = float(np.max(unstable.real)) if len(unstable) else float("nan")
+
+    pole_err = abs(p_identified - p_analytic) / p_analytic
+
+    omega = np.logspace(-1, math.log10(math.pi / dt), 4000)
+    L = loop_transfer(A, B, Cp, omega)
+    base = margins(omega, L)
+    tau_break = predicted_break(omega, L)
+
+    est = estimator_lag_s(base["omega_c_rad_s"], args.out_dir / "estimator-phase.npz")
+
+    # The budget is sized on the NONLINEAR break, not the linear delay margin.
+    # The linear margin is an upper bound the real loop does not enjoy: the
+    # 40 A clamp is 28 N*m, and gravity alone asks for m*g*l*theta = 28 N*m at
+    # 3.1 degrees of lean, so the impulse tests run deep in saturation. A
+    # budget written against the linear number would be writing a cheque the
+    # saturated loop cannot cash.
+    #
+    # The estimator is charged at its TIME-DOMAIN cost (the 22 ms difference
+    # between the two measured break points) rather than its frequency-domain
+    # phase (16.6 ms). The larger figure is the one measured against the
+    # saturating plant this budget is actually for.
+    estimator_cost = TRUTH_BREAK_S - ESTIMATOR_BREAK_S
+
+    # The budget itself lives in `docs/design-delay-budget-stage0b.md` (#122),
+    # which set AC-6 at 20 ms. This script does NOT restate it. What it adds is
+    # the check that AC-6's threshold survives contact with the amplitude the
+    # ceiling is quoted at -- and at 30 N*s it does not.
+    AC6_TOTAL_DELAY_S = 0.020
+    amplitude = {}
+    for ns, row in AMPLITUDE_BREAKS_NS.items():
+        if row["truth_s"] is None:
+            amplitude[f"{ns:g} N*s"] = {
+                "verdict": "NO CEILING EXISTS -- strikes at zero injected delay",
+                "zero_delay_peak_deg": row["zero_delay_peak_deg"],
+            }
+            continue
+        amplitude[f"{ns:g} N*s"] = {
+            "truth_ceiling_s": row["truth_s"],
+            "estimator_ceiling_s": row["estimator_s"],
+            "zero_delay_peak_deg": row["zero_delay_peak_deg"],
+            "ac6_20ms_still_inside_ceiling":
+                bool(row["estimator_s"] > AC6_TOTAL_DELAY_S),
+        }
+
+    budget = {
+        "reference_impulse_ns": REFERENCE_IMPULSE_NS,
+        "ac6_total_delay_s": AC6_TOTAL_DELAY_S,
+        "estimator_time_domain_s": estimator_cost,
+        "estimator_freq_domain_s": est.get("worst_equivalent_delay_s"),
+        "ceiling_vs_disturbance": amplitude,
+        # The textbook rule, against the CORRECTED pole. With the fixed-pivot
+        # pole it looked like a 1.6x over-prediction; it is not.
+        "robust_target_0p2_over_p_s": 0.2 / p_identified,
+        "rhp_ceiling_1_over_p_s": 1.0 / p_identified,
+    }
+
+    report = {
+        "trim": {"pitch_rad": trim_pitch, "max_qacc": trim_qacc},
+        "plant": {
+            "ballast_kg": BALLAST_KG, "ballast_height_m": BALLAST_M,
+            **an,
+            "unstable_pole_identified_rad_s": p_identified,
+            "pole_agreement_rel_err": pole_err,
+        },
+        "loop": {
+            "kp_a_per_rad": KP_A_PER_RAD, "kd_a_per_rad_s": KD_A_PER_RAD_S,
+            "control_dt_s": dt,
+            **(base or {}),
+        },
+        "delay": {
+            "linear_predicted_break_s": tau_break,
+            "measured_break_truth_pitch_s": TRUTH_BREAK_S,
+            "measured_break_estimator_in_loop_s": ESTIMATOR_BREAK_S,
+            "estimator_cost_in_delay_margin_s": TRUTH_BREAK_S - ESTIMATOR_BREAK_S,
+            # The linear margin is ~2.2x the measured one. That is saturation,
+            # not a bug: see the doc's section 4. Reported, not hidden.
+            "linear_over_measured_ratio": tau_break / TRUTH_BREAK_S,
+            "rhp_pole_limit_s": 1.0 / p_identified,
+            "rhp_robust_limit_s": 0.2 / p_identified,
+        },
+        "estimator": est,
+        "budget": budget,
+    }
+
+    print(json.dumps(report, indent=2))
+
+    # 10%: this check exists to catch a STRUCTURAL error -- the wrong plant
+    # topology, a sign, a missing body -- not to validate to three digits. The
+    # analytic form is a rigid two-body idealisation of a model that has a
+    # compliant contact and a finite tyre patch, so a few percent of daylight
+    # between them is expected and is not evidence of a defect.
+    if pole_err > 0.10:
+        print(f"\nFAIL: identified pole {p_identified:.3f} and analytic pole "
+              f"{p_analytic:.3f} rad/s disagree by {pole_err:.1%}. The "
+              f"linearization is not trustworthy; no delay number below it is.",
+              file=sys.stderr)
+        return 1
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    out = args.out_dir / "delay_budget.json"
+    out.write_text(json.dumps(report, indent=2) + "\n")
+    print(f"\nwrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Follow-up to #122, not a competitor to it.** #122 merged while this was in flight and closed #113. Reworked to be strictly additive: it does **not** restate the budget and does **not** re-litigate AC-6's 20 ms.

Opens #132 and #133.

## Delivered as a handoff, not a cross-turf edit

The corrections below belong in `docs/design-delay-budget-stage0b.md`, which is COO turf (`CODEOWNERS:52`). The `policy` turf gate refused that edit and **was right to** — `TURF-OVERRIDE` would have been me authorising myself, which is exactly what the gate exists to stop.

So this PR touches **only Senior Controls' own tree**: the proposed edits are written out in full in `roles/senior-controls/log/2026-07-31-delay-budget-pole-correction.md`, **for the COO to apply or reject.** Two files, both mine.

## 1. The unstable pole is 64% higher than the budget assumes

#122 used `sqrt(mgl/I)` — the pendulum on a **fixed** pivot — for **3.191 rad/s**, noting it deliberately ignores rolling coupling as *"the outer loop's job, not this pole's."*

That is right about the **ride-away** mode and wrong about the **pole**. The axle rides on a wheel free to roll, so as the board pitches the support runs *out from under* the mass — support translation appears in the tipping mode's own characteristic equation, through the `(m·l)²` term, whether or not any outer loop is closed.

| Form | Value |
|---|---|
| `sqrt(mgl/I)`, fixed pivot (#122) | 3.191 rad/s |
| **Identified from the model** (`mjd_transitionFD`, contact included) | **5.238 rad/s** |
| Closed form, translating support | 5.564 rad/s — agrees to **5.9%** |

The script **exits non-zero rather than reporting a number** if that cross-check fails. It caught a real error in my own first pass, which is why it is wired that way.

### The consequence is the part worth reading

#122 §3 recorded that the textbook `0.2/p` target *"over-predicted the achievable margin by roughly 1.6×"* and attributed the gap to the current clamp and the estimator.

**The attribution was wrong.**

| | #122's pole | Identified pole | Measured |
|---|---|---|---|
| `0.2/p` robust target | 62.7 ms | **38.2 ms** | **39 ms** |
| `1/p` fundamental ceiling | 313 ms | **191 ms** | — |

`0.2/p` lands within **2%** of the measured ceiling. The rule was never loose — the pole was 64% low, and a plausible physical effect got fitted to the resulting error. The clamp and estimator are real and do matter (the estimator costs ~21 ms, exactly as #122 measured), but they are not what explains that gap, because with the right pole there is no gap to explain.

**#122's actual conclusion is unchanged and still correct**: gate on the measured number. What changes is that the analytic bound becomes a sharp cross-check rather than expected slack.

## 2. AC-6's 20 ms does not survive a 1.5× disturbance

#122 listed *"one disturbance magnitude, one disturbance shape"* as unmeasured. Measured now — the ceiling is saturation-driven, so it is **not a plant constant**. Bisected to 1 ms, same harness as #122:

| Impulse | Truth ceiling | Estimator ceiling | Peak pitch at zero delay |
|---|---|---|---|
| 10 N·s | 71 ms | 48 ms | 2.94° |
| **20 N·s (nominal)** | **60 ms** | **38 ms** | 5.95° |
| 30 N·s | 37 ms | **15 ms** | 8.98° |
| 40 N·s | — | — | **inverts at zero delay** |

**At 30 N·s the estimator-in-loop ceiling is 15 ms — below AC-6's own 20 ms, before a microsecond of transport is charged.** The ceiling falls faster than linearly (~1.0 ms/N·s from 10→20, ~2.3 ms/N·s from 20→30), so the 2× safety factor over 38 ms does not survive a 1.5× increase in disturbance.

At 40 N·s — ~0.51 m/s of velocity change on a 78 kg system, i.e. a kerb — the board inverts with a **perfect, zero-delay** controller. Delay is not what fails there.

So the binding constraint is **disturbance-rejection capability, not loop delay**, and AC-6's threshold is only meaningful with its reference disturbance attached.

**#122's estimator line item holds up well:** ~22 ms at *every* amplitude (23/22/22), which is exactly what justifies charging it as a fixed line item. Independently corroborated at 16.6 ms from θ̂/θ phase at the derived crossover (two excitations agreeing to 0.13°, coherence ≈ 1.00).

## Also filed

- **#132** — the loop crosses over (4.48 rad/s) **below** its corrected unstable pole (5.238) with 2.9 dB peak gain, on an unfitted `kt` that scales loop gain directly. The comfortable delay margin and that marginal gain margin are **not independent**: the loop tolerates delay partly *because* it is weak, so the known fix (retune for `ω_c ≥ 2p`) would reduce the very ceiling AC-6 gates on.
- **#133** — the estimator's share, and the reference disturbance nobody has defended (20 N·s is inherited, not derived).

Not addressed here: **#130** (consecutive misses). This measures fixed delay only, same as #122 — burst structure still needs the imperfection-profile machinery #130 asks for.

## Verification

- `pytest tests/test_delay_budget_stage0b.py tests/test_imperfections.py` — **25 passed**; #122's own regression gates still hold.
- `policy_check.py` — all hard checks pass, no turf violation.
- `scripts/analyse_delay_budget.py` writes `sim/out/experiments/delay_budget.json` with a machine-checkable `ac6_20ms_still_inside_ceiling` flag per amplitude (**`false` at 30 N·s**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)