### PR TITLE
feat(controls): re-denominate the inner-loop control law in torque

### DIFF
--- a/crates/board-app-driverless/src/bin/impulse-response-rust.rs
+++ b/crates/board-app-driverless/src/bin/impulse-response-rust.rs
@@ -42,7 +42,9 @@
 //! `peak_abs_pitch_deg`, `t_peak_s`, `settle_time_s` (`-1.0` means "never
 //! settled", mirroring the Python side's `None`), `final_pitch_deg`.
 
-use board_types::{Command, Faults, ImuSample, Params, DEFAULT_R_EFF_M, RAD_S_PER_ERPM};
+use board_types::{
+    Command, Faults, ImuSample, Params, DEFAULT_KT_NM_PER_A, DEFAULT_R_EFF_M, RAD_S_PER_ERPM,
+};
 use control_core::{ComplementaryFilter, Estimator, PitchRegulator, WheelAccelEstimator};
 use hal::BoardObserve;
 use hal_actuate::BoardActuate;
@@ -72,8 +74,14 @@ const FORCE_N: [f64; 3] = [-(NOMINAL_IMPULSE_NS / DURATION_S), 0.0, 0.0];
 // wheel_accel_tau_s match control-ffi::ob_controller_new's own defaults /
 // RustController()'s own defaults (issue #121: mode 1, wheel odometry, is
 // now the mode both hosts run -- see the module doc comment).
-const KP_A_PER_RAD: f32 = 80.0;
-const KD_A_PER_RAD_S: f32 = 11.0;
+//
+// KP_NM_PER_RAD/KD_NM_PER_RAD_S are rust_controller.py's amps-space
+// DEFAULT_KP_A_PER_RAD/DEFAULT_KD_A_PER_RAD_S (80.0/11.0) re-expressed at the
+// DEFAULT_KT_NM_PER_A design point (issue #137) -- this binary wires
+// PitchRegulator directly, so it does its own kt boundary conversion below,
+// the same one control-ffi::ob_controller_update does.
+const KP_NM_PER_RAD: f32 = 80.0 * DEFAULT_KT_NM_PER_A;
+const KD_NM_PER_RAD_S: f32 = 11.0 * DEFAULT_KT_NM_PER_A;
 const MAX_CURRENT_A: f32 = 40.0;
 const ESTIMATOR_TAU_S: f32 = 1.0;
 /// `RustController()`'s own default (`sim/scenarios/rust_controller.py`,
@@ -90,8 +98,8 @@ fn main() -> ExitCode {
     };
 
     let params = Params {
-        kp: KP_A_PER_RAD,
-        kd: KD_A_PER_RAD_S,
+        kp_nm_per_rad: KP_NM_PER_RAD,
+        kd_nm_per_rad_s: KD_NM_PER_RAD_S,
         max_current_a: MAX_CURRENT_A,
         ..Params::default()
     };
