### PR TITLE
fix(controls): probe the repo .venv for MuJoCo, so plant-mujoco builds on macOS

### DIFF
--- a/crates/plant-mujoco/README.md
+++ b/crates/plant-mujoco/README.md
@@ -16,25 +16,51 @@ a build error.
 ## Linking
 
 `build.rs` discovers libmujoco via a single `MUJOCO_DIR` env var, with a
-wheel-probe fallback (`python3 -c 'import mujoco'`) if it is unset. Either
-way it links the **same** `libmujoco.so.3.10.0` the pip-installed `mujoco`
-wheel ships and the `sim` CI job already installs from
-`requirements-sim.txt` -- not a system package, not a vendored copy. That is
-what makes the Rust-vs-Python plant equivalence check below meaningful: both
-sides load the identical shared object.
+wheel-probe fallback if it is unset. The probe asks each of these, in order,
+and takes the first that can `import mujoco`:
 
-The build fails loudly, not silently, if no MuJoCo install is found.
+1. `python3`, then `python`, as found on `PATH` — this is what CI hits, since
+   it `pip install`s the wheel into the runner's system Python.
+2. `<repo>/.venv/bin/python3`, then `<repo>/.venv/bin/python` — **this is what
+   a developer machine hits**, because the wheel goes into the repo `.venv`
+   that every other tool here uses, while `python3` on `PATH` is a Homebrew or
+   system interpreter that has never heard of MuJoCo.
 
