### PR TITLE
ops: the delay budget doc belongs to Controls, not the COO

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,15 @@
 /scripts/                       @MikePaNtZ
 # role: Senior Controls
 /docs/sim-impulse-response.md   @MikePaNtZ
+# The delay budget is Controls' analysis end to end -- their derivation, their
+# measured numbers, their maintenance. It sat under the COO's /docs/ rule and
+# needed a TURF-OVERRIDE twice in a row (#122 creating it, #134 correcting it),
+# which is the signal that the seam is wrong rather than that the author is.
+# Same shape as ci.yml in #87: a path whose owner and whose author differ, where
+# the override was becoming routine -- and a routine override is a check that
+# has stopped meaning anything.
+# role: Senior Controls
+/docs/design-delay-budget-stage0b.md  @MikePaNtZ
 # role: Senior Controls
 /.github/workflows/ci.yml       @MikePaNtZ
 # The policy gate lives in its OWN workflow so its owner owns its file (#87).


### PR DESCRIPTION
Second `TURF-OVERRIDE` in a row on the same file — **#122 creating** `docs/design-delay-budget-stage0b.md`, **#134 correcting it** — and both were legitimate.

**That is the signal that the seam is wrong, not that the author is.**

The doc is Controls' analysis end to end: their derivation of the unstable pole, their bisected delay measurements, their maintenance. It sat under the COO's blanket `/docs/` rule only because that rule is broad — and there is **already precedent for the exception**: `/docs/sim-impulse-response.md` has been Controls' for exactly the same reason.

Same shape as `ci.yml` in #87: a path whose **owner** and whose **author** differ, where the override was on its way to becoming routine. A routine override is a check that has stopped meaning anything — the argument I accepted for `doc-drift` in #85, and the one the CMO made for the site's feedstock gate.

**Unblocks #134 permanently rather than per-PR.** Controls should not need my signature to correct their own numbers.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>