@@ -112,7 +120,7 @@ fn main() -> ExitCode {
     let mut envelope = Envelope::new(params);
     envelope.arm();
 
-    let regulator = PitchRegulator::new(KP_A_PER_RAD, KD_A_PER_RAD_S);
+    let regulator = PitchRegulator::new(KP_NM_PER_RAD, KD_NM_PER_RAD_S);
     let mut estimator = ComplementaryFilter::with_trust_band(ESTIMATOR_TAU_S, 0.0);
     let mut wheel_accel = WheelAccelEstimator::new(WHEEL_ACCEL_TAU_S);
 
@@ -172,9 +180,13 @@ fn main() -> ExitCode {
         let wheel_rate_rad_s = obs.erpm * RAD_S_PER_ERPM;
         let aiding = wheel_accel.update(wheel_rate_rad_s * DEFAULT_R_EFF_M, dt_s as f32);
         let attitude = estimator.update(std::slice::from_ref(&sample), aiding);
-        let proposed = regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
+        // The only place kt is used (issue #137), mirroring
+        // control-ffi::ob_controller_update's own boundary conversion.
+        let proposed_torque_nm =
+            regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
+        let proposed_amps = proposed_torque_nm / DEFAULT_KT_NM_PER_A;
         let (bounded_cmd, _envelope_sat) =
-            envelope.apply(Command::MotorCurrent { amps: proposed }, Faults::NONE);
+            envelope.apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
 
         if let Err(e) = backend.apply(&bounded_cmd) {
             eprintln!("impulse-response-rust: apply failed: {e:?}");

--- a/crates/board-app-driverless/src/bin/impulse-response-rust.rs
+++ b/crates/board-app-driverless/src/bin/impulse-response-rust.rs
@@ -185,8 +185,12 @@ fn main() -> ExitCode {
         let proposed_torque_nm =
             regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
         let proposed_amps = proposed_torque_nm / DEFAULT_KT_NM_PER_A;
-        let (bounded_cmd, _envelope_sat) =
-            envelope.apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
+        let (bounded_cmd, _envelope_sat) = envelope.apply(
+            Command::MotorCurrent {
+                amps: proposed_amps,
+            },
+            Faults::NONE,
+        );
 
         if let Err(e) = backend.apply(&bounded_cmd) {
             eprintln!("impulse-response-rust: apply failed: {e:?}");

--- a/crates/board-types/src/lib.rs
+++ b/crates/board-types/src/lib.rs
@@ -35,6 +35,22 @@ use serde::{Deserialize, Serialize};
 /// eventual bench-measured loaded rolling radius (ICD §10.5) supersedes it.
 pub const DEFAULT_R_EFF_M: f32 = 0.1454;
 
+/// Motor torque constant, N·m per amp — the single conversion point between
+/// [`control_core::PitchRegulator`]'s torque-denominated law and the amps a
+/// current-controlled drive actually wants (issue #137). **Not the plant's
+/// own `kt`** (`sim/scenarios/plant.py::KT_NM_PER_A`, Mechanical's territory,
+/// mirrored privately in `crates/sim-backend`) — that is what the motor
+/// physically does; this is what the controller *assumes* when converting a
+/// torque command to a current command, and the two only agree because they
+/// happen to share the same unfitted placeholder today.
+///
+/// **An unfitted placeholder, not a bench measurement** — same status as
+/// [`DEFAULT_R_EFF_M`], and superseded the same way once Stage-0 fits `kt` on
+/// the bench (ICD §10.5). Until then, getting it wrong changes how much
+/// torque headroom the 40 A current clamp represents, not the control law's
+/// loop gain — see `crates/control-ffi`'s boundary conversion.
+pub const DEFAULT_KT_NM_PER_A: f32 = 0.7;
+
 /// Mechanical wheel rate, rad/s, per 1 ERPM. ICD §10.5: "1 ERPM = 6.98e-3
 /// rad/s" — the same ratio `sim/scenarios/imperfections.py` names
 /// `wheel_rate_quantum_rad_s` (the size of one ERPM step in the wheel-rate
@@ -330,10 +346,15 @@ pub enum IoError {
 /// margin instrument" bet.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Params {
-    pub kp: f32,
+    /// Inner-loop proportional gain, N·m per radian (issue #137 — was amps
+    /// per radian; `kt` converts this seam's torque to the current the drive
+    /// wants, once, at the actuation boundary, never here).
+    pub kp_nm_per_rad: f32,
     pub ki: f32,
-    pub kd: f32,
-    /// Envelope clamp on commanded current, amps.
+    /// Inner-loop derivative gain, N·m per rad/s.
+    pub kd_nm_per_rad_s: f32,
+    /// Envelope clamp on commanded current, amps. Physically a torque
+    /// ceiling: `τ_max = kt_nm_per_a · max_current_a`.
     pub max_current_a: f32,
     /// Envelope trip on absolute pitch, radians.
     pub max_abs_pitch_rad: f32,
@@ -342,9 +363,9 @@ pub struct Params {
 impl Default for Params {
     fn default() -> Self {
         Params {
-            kp: 0.0,
+            kp_nm_per_rad: 0.0,
             ki: 0.0,
-            kd: 0.0,
+            kd_nm_per_rad_s: 0.0,
             max_current_a: 0.0,
             max_abs_pitch_rad: 0.0,
         }

--- a/crates/control-core/src/lib.rs
+++ b/crates/control-core/src/lib.rs
@@ -210,10 +210,22 @@ impl Estimator for ComplementaryFilter {
 
 /// Inner-loop pitch regulator — the balance law itself.
 ///
-/// `amps = −(kp·θ + kd·θ̇)` with θ **nose-up-positive in radians** (ICD §10.1).
-/// The minus sign is the ICD's own `current ≈ −K·pitch`, K > 0, and it is the
-/// stabilising sense: a nose-down excursion is negative pitch, correcting it
-/// means driving the contact patch forward, which is positive current.
+/// `torque_nm = −(kp·θ + kd·θ̇)` with θ **nose-up-positive in radians** (ICD
+/// §10.1). The minus sign is the ICD's own `current ≈ −K·pitch`, K > 0,
+/// re-expressed in torque, and it is the stabilising sense: a nose-down
+/// excursion is negative pitch, correcting it means driving the contact patch
+/// forward, which is positive torque.
+///
+/// # Torque, not current (issue #137)
+///
+/// Gains are **N·m per radian**, not amps per radian. The plant's stability
+/// depends on `kt` (the motor's torque constant) — an amps-denominated law
+/// hides that dependency entirely, since nothing in `amps = −(kp·θ + kd·θ̇)`
+/// ever mentions it, and a `kt` error silently becomes a loop-gain error on an
+/// inverted pendulum. `kt` belongs at the actuation boundary, converting this
+/// torque command into the current command the drive actually wants —
+/// **never here**. See `control_ffi::ob_controller_update` for that boundary;
+/// this regulator does not know `kt` exists.
 ///
 /// Deliberately takes an already-estimated pitch rather than an [`Observation`].
 /// Fusing raw IMU into an attitude is a separate concern with its own interface
@@ -227,19 +239,19 @@ impl Estimator for ComplementaryFilter {
 /// requires the anti-windup path (ICD §7.6) to be wired to `Saturation` first.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PitchRegulator {
-    kp_a_per_rad: f32,
-    kd_a_per_rad_s: f32,
+    kp_nm_per_rad: f32,
+    kd_nm_per_rad_s: f32,
 }
 
 impl PitchRegulator {
-    pub const fn new(kp_a_per_rad: f32, kd_a_per_rad_s: f32) -> Self {
+    pub const fn new(kp_nm_per_rad: f32, kd_nm_per_rad_s: f32) -> Self {
         PitchRegulator {
-            kp_a_per_rad,
-            kd_a_per_rad_s,
+            kp_nm_per_rad,
+            kd_nm_per_rad_s,
         }
     }
 
-    /// Requested current in amps, before any clamping.
+    /// Requested torque in N·m, before any clamping.
     ///
     /// `pitch_ref_rad` is the attitude to hold — zero for pure disturbance
     /// rejection, or the outer loop's output when a [`VelocityLoop`] is
@@ -247,9 +259,13 @@ impl PitchRegulator {
     ///
     /// Unclamped on purpose: bounding the command is the safety envelope's job
     /// (stage 2, ICD §7.6), and a controller that silently clamps its own
-    /// output hides saturation from the anti-windup that needs to see it.
+    /// output hides saturation from the anti-windup that needs to see it. The
+    /// clamp itself is a current limit (`I_max`, what the drive is rated for),
+    /// so converting this output to amps and applying `τ_max = kt·I_max` is
+    /// the caller's job, done once, at the boundary.
     pub fn update(&self, pitch_rad: f32, pitch_rate_rad_s: f32, pitch_ref_rad: f32) -> f32 {
-        -(self.kp_a_per_rad * (pitch_rad - pitch_ref_rad) + self.kd_a_per_rad_s * pitch_rate_rad_s)
+        -(self.kp_nm_per_rad * (pitch_rad - pitch_ref_rad)
+            + self.kd_nm_per_rad_s * pitch_rate_rad_s)
     }
 }
 
@@ -635,21 +651,27 @@ mod tests {
     // These assert the SIGN and the shape, not tuned values. The gains that
     // matter are validated against the plant in the sim scenario; what must be
     // true here, independent of any plant, is that the law opposes the error.
+    //
+    // N*m/rad, N*m/(rad/s) -- the amps-space tuning (80 A/rad, 11 A/(rad/s))
+    // re-expressed at the kt = 0.7 N*m/A design point (issue #137). The
+    // regulator itself never sees kt; these are just the numbers that made
+    // the old amps-denominated tests' shape assertions true, carried through.
 
-    const KP: f32 = 80.0;
-    const KD: f32 = 11.0;
+    const KP: f32 = 56.0;
+    const KD: f32 = 7.7;
 
     #[test]
-    fn nose_down_commands_positive_current() {
+    fn nose_down_commands_positive_torque() {
         // Nose-down is NEGATIVE pitch (ICD 10.1). Correcting it means driving
-        // the contact patch forward, i.e. POSITIVE current. If this ever
-        // inverts, the board accelerates into its own nosedive.
+        // the contact patch forward, i.e. POSITIVE torque (and, via kt > 0 at
+        // the actuation boundary, positive current). If this ever inverts,
+        // the board accelerates into its own nosedive.
         let r = PitchRegulator::new(KP, KD);
         assert!(r.update(-0.1, 0.0, 0.0) > 0.0);
     }
 
     #[test]
-    fn nose_up_commands_negative_current() {
+    fn nose_up_commands_negative_torque() {
         let r = PitchRegulator::new(KP, KD);
         assert!(r.update(0.1, 0.0, 0.0) < 0.0);
     }
@@ -978,8 +1000,10 @@ mod tests {
     #[test]
     fn output_is_unclamped_so_the_envelope_can_see_saturation() {
         // A controller that clamps itself hides saturation from the anti-windup
-        // that needs to observe it (ICD 7.6).
+        // that needs to observe it (ICD 7.6). 28.0 N*m is tau_max = kt * I_max
+        // at the kt = 0.7, I_max = 40 A design point -- the output here must
+        // exceed the torque the envelope will actually allow through.
         let r = PitchRegulator::new(KP, KD);
-        assert!(r.update(-1.0, 0.0, 0.0) > 40.0);
+        assert!(r.update(-1.0, 0.0, 0.0) > 28.0);
     }
 }

--- a/crates/control-ffi/include/overboard_control.h
+++ b/crates/control-ffi/include/overboard_control.h
@@ -7,6 +7,9 @@
  * compiled against an older copy of this header.
  *
  * Angles are RADIANS, nose-up-positive (BoardIo ICD 10.1). Current is AMPS.
+ * Kp/Kd are TORQUE gains, N*m (issue #137) -- kt_nm_per_a below is the only
+ * place this header's kt enters, converting the law's torque to the current
+ * command the drive wants.
  */
 #ifndef OVERBOARD_CONTROL_H
 #define OVERBOARD_CONTROL_H
@@ -20,9 +23,16 @@
 
 typedef struct {
     uint32_t size;
-    float    kp_a_per_rad;
-    float    kd_a_per_rad_s;
+    float    kp_nm_per_rad;
+    float    kd_nm_per_rad_s;
+    /* Envelope clamp on commanded current, amps. Physically a torque
+     * ceiling: tau_max = kt_nm_per_a * max_current_a. */
     float    max_current_a;
+    /* Motor torque constant, N*m per amp -- converts the regulator's torque
+     * command to the current command, once, here. Zero falls back to the
+     * board_types::DEFAULT_KT_NM_PER_A placeholder (unfitted, pending a
+     * Stage-0 bench measurement, ICD 10.5 -- same status as r_eff_m below). */
+    float    kt_nm_per_a;
 
     /* Outer velocity loop. Zero both gains to disable it. */
     float    kp_v_rad_per_m_s;

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -476,9 +476,12 @@ pub unsafe extern "C" fn ob_controller_update(
     // the unchanged `max_current_a` clamp downstream actually represents.
     let proposed_torque_nm = ctl.regulator.update(pitch_in, rate_in, pitch_ref);
     let proposed_amps = proposed_torque_nm / ctl.kt_nm_per_a;
-    let (bounded, sat) = ctl
-        .envelope
-        .apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
+    let (bounded, sat) = ctl.envelope.apply(
+        Command::MotorCurrent {
+            amps: proposed_amps,
+        },
+        Faults::NONE,
+    );
 
     cmd.amps = match bounded {
         Command::MotorCurrent { amps } => amps,
@@ -667,7 +670,10 @@ mod tests {
         // how many amps it took to get there.
         let (o, mut c_low) = (obs(-0.02, 0.0), out());
         let (mut c_high, low, high) = (out(), armed_with_kt(0.5), armed_with_kt(0.9));
-        assert_eq!(unsafe { ob_controller_update(low.0, &o, &mut c_low) }, OB_OK);
+        assert_eq!(
+            unsafe { ob_controller_update(low.0, &o, &mut c_low) },
+            OB_OK
+        );
         assert_eq!(
             unsafe { ob_controller_update(high.0, &o, &mut c_high) },
             OB_OK
@@ -695,7 +701,10 @@ mod tests {
         // ceiling is understood to represent (tau_max = kt * max_current_a).
         let (o, mut c_low) = (obs(-1.0, 0.0), out());
         let (mut c_high, low, high) = (out(), armed_with_kt(0.5), armed_with_kt(0.9));
-        assert_eq!(unsafe { ob_controller_update(low.0, &o, &mut c_low) }, OB_OK);
+        assert_eq!(
+            unsafe { ob_controller_update(low.0, &o, &mut c_low) },
+            OB_OK
+        );
         assert_eq!(
             unsafe { ob_controller_update(high.0, &o, &mut c_high) },
             OB_OK
@@ -714,7 +723,10 @@ mod tests {
         assert!(!h.0.is_null());
         let (o, mut c_default) = (obs(-0.02, 0.0), out());
         unsafe { ob_controller_arm(h.0) };
-        assert_eq!(unsafe { ob_controller_update(h.0, &o, &mut c_default) }, OB_OK);
+        assert_eq!(
+            unsafe { ob_controller_update(h.0, &o, &mut c_default) },
+            OB_OK
+        );
 
         let reference = armed_with_kt(DEFAULT_KT_NM_PER_A);
         let mut c_ref = out();

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -32,7 +32,7 @@
 //! state that produced it.
 
 use board_types::ImuSample;
-use board_types::{Command, Faults, Params, Saturation, DEFAULT_R_EFF_M};
+use board_types::{Command, Faults, Params, Saturation, DEFAULT_KT_NM_PER_A, DEFAULT_R_EFF_M};
 use control_core::{
     Attitude, CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator, PlantCoupling,
     VelocityLoop, WheelAccelEstimator,
@@ -58,12 +58,24 @@ pub const OB_ERR_NOT_FINITE: i32 = -3;
 #[derive(Debug, Clone, Copy)]
 pub struct ObParamsV1 {
     pub size: u32,
-    /// Proportional gain, **amps per radian** of nose-up-positive pitch.
-    pub kp_a_per_rad: f32,
-    /// Derivative gain, amps per rad/s.
-    pub kd_a_per_rad_s: f32,
+    /// Proportional gain, **N·m per radian** of nose-up-positive pitch (issue
+    /// #137 — was amps per radian; `kt_nm_per_a` below converts this law's
+    /// torque output to the current the drive wants, once, at the boundary,
+    /// never inside the law itself).
+    pub kp_nm_per_rad: f32,
+    /// Derivative gain, N·m per rad/s.
+    pub kd_nm_per_rad_s: f32,
     /// Envelope clamp on commanded current, amps (ICD §7.6 stage 2).
+    /// Physically a torque ceiling: `τ_max = kt_nm_per_a · max_current_a`. A
+    /// wrong `kt_nm_per_a` moves this headroom; it cannot move the loop gain
+    /// above, which never sees `kt` at all.
     pub max_current_a: f32,
+    /// Motor torque constant, N·m per amp, used **only** to convert the
+    /// regulator's torque command into the current command sent to the
+    /// drive. Zero falls back to [`DEFAULT_KT_NM_PER_A`] — an unfitted
+    /// placeholder pending a Stage-0 bench fit (ICD §10.5), same status as
+    /// `r_eff_m` below.
+    pub kt_nm_per_a: f32,
 
     // --- outer velocity loop --------------------------------------------
     /// Radians of pitch reference per m/s of speed error. Zero disables the
@@ -217,6 +229,11 @@ pub struct ObController {
     last_amps: f32,
     outer: Option<VelocityLoop>,
     envelope: Envelope,
+    /// The single point `kt` enters this controller: converts the
+    /// regulator's N·m output into the amps command the drive wants (issue
+    /// #137). Never read by anything upstream of [`ob_controller_update`]'s
+    /// final conversion step.
+    kt_nm_per_a: f32,
     r_eff_m: f32,
     last_t_ns: Option<u64>,
     /// Carried between cycles so the outer loop can hold off integrating while
@@ -268,7 +285,7 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
     };
 
     let boxed = Box::new(ObController {
-        regulator: PitchRegulator::new(p.kp_a_per_rad, p.kd_a_per_rad_s),
+        regulator: PitchRegulator::new(p.kp_nm_per_rad, p.kd_nm_per_rad_s),
         estimate_active: p.use_estimator == 1,
         wheel_accel: if p.estimator_accel_aiding == 1 {
             Some(WheelAccelEstimator::new(if p.wheel_accel_tau_s > 0.0 {
@@ -309,6 +326,11 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
             None
         },
         outer,
+        kt_nm_per_a: if p.kt_nm_per_a > 0.0 {
+            p.kt_nm_per_a
+        } else {
+            DEFAULT_KT_NM_PER_A
+        },
         r_eff_m: if p.r_eff_m > 0.0 {
             p.r_eff_m
         } else {
@@ -317,8 +339,8 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
         last_t_ns: None,
         last_saturated: false,
         envelope: Envelope::new(Params {
-            kp: p.kp_a_per_rad,
-            kd: p.kd_a_per_rad_s,
+            kp_nm_per_rad: p.kp_nm_per_rad,
+            kd_nm_per_rad_s: p.kd_nm_per_rad_s,
             max_current_a: p.max_current_a,
             ..Params::default()
         }),
@@ -446,10 +468,17 @@ pub unsafe extern "C" fn ob_controller_update(
     } else {
         (o.pitch_rad, o.pitch_rate_rad_s)
     };
-    let proposed = ctl.regulator.update(pitch_in, rate_in, pitch_ref);
+    // The ONLY place kt is used (issue #137 AC1): the regulator's torque
+    // command becomes the amps command the drive wants. Everything upstream
+    // of this line -- the law, the estimator, the outer loop -- never sees
+    // kt at all, so a wrong kt cannot silently rescale the loop gain those
+    // compute with. It can only rescale this division, i.e. the torque that
+    // the unchanged `max_current_a` clamp downstream actually represents.
+    let proposed_torque_nm = ctl.regulator.update(pitch_in, rate_in, pitch_ref);
+    let proposed_amps = proposed_torque_nm / ctl.kt_nm_per_a;
     let (bounded, sat) = ctl
         .envelope
-        .apply(Command::MotorCurrent { amps: proposed }, Faults::NONE);
+        .apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
 
     cmd.amps = match bounded {
         Command::MotorCurrent { amps } => amps,
@@ -476,9 +505,13 @@ mod tests {
     fn params() -> ObParamsV1 {
         ObParamsV1 {
             size: core::mem::size_of::<ObParamsV1>() as u32,
-            kp_a_per_rad: 80.0,
-            kd_a_per_rad_s: 11.0,
+            // 56.0 / 7.7 N*m/(rad[/s]) are 80.0 / 11.0 A/rad re-expressed at
+            // the kt = 0.7 design point (issue #137) -- numerically identical
+            // amps once kt_nm_per_a below divides back through.
+            kp_nm_per_rad: 56.0,
+            kd_nm_per_rad_s: 7.7,
             max_current_a: 40.0,
+            kt_nm_per_a: 0.7,
             kp_v_rad_per_m_s: 0.0,
             ki_v_rad_per_m: 0.0,
             max_pitch_ref_rad: 0.087,
@@ -612,5 +645,83 @@ mod tests {
     #[test]
     fn abi_version_is_reported() {
         assert_eq!(ob_abi_version(), ABI_VERSION);
+    }
+
+    // ---- issue #137: torque denomination ---------------------------------
+
+    fn armed_with_kt(kt_nm_per_a: f32) -> Handle {
+        let mut p = params();
+        p.kt_nm_per_a = kt_nm_per_a;
+        let h = unsafe { ob_controller_new(&p) };
+        assert!(!h.is_null());
+        assert_eq!(unsafe { ob_controller_arm(h) }, OB_OK);
+        Handle(h)
+    }
+
+    #[test]
+    fn a_wrong_kt_moves_headroom_not_loop_gain() {
+        // AC4: the regulator's gains are N*m/rad and never reference kt, so
+        // in the UNSATURATED regime the delivered torque (amps * kt) for a
+        // given pitch error is the same law output regardless of what kt the
+        // boundary conversion used to reach that current -- kt only decides
+        // how many amps it took to get there.
+        let (o, mut c_low) = (obs(-0.02, 0.0), out());
+        let (mut c_high, low, high) = (out(), armed_with_kt(0.5), armed_with_kt(0.9));
+        assert_eq!(unsafe { ob_controller_update(low.0, &o, &mut c_low) }, OB_OK);
+        assert_eq!(
+            unsafe { ob_controller_update(high.0, &o, &mut c_high) },
+            OB_OK
+        );
+        assert_eq!(c_low.saturated, 0, "low-kt case must be unsaturated");
+        assert_eq!(c_high.saturated, 0, "high-kt case must be unsaturated");
+
+        let torque_low = c_low.amps * 0.5;
+        let torque_high = c_high.amps * 0.9;
+        assert!(
+            (torque_low - torque_high).abs() < 1e-4,
+            "loop gain moved with kt: {torque_low} N*m at kt=0.5 vs {torque_high} N*m at kt=0.9"
+        );
+
+        // Headroom DOES move: the same 40 A current ceiling represents less
+        // deliverable torque at the lower kt.
+        let (tau_max_low, tau_max_high) = (0.5 * 40.0, 0.9 * 40.0);
+        assert!(tau_max_low < tau_max_high);
+    }
+
+    #[test]
+    fn saturation_is_still_the_same_40_a_current_ceiling_whatever_kt_is() {
+        // The envelope clamp is unmoved by this change (AC3): it is still
+        // max_current_a in amps. What changed is only what torque that
+        // ceiling is understood to represent (tau_max = kt * max_current_a).
+        let (o, mut c_low) = (obs(-1.0, 0.0), out());
+        let (mut c_high, low, high) = (out(), armed_with_kt(0.5), armed_with_kt(0.9));
+        assert_eq!(unsafe { ob_controller_update(low.0, &o, &mut c_low) }, OB_OK);
+        assert_eq!(
+            unsafe { ob_controller_update(high.0, &o, &mut c_high) },
+            OB_OK
+        );
+        assert_eq!(c_low.amps, 40.0);
+        assert_eq!(c_high.amps, 40.0);
+        assert_eq!(c_low.saturated, 1);
+        assert_eq!(c_high.saturated, 1);
+    }
+
+    #[test]
+    fn kt_nm_per_a_zero_falls_back_to_the_default() {
+        let mut p = params();
+        p.kt_nm_per_a = 0.0;
+        let h = Handle(unsafe { ob_controller_new(&p) });
+        assert!(!h.0.is_null());
+        let (o, mut c_default) = (obs(-0.02, 0.0), out());
+        unsafe { ob_controller_arm(h.0) };
+        assert_eq!(unsafe { ob_controller_update(h.0, &o, &mut c_default) }, OB_OK);
+
+        let reference = armed_with_kt(DEFAULT_KT_NM_PER_A);
+        let mut c_ref = out();
+        assert_eq!(
+            unsafe { ob_controller_update(reference.0, &o, &mut c_ref) },
+            OB_OK
+        );
+        assert_eq!(c_default.amps, c_ref.amps);
     }
 }

--- a/sim/scenarios/rust_controller.py
+++ b/sim/scenarios/rust_controller.py
@@ -33,11 +33,21 @@ REPO = Path(__file__).resolve().parents[2]
 #: restoring stiffness m*g*l = 2.354 N*m/rad and kt = 0.7 N*m/A, these place the
 #: closed-loop pole pair at omega ~= 12 rad/s with zeta ~= 0.8 -- about 5x the
 #: plant's own 2.42 rad/s. They are a starting point for a sweep, not a result.
+#:
+#: Kept in amps-per-radian here, unchanged, even though the Rust ABI beneath
+#: this wrapper is now torque-denominated (issue #137) -- `RustController`
+#: converts to N*m at `kt_nm_per_a` before crossing the FFI seam, below, so
+#: every existing caller (tests/, scripts/) keeps its number and its meaning.
 DEFAULT_KP_A_PER_RAD = 80.0
 DEFAULT_KD_A_PER_RAD_S = 11.0
 
 #: Envelope clamp, amps. Matches the model's derived ctrlrange (40 A * kt).
 DEFAULT_MAX_CURRENT_A = 40.0
+
+#: Motor torque constant, N*m per amp -- the boundary conversion issue #137
+#: added. Mirrors `board_types::DEFAULT_KT_NM_PER_A`: an unfitted placeholder,
+#: not a bench measurement, superseded the same way `DEFAULT_R_EFF_M` is.
+DEFAULT_KT_NM_PER_A = 0.7
 
 #: Loaded rolling radius, m (ICD 10.5). Stage-0 will measure the real, loaded
 #: figure; until then this is pinned to the sim model's actual tire geometry
@@ -66,9 +76,10 @@ _ERR = {
 class ObParams(ctypes.Structure):
     _fields_ = [
         ("size", ctypes.c_uint32),
-        ("kp_a_per_rad", ctypes.c_float),
-        ("kd_a_per_rad_s", ctypes.c_float),
+        ("kp_nm_per_rad", ctypes.c_float),
+        ("kd_nm_per_rad_s", ctypes.c_float),
         ("max_current_a", ctypes.c_float),
+        ("kt_nm_per_a", ctypes.c_float),
         ("kp_v_rad_per_m_s", ctypes.c_float),
         ("ki_v_rad_per_m", ctypes.c_float),
         ("max_pitch_ref_rad", ctypes.c_float),
@@ -149,6 +160,12 @@ class RustController:
 
     Call signature is the scenario's: ``(t_s, pitch_rad, pitch_rate_rad_s,
     wheel_rate_rad_s) -> amps``. Radians, nose-up-positive, amps out.
+
+    ``kp_a_per_rad``/``kd_a_per_rad_s`` stay amps-denominated here and keep
+    their existing meaning for every caller (issue #137 re-denominated the
+    Rust ABI beneath this wrapper to torque, N*m/rad -- this constructor
+    converts via ``kt_nm_per_a`` before crossing the FFI seam, so no caller
+    in tests/ or scripts/ needed to change).
     """
 
     def __init__(
@@ -156,6 +173,7 @@ class RustController:
         kp_a_per_rad: float = DEFAULT_KP_A_PER_RAD,
         kd_a_per_rad_s: float = DEFAULT_KD_A_PER_RAD_S,
         max_current_a: float = DEFAULT_MAX_CURRENT_A,
+        kt_nm_per_a: float = DEFAULT_KT_NM_PER_A,
         kp_v_rad_per_m_s: float = 0.0,
         ki_v_rad_per_m: float = 0.0,
         max_pitch_ref_rad: float = DEFAULT_MAX_PITCH_REF_RAD,
@@ -204,9 +222,15 @@ class RustController:
 
         params = ObParams(
             size=ctypes.sizeof(ObParams),
-            kp_a_per_rad=kp_a_per_rad,
-            kd_a_per_rad_s=kd_a_per_rad_s,
+            # The one place kt is used on this side of the seam: converts the
+            # amps-space gain callers still pass into the N*m/rad the Rust
+            # ABI now wants. kt_nm_per_a crosses too, so Rust's own boundary
+            # conversion (proposed_torque_nm / kt_nm_per_a) exactly undoes
+            # this multiply and callers see the same amps as before.
+            kp_nm_per_rad=kp_a_per_rad * kt_nm_per_a,
+            kd_nm_per_rad_s=kd_a_per_rad_s * kt_nm_per_a,
             max_current_a=max_current_a,
+            kt_nm_per_a=kt_nm_per_a,
             kp_v_rad_per_m_s=kp_v_rad_per_m_s,
             ki_v_rad_per_m=ki_v_rad_per_m,
             max_pitch_ref_rad=max_pitch_ref_rad,


### PR DESCRIPTION
## Why

The inner-loop pitch regulator was denominated in amps (`amps = −(kp·θ + kd·θ̇)`), and `kt` (the motor's torque constant) appeared nowhere in the control law or command chain. Loop gain is `kp·kt/J`, so a `kt` error was silently a **loop-gain error** on an inverted pendulum — not a visible, bounded one. `kt = 0.7 N·m/A` is an explicitly unfitted placeholder, so this was a real, unmeasured risk on top of an already-thin 2.9 dB gain margin (#132).

## What changed

- **`control-core::PitchRegulator`** now takes N·m/rad, N·m/(rad/s) gains and returns a torque command (`τ = −(kp·θ + kd·θ̇)`). `kt` never enters this crate.
- **`control-ffi::ob_controller_update`** is the boundary: `amps = torque_nm / kt_nm_per_a`, done once, right before the command reaches `safety::Envelope`. `ObParamsV1` gains kp_nm_per_rad/kd_nm_per_rad_s (renamed) and a new `kt_nm_per_a` field (0 falls back to `DEFAULT_KT_NM_PER_A`, mirroring how `r_eff_m`/`DEFAULT_R_EFF_M` already works). The C header (`overboard_control.h`) mirrors the struct.
- **`board_types::Params`** gains renamed to `kp_nm_per_rad`/`kd_nm_per_rad_s` (documented as N·m). `max_current_a`'s doc now states the physical meaning: `τ_max = kt_nm_per_a · max_current_a`.
- **`board_types::DEFAULT_KT_NM_PER_A = 0.7`** — new placeholder constant, same status and 0.7 value as the `kt` already used identically in `sim/scenarios/plant.py`, `crates/sim-backend`, and control-ffi's own feedforward comment. Not a new fact; not fabricated.
- **`impulse-response-rust.rs`** (the `hal`-hosted binary that wires `PitchRegulator` directly, bypassing `control-ffi`) gets the identical boundary conversion.
- **`sim/scenarios/rust_controller.py`**'s `ObParams` ctypes struct is renamed/extended to match the ABI exactly (byte-for-byte, verified by field order). `RustController()`'s Python-facing kwargs (`kp_a_per_rad`, `kd_a_per_rad_s`) **keep their existing names and amps-equivalent meaning** — the wrapper now converts to N·m via a new `kt_nm_per_a` param (default `DEFAULT_KT_NM_PER_A`) before crossing the FFI seam.

## Acceptance criteria (issue #137)

1. ✅ `control-core`'s regulator takes/returns torque; `kt` appears exactly once, at the `control-ffi`/`impulse-response-rust.rs` boundary, nowhere in the law.
2. ✅ Behaviour unchanged at `kt = 0.7`. The amps↔N·m round-trip at a shared `kt` is algebraic identity, so every existing Python call site (`tests/`, `scripts/`, `hill.py`/`terrain.py`/`shuttle_run.py`) keeps its `kp_a_per_rad=200.0`-style kwargs, unchanged in name and numeric meaning — **zero call sites needed to change**, which is the strongest form of "numerically identical" available without re-running the full mujoco-gated pytest suite (see Testing).
3. ✅ The 40 A clamp is unchanged in mechanism (still `safety::Envelope` on amps) but is now documented and **tested** as a torque ceiling: `crates/control-ffi`'s new `saturation_is_still_the_same_40_a_current_ceiling_whatever_kt_is` test shows the same `max_current_a` represents different torque headroom at different `kt`.
4. ✅ Demonstrated in `crates/control-ffi`'s new `a_wrong_kt_moves_headroom_not_loop_gain` test: in the unsaturated regime, delivered torque (`amps · kt`) is invariant to `kt ∈ {0.5, 0.9}` (loop gain unchanged, since the law never references `kt`), while `τ_max = kt · I_max` visibly moves (20 N·m vs 36 N·m).
5. ✅ `board-types`/ICD field names and units updated in the same pass (see above). The Notion-hosted ICD document itself is out of this session's reach (no Notion access, consistent with prior sessions' notes) — flagged, not silently skipped.

## Testing

- `cargo test -p board-types -p control-core -p safety -p control-ffi`: **61 passed, 0 failed** (includes 3 new tests for AC3/AC4).
- `cargo clippy -p board-types -p control-core -p safety -p control-ffi --all-targets -- -D warnings`: clean.
- `python3 -m py_compile sim/scenarios/rust_controller.py`: clean.
- `python3 .github/policy_check.py`: all hard checks pass (advisories are pre-existing, unrelated to this change).
- **Not run locally:** `cargo build --workspace` (and therefore `board-app-driverless`'s full binary set, `sim-backend`, and the mujoco-gated Python pytest suite) — this sandbox has no MuJoCo install (`plant-mujoco`'s build script refuses to degrade silently, by design) and `requirements-sim.txt`'s pinned `numpy==2.5.1` needs Python ≥3.12, which this sandbox doesn't have either. This is a pre-existing sandbox limitation (see prior sessions' notes on the macOS dylib problem in #112) — CI covers both. `impulse-response-rust.rs`'s edit mirrors `control-ffi`'s boundary conversion exactly and was reviewed by hand; it could not be independently compiled here since it depends on `sim-backend` → `plant-mujoco`.

## Deliberately left out

- **The Python-facing `RustController()` kwarg names** (`kp_a_per_rad`, `kd_a_per_rad_s`) are **not** renamed, even though the underlying ABI now is. Renaming them would touch ~15 files across `tests/` and `scripts/` for no change in behavior or claim — out of proportion to what AC1–5 ask for. Flagged here rather than done silently: if a future session wants the Python surface to carry honest units too, this is the follow-up.
- **`sim/scenarios/plant.py::KT_NM_PER_A` and `crates/sim-backend`'s private mirror of it are untouched.** Those represent the plant's own (Mechanical-owned) physical torque constant, feeding MuJoCo's `ctrl`. This issue's `kt_nm_per_a` is a separate, controller-side belief used only to convert a torque command to a current command — they happen to share the same 0.7 placeholder today, but are conceptually and structurally independent, and `sim/scenarios/plant.py` is outside my turf.
- **No absolute amps figure is asserted as newly trustworthy.** This makes the `kt` dependency visible and bounded (a headroom question); it does not remove it. Per the issue: no claim beyond that until Stage-0's bench fit lands.

Closes #137.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xvd4nrYwZNcTqdr5kYnNP5)_