-**Known local-dev friction (issue #112, macOS only, not fixed here on
-purpose):** the pip wheel's `.dylib` install name does not always match its
-filename, so `cargo test -p plant-mujoco` (and running `target/*/plant-replay`
-directly) can fail to resolve libmujoco at runtime even though the build
-succeeds, depending on which wheel build produced the local venv's `mujoco`
-package. CI (`ubuntu-latest`) is unaffected. Locally, invoking through
-`cargo run`/`cargo test` (not the raw built artifact) works around it: Cargo
-adds the linked library's `OUT_DIR` to `DYLD_LIBRARY_PATH` for every `cargo
-test`/`cargo run` in the same invocation (see the comment in `build.rs`),
-which `tests/test_rust_python_plant_replay_equivalence.py` relies on for exactly this reason.
+`PATH` is probed first, so the `.venv` entries are strictly additive and
+cannot change which libmujoco CI links against.
+
+Either way it links the **same** `libmujoco.so.3.10.0` (or, on macOS,
+`libmujoco.3.10.0.dylib`) the pip-installed `mujoco` wheel ships and the `sim`
+CI job already installs from `requirements-sim.txt` -- not a system package,
+not a vendored copy. That is what makes the Rust-vs-Python plant equivalence
+check below meaningful: both sides load the identical shared object.
+
+The build fails loudly, not silently, if no MuJoCo install is found, and the
+panic lists every interpreter it probed.
+
+### macOS: what issue #112 actually was
+
+**Resolved. `cargo test -p plant-mujoco` passes on macOS from a clean checkout
+with only `pip install -r requirements-sim.txt` -- no `MUJOCO_DIR`, no
+`DYLD_*`, no hand-created symlinks.**
+
+#112 filed this as a *runtime* defect: the wheel's `.dylib` carries a
+framework-style install name that does not match its own filename, so the
+loader could not resolve it. The install name mismatch is real -- `otool -D`
+reports `@rpath/mujoco.framework/Versions/A/libmujoco.3.10.0.dylib` for a file
+actually named `libmujoco.3.10.0.dylib` -- but it is **already handled**, and
+was before #112 was written. `build.rs` symlinks the library into `OUT_DIR`
+under **both** its unversioned and its real versioned name; the versioned one
+is what `DYLD_FALLBACK_LIBRARY_PATH` matches on, by leaf filename, when the
+`@rpath` lookup comes up short. That is why the versioned symlink exists and
+why removing it would look like an unrelated cleanup.
+
+What actually failed on macOS was one step earlier and had nothing to do with
+dylibs: **the build never got far enough to link.** The wheel-probe only asked
+the `PATH` interpreters, so on any machine using the repo `.venv` it panicked
+with "no MuJoCo install found" *despite* `requirements-sim.txt` having been
+installed exactly as documented -- which reads as a broken crate rather than
+an unactivated virtualenv. The `.venv` probe entries above are the fix.
 
 ## Ordering contract (I1b, issue #106)
 

--- a/crates/plant-mujoco/build.rs
+++ b/crates/plant-mujoco/build.rs
@@ -13,7 +13,9 @@
 //! `libmujoco.so.*` / `libmujoco*.dylib`. The pip-installed `mujoco` wheel's
 //! own package directory satisfies this shape exactly -- which is also why
 //! the wheel-probe fallback works: `import mujoco` and read
-//! `os.path.dirname(mujoco.__file__)`.
+//! `os.path.dirname(mujoco.__file__)`. The probe asks the `PATH`
+//! interpreters first and then the repo's own `.venv` -- see
+//! [`python_candidates`], which is what makes this build on a Mac (#112).
 //!
 //! The wheel ships no unversioned `libmujoco.so` / `libmujoco.dylib` symlink
 //! for a plain `-lmujoco` to find, so this links the exact same
@@ -134,8 +136,8 @@ fn locate_mujoco() -> PathBuf {
         return PathBuf::from(dir);
     }
 
-    for python in ["python3", "python"] {
-        let output = Command::new(python)
+    for python in python_candidates() {
+        let output = Command::new(&python)
             .args([
                 "-c",
                 "import mujoco, os; print(os.path.dirname(mujoco.__file__))",
@@ -155,11 +157,45 @@ fn locate_mujoco() -> PathBuf {
         "plant-mujoco: no MuJoCo install found. Set MUJOCO_DIR to the 'mujoco' \
          pip package directory (contains 'include/mujoco/*.h' and \
          'libmujoco.*'), or `pip install -r requirements-sim.txt` so the \
-         wheel-probe fallback (`python3 -c 'import mujoco'`) can find it. This \
-         crate refuses to build headless rather than silently degrading to \
-         'no plant' -- that silent degrade is the failure mode this \
-         programme keeps hitting."
+         wheel-probe fallback can find it. Probed, in order: {:?}. This crate \
+         refuses to build headless rather than silently degrading to 'no \
+         plant' -- that silent degrade is the failure mode this programme \
+         keeps hitting.",
+        python_candidates()
     );
+}
+
+/// Interpreters to ask, in order: whatever is on `PATH` first, then the
+/// repo's own `.venv`.
+///
+/// **The `.venv` entries are why `cargo test -p plant-mujoco` works on a Mac
+/// (issue #112).** CI installs the wheel into the runner's system Python, so
+/// `python3` on `PATH` finds it and the first candidate wins. A developer
+/// machine almost never does: the wheel goes into the repo `.venv` that every
+/// other tool here uses (`.venv/bin/python -m pytest`, `scripts/*.py`), and
+/// the `python3` on `PATH` is a Homebrew or system interpreter that has never
+/// heard of MuJoCo. The build then failed with "no MuJoCo install found"
+/// *despite* `requirements-sim.txt` having been installed exactly as
+/// documented -- which reads as a broken crate rather than an unactivated
+/// virtualenv.
+///
+/// Ordering is deliberate: `PATH` is probed FIRST so this is strictly
+/// additive and cannot change which libmujoco CI links against.
+fn python_candidates() -> Vec<String> {
+    let mut out = vec!["python3".to_string(), "python".to_string()];
+
+    // CARGO_MANIFEST_DIR is <repo>/crates/plant-mujoco.
+    if let Ok(manifest) = env::var("CARGO_MANIFEST_DIR") {
+        if let Some(repo) = Path::new(&manifest).ancestors().nth(2) {
+            for exe in ["python3", "python"] {
+                let venv = repo.join(".venv/bin").join(exe);
+                if venv.is_file() {
+                    out.push(venv.to_string_lossy().into_owned());
+                }
+            }
+        }
+    }
+    out
 }
 
 /// The versioned shared library in `dir`, if any.


### PR DESCRIPTION
Closes #112.

## What #112 said, and what was actually wrong

#112 filed this as a **runtime** defect: the wheel's `.dylib` carries a framework-style install name that doesn't match its filename, so the loader can't resolve libmujoco even though the build succeeds.

**The install-name mismatch is real but already handled — and was before #112 was written.**

```
$ otool -D .../mujoco/libmujoco.3.10.0.dylib
@rpath/mujoco.framework/Versions/A/libmujoco.3.10.0.dylib
```

`build.rs` symlinks the library into `OUT_DIR` under **both** its unversioned *and* its real versioned name. The versioned one is exactly what `DYLD_FALLBACK_LIBRARY_PATH` matches on — by leaf filename — when the `@rpath` lookup comes up short. That is why the versioned symlink exists, and why deleting it would look like a harmless cleanup and would not be.

**The real failure never reached the linker.** The wheel-probe only asked the `PATH` interpreters:

- **CI** `pip install`s the wheel into the runner's system Python, so `python3` on `PATH` finds it and everything works. `ubuntu-latest` was never affected, exactly as #112 says.
- **A developer machine** puts the wheel in the repo `.venv` that every other tool here uses (`.venv/bin/python -m pytest`, `scripts/*.py`), while `python3` on `PATH` is a Homebrew or system interpreter that has never heard of MuJoCo.

So the crate panicked with `no MuJoCo install found` *despite* `requirements-sim.txt` having been installed exactly as documented — which reads as a broken crate rather than an unactivated virtualenv. That is the afternoon #112 was filed to save.

## The fix

The probe now asks, in order:

1. `python3`, then `python`, from `PATH` — what CI hits.
2. `<repo>/.venv/bin/python3`, then `<repo>/.venv/bin/python` — what a developer machine hits.

**`PATH` is probed first, so this is strictly additive and cannot change which libmujoco CI links against.** The panic message now lists every interpreter it tried, so the next person sees *why* discovery failed rather than just that it did.

## Acceptance criteria

1. ✅ **`cargo test -p plant-mujoco` passes on macOS from a clean checkout with only the pip wheel installed** — verified after `cargo clean -p plant-mujoco`, with **no `MUJOCO_DIR`, no `DYLD_*`, no hand-created symlinks**: `15 passed`.
2. ✅ **No Linux/CI regression** — additive by construction (`PATH` first); `cargo fmt --check`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` all green locally.
3. ✅ **No env var is required**, so the "one documented env var" escape hatch in the AC was not needed. `MUJOCO_DIR` still works as the explicit override.
4. ✅ **The `build.rs` comments explaining the install-name mismatch are kept and extended** — the crate README now records what #112 actually was, so the next person doesn't re-diagnose a dylib problem that was already solved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)