### PR TITLE
fix(controls): re-denominate the control law in torque (#137)

### DIFF
--- a/crates/board-app-driverless/src/bin/impulse-response-rust.rs
+++ b/crates/board-app-driverless/src/bin/impulse-response-rust.rs
@@ -183,8 +183,12 @@ fn main() -> ExitCode {
             regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
         // The single kt division -- the actuation boundary (issue #137).
         let proposed_amps = proposed_torque_nm / KT_NM_PER_A;
-        let (bounded_cmd, _envelope_sat) =
-            envelope.apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
+        let (bounded_cmd, _envelope_sat) = envelope.apply(
+            Command::MotorCurrent {
+                amps: proposed_amps,
+            },
+            Faults::NONE,
+        );
 
         if let Err(e) = backend.apply(&bounded_cmd) {
             eprintln!("impulse-response-rust: apply failed: {e:?}");

--- a/crates/board-app-driverless/src/bin/impulse-response-rust.rs
+++ b/crates/board-app-driverless/src/bin/impulse-response-rust.rs
@@ -72,8 +72,14 @@ const FORCE_N: [f64; 3] = [-(NOMINAL_IMPULSE_NS / DURATION_S), 0.0, 0.0];
 // wheel_accel_tau_s match control-ffi::ob_controller_new's own defaults /
 // RustController()'s own defaults (issue #121: mode 1, wheel odometry, is
 // now the mode both hosts run -- see the module doc comment).
-const KP_A_PER_RAD: f32 = 80.0;
-const KD_A_PER_RAD_S: f32 = 11.0;
+//
+// Torque-denominated (issue #137): 80 A/rad, 11 A/(rad/s) at kt = 0.7 N*m/A
+// -- the same numbers this binary shipped before #137, re-denominated. `KT`
+// is the one place that conversion happens, applied once below right before
+// `Command::MotorCurrent` is built, mirroring `control-ffi`'s boundary.
+const KP_NM_PER_RAD: f32 = 56.0;
+const KD_NM_PER_RAD_S: f32 = 7.7;
+const KT_NM_PER_A: f32 = 0.7;
 const MAX_CURRENT_A: f32 = 40.0;
 const ESTIMATOR_TAU_S: f32 = 1.0;
 /// `RustController()`'s own default (`sim/scenarios/rust_controller.py`,
@@ -90,8 +96,9 @@ fn main() -> ExitCode {
     };
 
     let params = Params {
-        kp: KP_A_PER_RAD,
-        kd: KD_A_PER_RAD_S,
+        kp_nm_per_rad: KP_NM_PER_RAD,
+        kd_nm_per_rad_s: KD_NM_PER_RAD_S,
+        kt_nm_per_a: KT_NM_PER_A,
         max_current_a: MAX_CURRENT_A,
         ..Params::default()
     };
@@ -112,7 +119,7 @@ fn main() -> ExitCode {
     let mut envelope = Envelope::new(params);
     envelope.arm();
 
-    let regulator = PitchRegulator::new(KP_A_PER_RAD, KD_A_PER_RAD_S);
+    let regulator = PitchRegulator::new(KP_NM_PER_RAD, KD_NM_PER_RAD_S);
     let mut estimator = ComplementaryFilter::with_trust_band(ESTIMATOR_TAU_S, 0.0);
     let mut wheel_accel = WheelAccelEstimator::new(WHEEL_ACCEL_TAU_S);
 
@@ -172,9 +179,12 @@ fn main() -> ExitCode {
         let wheel_rate_rad_s = obs.erpm * RAD_S_PER_ERPM;
         let aiding = wheel_accel.update(wheel_rate_rad_s * DEFAULT_R_EFF_M, dt_s as f32);
         let attitude = estimator.update(std::slice::from_ref(&sample), aiding);
-        let proposed = regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
+        let proposed_torque_nm =
+            regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
+        // The single kt division -- the actuation boundary (issue #137).
+        let proposed_amps = proposed_torque_nm / KT_NM_PER_A;
         let (bounded_cmd, _envelope_sat) =
-            envelope.apply(Command::MotorCurrent { amps: proposed }, Faults::NONE);
+            envelope.apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
 
         if let Err(e) = backend.apply(&bounded_cmd) {
             eprintln!("impulse-response-rust: apply failed: {e:?}");

--- a/crates/board-types/src/lib.rs
+++ b/crates/board-types/src/lib.rs
@@ -328,11 +328,24 @@ pub enum IoError {
 /// equal the hardware backend's, from this same struct** — otherwise a CI
 /// margin gate is not comparable to hardware, which breaks the whole "sim as a
 /// margin instrument" bet.
+///
+/// `kp`/`kd` are **N·m-denominated** (issue #137) — a property of the plant
+/// (its inertia and restoring stiffness), not of the motor. `kt_nm_per_a` is
+/// the one place a fitted motor torque constant crosses this seam: it is used
+/// only to convert a torque command to the amps the drive accepts and to turn
+/// `max_current_a` into a torque ceiling ([`Params::tau_max_nm`]), never inside
+/// the control law itself.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Params {
-    pub kp: f32,
+    /// Proportional gain, N·m per radian of nose-up-positive pitch.
+    pub kp_nm_per_rad: f32,
     pub ki: f32,
-    pub kd: f32,
+    /// Derivative gain, N·m per rad/s.
+    pub kd_nm_per_rad_s: f32,
+    /// Motor torque constant, N·m per amp. **Unfitted placeholder until a
+    /// bench measurement lands** — see `sim/scenarios/plant.py::KT_NM_PER_A`,
+    /// which this mirrors when a run intends to model the plant faithfully.
+    pub kt_nm_per_a: f32,
     /// Envelope clamp on commanded current, amps.
     pub max_current_a: f32,
     /// Envelope trip on absolute pitch, radians.
@@ -342,12 +355,24 @@ pub struct Params {
 impl Default for Params {
     fn default() -> Self {
         Params {
-            kp: 0.0,
+            kp_nm_per_rad: 0.0,
             ki: 0.0,
-            kd: 0.0,
+            kd_nm_per_rad_s: 0.0,
+            kt_nm_per_a: 0.0,
             max_current_a: 0.0,
             max_abs_pitch_rad: 0.0,
         }
+    }
+}
+
+impl Params {
+    /// `τ_max = kt · I_max` — the 40 A envelope clamp, expressed as the
+    /// torque ceiling it actually represents once the law is denominated in
+    /// torque (issue #137, AC3). A wrong `kt_nm_per_a` moves this number, not
+    /// the loop gain: the headroom shrinks or grows, but the commanded torque
+    /// for a given pitch error does not change.
+    pub fn tau_max_nm(&self) -> f32 {
+        self.kt_nm_per_a * self.max_current_a.abs()
     }
 }
 
@@ -413,6 +438,43 @@ mod tests {
     #[test]
     fn command_zero_is_zero_amps() {
         assert_eq!(Command::ZERO, Command::MotorCurrent { amps: 0.0 });
+    }
+
+    #[test]
+    fn tau_max_is_kt_times_i_max() {
+        // Issue #137 AC3: the 40 A clamp expressed as a torque ceiling.
+        let p = Params {
+            kt_nm_per_a: 0.7,
+            max_current_a: 40.0,
+            ..Params::default()
+        };
+        assert!((p.tau_max_nm() - 28.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn tau_max_is_unaffected_by_the_sign_of_max_current_a() {
+        let p = Params {
+            kt_nm_per_a: 0.7,
+            max_current_a: -40.0,
+            ..Params::default()
+        };
+        assert!((p.tau_max_nm() - 28.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn a_higher_kt_buys_more_torque_headroom_at_the_same_current_limit() {
+        // The whole point of issue #137: kt moves headroom, not loop gain.
+        let low = Params {
+            kt_nm_per_a: 0.5,
+            max_current_a: 40.0,
+            ..Params::default()
+        };
+        let high = Params {
+            kt_nm_per_a: 0.9,
+            max_current_a: 40.0,
+            ..Params::default()
+        };
+        assert!(high.tau_max_nm() > low.tau_max_nm());
     }
 
     #[test]

--- a/crates/control-core/src/lib.rs
+++ b/crates/control-core/src/lib.rs
@@ -210,10 +210,25 @@ impl Estimator for ComplementaryFilter {
 
 /// Inner-loop pitch regulator — the balance law itself.
 ///
-/// `amps = −(kp·θ + kd·θ̇)` with θ **nose-up-positive in radians** (ICD §10.1).
-/// The minus sign is the ICD's own `current ≈ −K·pitch`, K > 0, and it is the
-/// stabilising sense: a nose-down excursion is negative pitch, correcting it
-/// means driving the contact patch forward, which is positive current.
+/// `τ = −(kp·θ + kd·θ̇)`, in **N·m**, with θ **nose-up-positive in radians**
+/// (ICD §10.1). The minus sign is the ICD's own `current ≈ −K·pitch`, K > 0,
+/// carried through to torque, and it is the stabilising sense: a nose-down
+/// excursion is negative pitch, correcting it means driving the contact patch
+/// forward, which is positive torque.
+///
+/// # Why torque, not amps (issue #137)
+///
+/// Loop gain is `kp·kt/J`. Denominating the law in amps means `kt` never
+/// appears anywhere the law is defined, tuned or tested — the controller's
+/// stability then depends on a motor constant it structurally cannot see.
+/// Denominating it in torque removes `kt` from the law entirely: gains here
+/// are a property of the plant (its inertia and restoring stiffness) and
+/// nothing else. **`kt` appears exactly once in this stack, as the single
+/// division `amps = τ / kt` applied at the actuation boundary** (currently
+/// `control-ffi::ob_controller_update` and
+/// `board-app-driverless`'s `impulse-response-rust` binary), never inside
+/// this law. A wrong `kt` then changes the amps a given torque command costs
+/// — a headroom error — instead of changing the torque itself — a gain error.
 ///
 /// Deliberately takes an already-estimated pitch rather than an [`Observation`].
 /// Fusing raw IMU into an attitude is a separate concern with its own interface
@@ -227,19 +242,19 @@ impl Estimator for ComplementaryFilter {
 /// requires the anti-windup path (ICD §7.6) to be wired to `Saturation` first.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PitchRegulator {
-    kp_a_per_rad: f32,
-    kd_a_per_rad_s: f32,
+    kp_nm_per_rad: f32,
+    kd_nm_per_rad_s: f32,
 }
 
 impl PitchRegulator {
-    pub const fn new(kp_a_per_rad: f32, kd_a_per_rad_s: f32) -> Self {
+    pub const fn new(kp_nm_per_rad: f32, kd_nm_per_rad_s: f32) -> Self {
         PitchRegulator {
-            kp_a_per_rad,
-            kd_a_per_rad_s,
+            kp_nm_per_rad,
+            kd_nm_per_rad_s,
         }
     }
 
-    /// Requested current in amps, before any clamping.
+    /// Requested torque in N·m, before any clamping.
     ///
     /// `pitch_ref_rad` is the attitude to hold — zero for pure disturbance
     /// rejection, or the outer loop's output when a [`VelocityLoop`] is
@@ -248,8 +263,12 @@ impl PitchRegulator {
     /// Unclamped on purpose: bounding the command is the safety envelope's job
     /// (stage 2, ICD §7.6), and a controller that silently clamps its own
     /// output hides saturation from the anti-windup that needs to see it.
+    /// Note the clamp itself is expressed in amps (the drive's real limit) —
+    /// converting this torque to amps via `kt` happens at the caller's
+    /// actuation boundary, not here.
     pub fn update(&self, pitch_rad: f32, pitch_rate_rad_s: f32, pitch_ref_rad: f32) -> f32 {
-        -(self.kp_a_per_rad * (pitch_rad - pitch_ref_rad) + self.kd_a_per_rad_s * pitch_rate_rad_s)
+        -(self.kp_nm_per_rad * (pitch_rad - pitch_ref_rad)
+            + self.kd_nm_per_rad_s * pitch_rate_rad_s)
     }
 }
 
@@ -640,16 +659,16 @@ mod tests {
     const KD: f32 = 11.0;
 
     #[test]
-    fn nose_down_commands_positive_current() {
+    fn nose_down_commands_positive_torque() {
         // Nose-down is NEGATIVE pitch (ICD 10.1). Correcting it means driving
-        // the contact patch forward, i.e. POSITIVE current. If this ever
+        // the contact patch forward, i.e. POSITIVE torque. If this ever
         // inverts, the board accelerates into its own nosedive.
         let r = PitchRegulator::new(KP, KD);
         assert!(r.update(-0.1, 0.0, 0.0) > 0.0);
     }
 
     #[test]
-    fn nose_up_commands_negative_current() {
+    fn nose_up_commands_negative_torque() {
         let r = PitchRegulator::new(KP, KD);
         assert!(r.update(0.1, 0.0, 0.0) < 0.0);
     }
@@ -978,7 +997,8 @@ mod tests {
     #[test]
     fn output_is_unclamped_so_the_envelope_can_see_saturation() {
         // A controller that clamps itself hides saturation from the anti-windup
-        // that needs to observe it (ICD 7.6).
+        // that needs to observe it (ICD 7.6). Magnitude here is arbitrary --
+        // just large enough to be clearly outside any plausible torque ceiling.
         let r = PitchRegulator::new(KP, KD);
         assert!(r.update(-1.0, 0.0, 0.0) > 40.0);
     }

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -478,9 +478,12 @@ pub unsafe extern "C" fn ob_controller_update(
     // torque itself, which is fixed by `pitch_in`/`rate_in` alone.
     let proposed_torque_nm = ctl.regulator.update(pitch_in, rate_in, pitch_ref);
     let proposed_amps = proposed_torque_nm / ctl.kt_nm_per_a;
-    let (bounded, sat) = ctl
-        .envelope
-        .apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
+    let (bounded, sat) = ctl.envelope.apply(
+        Command::MotorCurrent {
+            amps: proposed_amps,
+        },
+        Faults::NONE,
+    );
 
     cmd.amps = match bounded {
         Command::MotorCurrent { amps } => amps,
@@ -718,7 +721,10 @@ mod tests {
         assert_eq!(unsafe { ob_controller_update(hi.0, &o, &mut c_hi) }, OB_OK);
 
         assert_eq!(c_lo.saturated, 1, "kt=0.5: 28 N*m exceeds a 20 N*m ceiling");
-        assert_eq!(c_hi.saturated, 0, "kt=0.9: 28 N*m is within a 36 N*m ceiling");
+        assert_eq!(
+            c_hi.saturated, 0,
+            "kt=0.9: 28 N*m is within a 36 N*m ceiling"
+        );
         assert_eq!(c_lo.amps, 40.0);
         assert!(c_hi.amps < 40.0, "got {}", c_hi.amps);
     }

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -43,6 +43,13 @@ use safety::Envelope;
 /// Growing a struct is handled by its `size` field, not by this.
 pub const ABI_VERSION: u32 = 1;
 
+/// Motor torque constant fallback, N·m per amp — mirrors
+/// `sim/scenarios/plant.py::KT_NM_PER_A`. **Unfitted placeholder**, same
+/// caveat as that constant: nothing has been measured on the bench yet.
+/// Used only when a caller passes `kt_nm_per_a <= 0.0`, the same
+/// zero-means-use-the-default convention `r_eff_m` already follows below.
+pub const DEFAULT_KT_NM_PER_A: f32 = 0.7;
+
 // --- status codes ----------------------------------------------------------
 
 pub const OB_OK: i32 = 0;
@@ -58,10 +65,17 @@ pub const OB_ERR_NOT_FINITE: i32 = -3;
 #[derive(Debug, Clone, Copy)]
 pub struct ObParamsV1 {
     pub size: u32,
-    /// Proportional gain, **amps per radian** of nose-up-positive pitch.
-    pub kp_a_per_rad: f32,
-    /// Derivative gain, amps per rad/s.
-    pub kd_a_per_rad_s: f32,
+    /// Proportional gain, **N·m per radian** of nose-up-positive pitch
+    /// (issue #137 — a property of the plant, not the motor).
+    pub kp_nm_per_rad: f32,
+    /// Derivative gain, N·m per rad/s.
+    pub kd_nm_per_rad_s: f32,
+    /// Motor torque constant, N·m per amp. **The one place `kt` crosses this
+    /// ABI.** Converts the regulator's torque output to the current the drive
+    /// accepts, and turns `max_current_a` into a torque ceiling
+    /// (`board_types::Params::tau_max_nm`) — never used inside the law
+    /// itself. Zero or negative falls back to [`DEFAULT_KT_NM_PER_A`].
+    pub kt_nm_per_a: f32,
     /// Envelope clamp on commanded current, amps (ICD §7.6 stage 2).
     pub max_current_a: f32,
 
@@ -217,6 +231,10 @@ pub struct ObController {
     last_amps: f32,
     outer: Option<VelocityLoop>,
     envelope: Envelope,
+    /// The single point `kt` enters this stack (issue #137): divides the
+    /// regulator's torque output down to amps, immediately before the
+    /// envelope's amp clamp.
+    kt_nm_per_a: f32,
     r_eff_m: f32,
     last_t_ns: Option<u64>,
     /// Carried between cycles so the outer loop can hold off integrating while
@@ -267,8 +285,14 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
         None
     };
 
+    let kt_nm_per_a = if p.kt_nm_per_a > 0.0 {
+        p.kt_nm_per_a
+    } else {
+        DEFAULT_KT_NM_PER_A
+    };
+
     let boxed = Box::new(ObController {
-        regulator: PitchRegulator::new(p.kp_a_per_rad, p.kd_a_per_rad_s),
+        regulator: PitchRegulator::new(p.kp_nm_per_rad, p.kd_nm_per_rad_s),
         estimate_active: p.use_estimator == 1,
         wheel_accel: if p.estimator_accel_aiding == 1 {
             Some(WheelAccelEstimator::new(if p.wheel_accel_tau_s > 0.0 {
@@ -309,6 +333,7 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
             None
         },
         outer,
+        kt_nm_per_a,
         r_eff_m: if p.r_eff_m > 0.0 {
             p.r_eff_m
         } else {
@@ -317,8 +342,9 @@ pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut Ob
         last_t_ns: None,
         last_saturated: false,
         envelope: Envelope::new(Params {
-            kp: p.kp_a_per_rad,
-            kd: p.kd_a_per_rad_s,
+            kp_nm_per_rad: p.kp_nm_per_rad,
+            kd_nm_per_rad_s: p.kd_nm_per_rad_s,
+            kt_nm_per_a,
             max_current_a: p.max_current_a,
             ..Params::default()
         }),
@@ -446,10 +472,15 @@ pub unsafe extern "C" fn ob_controller_update(
     } else {
         (o.pitch_rad, o.pitch_rate_rad_s)
     };
-    let proposed = ctl.regulator.update(pitch_in, rate_in, pitch_ref);
+    // The law lives entirely in torque; this division is the ONLY place `kt`
+    // enters the control path (issue #137). A wrong `kt` here changes how
+    // much current a given torque command costs -- headroom -- not the
+    // torque itself, which is fixed by `pitch_in`/`rate_in` alone.
+    let proposed_torque_nm = ctl.regulator.update(pitch_in, rate_in, pitch_ref);
+    let proposed_amps = proposed_torque_nm / ctl.kt_nm_per_a;
     let (bounded, sat) = ctl
         .envelope
-        .apply(Command::MotorCurrent { amps: proposed }, Faults::NONE);
+        .apply(Command::MotorCurrent { amps: proposed_amps }, Faults::NONE);
 
     cmd.amps = match bounded {
         Command::MotorCurrent { amps } => amps,
@@ -476,8 +507,11 @@ mod tests {
     fn params() -> ObParamsV1 {
         ObParamsV1 {
             size: core::mem::size_of::<ObParamsV1>() as u32,
-            kp_a_per_rad: 80.0,
-            kd_a_per_rad_s: 11.0,
+            // 80 A/rad, 11 A/(rad/s) at kt = 0.7 N*m/A -- the same numbers
+            // this crate shipped before issue #137, re-denominated.
+            kp_nm_per_rad: 56.0,
+            kd_nm_per_rad_s: 7.7,
+            kt_nm_per_a: 0.7,
             max_current_a: 40.0,
             kp_v_rad_per_m_s: 0.0,
             ki_v_rad_per_m: 0.0,
@@ -612,5 +646,80 @@ mod tests {
     #[test]
     fn abi_version_is_reported() {
         assert_eq!(ob_abi_version(), ABI_VERSION);
+    }
+
+    #[test]
+    fn zero_kt_falls_back_to_the_default_placeholder() {
+        // Same zero-means-default convention `r_eff_m` already follows --
+        // asserted here because it is new with issue #137.
+        let mut p = params();
+        p.kt_nm_per_a = 0.0;
+        let h = unsafe { ob_controller_new(&p) };
+        assert!(!h.is_null());
+        let ctl = unsafe { &*h };
+        assert_eq!(ctl.kt_nm_per_a, DEFAULT_KT_NM_PER_A);
+        unsafe { ob_controller_free(h) };
+    }
+
+    // ---- issue #137 AC4: kt moves headroom, not loop gain -----------------
+    //
+    // "Demonstrate it: run with kt at 0.5 and 0.9 and show the loop gain is
+    // unchanged while headroom moves." Both controllers below share the SAME
+    // kp_nm_per_rad/kd_nm_per_rad_s -- only kt_nm_per_a differs.
+
+    fn controller_with_kt(kt_nm_per_a: f32) -> Handle {
+        let mut p = params();
+        p.kt_nm_per_a = kt_nm_per_a;
+        let h = unsafe { ob_controller_new(&p) };
+        assert!(!h.is_null());
+        assert_eq!(unsafe { ob_controller_arm(h) }, OB_OK);
+        Handle(h)
+    }
+
+    #[test]
+    fn loop_gain_the_torque_actually_commanded_is_unchanged_by_kt() {
+        // Small error, well inside either kt's headroom: neither saturates.
+        // If loop gain depended on kt this would fail -- it does not, because
+        // kt appears nowhere in the law.
+        let (lo, hi) = (controller_with_kt(0.5), controller_with_kt(0.9));
+        let (o, mut c_lo) = (obs(-0.05, 0.0), out());
+        let mut c_hi = out();
+        assert_eq!(unsafe { ob_controller_update(lo.0, &o, &mut c_lo) }, OB_OK);
+        assert_eq!(unsafe { ob_controller_update(hi.0, &o, &mut c_hi) }, OB_OK);
+        assert_eq!(c_lo.saturated, 0);
+        assert_eq!(c_hi.saturated, 0);
+
+        // amps differ (headroom cost of the SAME torque differs)...
+        assert!(
+            (c_lo.amps - c_hi.amps).abs() > 1e-3,
+            "expected different amps for different kt: lo={} hi={}",
+            c_lo.amps,
+            c_hi.amps
+        );
+        // ...but amps * kt -- the torque actually realised -- is identical.
+        let (torque_lo, torque_hi) = (c_lo.amps * 0.5, c_hi.amps * 0.9);
+        assert!(
+            (torque_lo - torque_hi).abs() < 1e-3,
+            "loop gain moved with kt: lo={torque_lo} N*m hi={torque_hi} N*m"
+        );
+    }
+
+    #[test]
+    fn headroom_moves_with_kt_at_a_fixed_current_limit() {
+        // pitch = -0.5 rad asks the law (kp_nm_per_rad = 56.0) for 28 N*m,
+        // exactly halfway between kt=0.5's ceiling (0.5*40 = 20 N*m) and
+        // kt=0.9's ceiling (0.9*40 = 36 N*m) -- so the SAME command saturates
+        // at one kt and not the other. Same max_current_a (40 A) throughout;
+        // only the belief about kt changes what that 40 A is worth in torque.
+        let (lo, hi) = (controller_with_kt(0.5), controller_with_kt(0.9));
+        let (o, mut c_lo) = (obs(-0.5, 0.0), out());
+        let mut c_hi = out();
+        assert_eq!(unsafe { ob_controller_update(lo.0, &o, &mut c_lo) }, OB_OK);
+        assert_eq!(unsafe { ob_controller_update(hi.0, &o, &mut c_hi) }, OB_OK);
+
+        assert_eq!(c_lo.saturated, 1, "kt=0.5: 28 N*m exceeds a 20 N*m ceiling");
+        assert_eq!(c_hi.saturated, 0, "kt=0.9: 28 N*m is within a 36 N*m ceiling");
+        assert_eq!(c_lo.amps, 40.0);
+        assert!(c_hi.amps < 40.0, "got {}", c_hi.amps);
     }
 }

--- a/crates/control-ffi/src/lib.rs
+++ b/crates/control-ffi/src/lib.rs
@@ -39,9 +39,20 @@ use control_core::{
 };
 use safety::Envelope;
 
-/// Bumped only for an incompatible change to the *function* signatures.
-/// Growing a struct is handled by its `size` field, not by this.
-pub const ABI_VERSION: u32 = 1;
+/// Bumped for an incompatible change to the *function* signatures, OR to a
+/// struct's field layout (renamed/reordered/retyped fields) -- anything the
+/// `size` guard cannot catch on its own. `size` only proves the byte count
+/// matches; it says nothing about what those bytes mean. Growing a struct
+/// with a purely additive new field at the end, with existing fields
+/// untouched, is still handled by `size` alone and does not need a bump.
+///
+/// Bumped to 2 by issue #137: `ObParamsV1` renamed two fields
+/// (`kp_a_per_rad`/`kd_a_per_rad_s` -> `kp_nm_per_rad`/`kd_nm_per_rad_s`) and
+/// is now `ObParamsV2`. A caller still holding the old ctypes struct has the
+/// same `size` in the lucky case and a different one otherwise, but even a
+/// same-`size` collision must not be told "compatible" -- that is silent
+/// misreading of memory, exactly what the version field exists to prevent.
+pub const ABI_VERSION: u32 = 2;
 
 /// Motor torque constant fallback, N·m per amp — mirrors
 /// `sim/scenarios/plant.py::KT_NM_PER_A`. **Unfitted placeholder**, same
@@ -63,7 +74,7 @@ pub const OB_ERR_NOT_FINITE: i32 = -3;
 /// Controller gains and envelope limits.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct ObParamsV1 {
+pub struct ObParamsV2 {
     pub size: u32,
     /// Proportional gain, **N·m per radian** of nose-up-positive pitch
     /// (issue #137 — a property of the plant, not the motor).
@@ -259,14 +270,14 @@ pub extern "C" fn ob_abi_version() -> u32 {
 /// Construct a controller. Returns null on a null or mis-sized `params`.
 ///
 /// # Safety
-/// `params` must point to a valid `ObParamsV1`.
+/// `params` must point to a valid `ObParamsV2`.
 #[no_mangle]
-pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV1) -> *mut ObController {
+pub unsafe extern "C" fn ob_controller_new(params: *const ObParamsV2) -> *mut ObController {
     if params.is_null() {
         return core::ptr::null_mut();
     }
     let p = unsafe { &*params };
-    if p.size as usize != core::mem::size_of::<ObParamsV1>() {
+    if p.size as usize != core::mem::size_of::<ObParamsV2>() {
         return core::ptr::null_mut();
     }
 
@@ -507,9 +518,9 @@ pub unsafe extern "C" fn ob_controller_update(
 mod tests {
     use super::*;
 
-    fn params() -> ObParamsV1 {
-        ObParamsV1 {
-            size: core::mem::size_of::<ObParamsV1>() as u32,
+    fn params() -> ObParamsV2 {
+        ObParamsV2 {
+            size: core::mem::size_of::<ObParamsV2>() as u32,
             // 80 A/rad, 11 A/(rad/s) at kt = 0.7 N*m/A -- the same numbers
             // this crate shipped before issue #137, re-denominated.
             kp_nm_per_rad: 56.0,

--- a/docs/design-delay-budget-stage0b.md
+++ b/docs/design-delay-budget-stage0b.md
@@ -62,9 +62,9 @@ analytic pole.
 
 **Why this doesn't route through `kt`.** `KT_NM_PER_A = 0.7` (`sim/scenarios/plant.py`) is
 explicitly flagged in-repo as an **unfitted guess**. A crossover-frequency derivation from the
-current gains (`kp_a_per_rad × kt`) would inherit that fragility directly. `p` above needs no
-`kt` at all — it is pure mass/geometry/gravity — which is why it is trustworthy where a
-gain-based crossover estimate would not be.
+torque-denominated gains (`kp_nm_per_rad / kt`, issue #137) would inherit that fragility
+directly. `p` above needs no `kt` at all — it is pure mass/geometry/gravity — which is why it
+is trustworthy where a gain-based crossover estimate would not be.
 
 ## 2. The delay budget, line items (AC2)
 

--- a/scripts/analyse_control.py
+++ b/scripts/analyse_control.py
@@ -44,8 +44,15 @@ G = 9.81
 
 
 def ctl(**kw):
-    base = dict(kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
-                com_above_axle=True)
+    # This script's own kwargs stay amps/rad for backward compatibility with
+    # every dataset already archived against it; the conversion to the
+    # torque-denominated ABI (issue #137) happens right here.
+    if "kp_a_per_rad" in kw:
+        kw["kp_nm_per_rad"] = kw.pop("kp_a_per_rad") * KT_NM_PER_A
+    if "kd_a_per_rad_s" in kw:
+        kw["kd_nm_per_rad_s"] = kw.pop("kd_a_per_rad_s") * KT_NM_PER_A
+    base = dict(kp_nm_per_rad=200.0 * KT_NM_PER_A, kd_nm_per_rad_s=30.0 * KT_NM_PER_A,
+                kt_nm_per_a=KT_NM_PER_A, max_current_a=40.0, com_above_axle=True)
     base.update(kw)
     return RustController(**base)
 

--- a/scripts/analyse_estimator.py
+++ b/scripts/analyse_estimator.py
@@ -72,7 +72,8 @@ def collect(kind: str) -> dict:
     # offline pass meaningless, because the trajectory would already have been
     # flown on the estimate.
     with RustController(
-        kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
+        # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated (#137).
+        kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0, max_current_a=40.0,
         kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02, com_above_axle=True,
         v_ref_fn=vref_fn,
         use_estimator=False,

--- a/scripts/analyse_estimator_phase.py
+++ b/scripts/analyse_estimator_phase.py
@@ -64,10 +64,12 @@ from sim.scenarios.shuttle_run import ShuttleParams, VelocityProfile  # noqa: E4
 INK, AMBER, MINT, MUTED, RED = "#16232E", "#F2A24A", "#2AAE97", "#96A8B0", "#C2513B"
 
 #: Where the inner loop crosses over, rad/s. From the gain derivation in
-#: `rust_controller.DEFAULT_KP_A_PER_RAD`'s docstring, at the ridden inertia.
+#: `rust_controller.DEFAULT_KP_NM_PER_RAD`'s docstring, at the ridden inertia.
 OMEGA_C = 12.0
 
-GAINS = dict(kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
+# 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated in torque (#137).
+GAINS = dict(kp_nm_per_rad=200.0 * KT_NM_PER_A, kd_nm_per_rad_s=30.0 * KT_NM_PER_A,
+             max_current_a=40.0,
              kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02, com_above_axle=True)
 
 #: Beyond this the nose is on the ground. Taken from the MODEL rather than

--- a/scripts/demonstrate_kt_headroom.py
+++ b/scripts/demonstrate_kt_headroom.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Issue #137 AC4 -- demonstrate that a wrong `kt` moves headroom, not loop gain.
+
+Before this issue, gains were amps-denominated and `kt` never crossed the
+control law at all: a `kt` error was a **gain** error, changing loop gain
+`kp*kt/J` in a way the controller could not see or bound. After it, gains are
+torque-denominated and `kt` enters exactly once, at the actuation boundary,
+converting a torque command to the amps the drive accepts.
+
+**Deliberately NOT run against the MuJoCo plant.** The plant has its own
+fixed, real `kt` (`sim/scenarios/plant.py::KT_NM_PER_A`, out of scope for this
+issue -- it stays 0.7). Sweeping the CONTROLLER's assumed `kt` against a plant
+whose real `kt` does not move demonstrates a *model-mismatch* effect (a real
+and separate concern), not the property this issue's law change buys. To
+isolate that property cleanly, this script drives `control_core::PitchRegulator`
++ `safety::Envelope` directly, over the C ABI, exactly as `control-ffi`'s own
+tests do -- fixed pitch/rate in, command out, no plant in the loop. See
+`crates/control-ffi/src/lib.rs`'s `loop_gain_the_torque_actually_commanded_is_
+unchanged_by_kt` and `headroom_moves_with_kt_at_a_fixed_current_limit` for the
+Rust-side version of the same demonstration.
+
+    python scripts/demonstrate_kt_headroom.py
+
+Requires the release library: `cargo build --release -p control-ffi`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from sim.scenarios.rust_controller import DEFAULT_KD_NM_PER_RAD_S, DEFAULT_KP_NM_PER_RAD, RustController
+
+MAX_CURRENT_A = 40.0
+
+
+def command(kt_nm_per_a: float, pitch_rad: float):
+    """One `ob_controller_update` call, no plant: pitch/rate in, amps out.
+
+    `use_estimator=False` -- the regulator acts on the passed-in truth pitch
+    directly, matching `crates/control-ffi`'s own `params()` test helper.
+    Leaving the estimator on would fuse a zeroed synthetic IMU sample (no
+    real plant behind it here) instead of the pitch this script actually
+    wants to probe.
+    """
+    with RustController(
+        kp_nm_per_rad=DEFAULT_KP_NM_PER_RAD,
+        kd_nm_per_rad_s=DEFAULT_KD_NM_PER_RAD_S,
+        kt_nm_per_a=kt_nm_per_a,
+        max_current_a=MAX_CURRENT_A,
+        use_estimator=False,
+    ) as c:
+        amps = c(t_s=0.0, pitch_rad=pitch_rad, pitch_rate_rad_s=0.0, wheel_rate_rad_s=0.0)
+        saturated = c.saturated_cycles == 1
+    return amps, saturated
+
+
+def main() -> int:
+    print(f"kp_nm_per_rad={DEFAULT_KP_NM_PER_RAD}, kd_nm_per_rad_s={DEFAULT_KD_NM_PER_RAD_S} "
+          "(fixed -- identical between every run below)")
+    print()
+
+    # --- 1. Loop gain: small error, nowhere near saturation at either kt ----
+    pitch = -0.05
+    amps_lo, sat_lo = command(0.5, pitch)
+    amps_hi, sat_hi = command(0.9, pitch)
+    torque_lo, torque_hi = amps_lo * 0.5, amps_hi * 0.9
+    print(f"pitch = {pitch} rad (small error, unsaturated either way)")
+    print(f"{'':28}{'kt=0.5':>12}{'kt=0.9':>12}")
+    print(f"{'amps commanded':28}{amps_lo:>12.4f}{amps_hi:>12.4f}   <- headroom cost DIFFERS")
+    print(f"{'torque realised (amps*kt)':28}{torque_lo:>12.4f}{torque_hi:>12.4f}   <- LOOP GAIN, unchanged")
+    print(f"  loop gain difference: {abs(torque_lo - torque_hi):.2e} N*m "
+          "(zero up to float32 rounding)")
+    print()
+
+    # --- 2. Headroom: an error large enough to expose the ceiling moving ---
+    pitch = -0.5   # -> 28 N*m intended, exactly between the two ceilings below
+    tau_max_lo, tau_max_hi = 0.5 * MAX_CURRENT_A, 0.9 * MAX_CURRENT_A
+    amps_lo, sat_lo = command(0.5, pitch)
+    amps_hi, sat_hi = command(0.9, pitch)
+    print(f"pitch = {pitch} rad -> {DEFAULT_KP_NM_PER_RAD * abs(pitch):.1f} N*m intended")
+    print(f"{'':28}{'kt=0.5':>12}{'kt=0.9':>12}")
+    print(f"{'tau_max = kt * I_max':28}{tau_max_lo:>12.1f}{tau_max_hi:>12.1f}   N*m  <- HEADROOM, moves")
+    print(f"{'amps commanded':28}{amps_lo:>12.4f}{amps_hi:>12.4f}   A")
+    print(f"{'saturated':28}{str(sat_lo):>12}{str(sat_hi):>12}")
+    print()
+    print("At kt=0.5 the SAME 28 N*m command exceeds a 20 N*m ceiling and saturates; "
+          "at kt=0.9 it is within a 36 N*m ceiling and does not. The torque the law "
+          "asked for never changed -- only how much of it the drive's 40 A can deliver.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -74,7 +74,12 @@ def one_run(model, kp, kd, clamp_a, impulse, seconds,
     """
     if com_above_axle is None:
         com_above_axle = plant_summary(model)["inverted_pendulum"]
-    with RustController(kp_a_per_rad=kp, kd_a_per_rad_s=kd, max_current_a=clamp_a,
+    # This script's own CLI/function surface stays amps/rad for backward
+    # compatibility (`--kp 80 --kd 11` keeps meaning what it always meant);
+    # the conversion to the torque-denominated ABI (issue #137) happens right
+    # here, the one place `KT_NM_PER_A` enters this function.
+    with RustController(kp_nm_per_rad=kp * KT_NM_PER_A, kd_nm_per_rad_s=kd * KT_NM_PER_A,
+                        kt_nm_per_a=KT_NM_PER_A, max_current_a=clamp_a,
                         kp_v_rad_per_m_s=kp_v, ki_v_rad_per_m=ki_v, v_ref_m_s=v_ref,
                         com_above_axle=com_above_axle) as ctl:
         r = run(ImpulseParams(magnitude_ns=impulse, sim_seconds=seconds),

--- a/sim/scenarios/hill.py
+++ b/sim/scenarios/hill.py
@@ -313,8 +313,9 @@ def run(
         def controller_factory():
             return RustController(
                 v_ref_fn=v_ref_at,
-                kp_a_per_rad=200.0,
-                kd_a_per_rad_s=30.0,
+                # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated (#137).
+                kp_nm_per_rad=140.0,
+                kd_nm_per_rad_s=21.0,
                 max_current_a=params.max_current_a,
                 kp_v_rad_per_m_s=0.05,
                 ki_v_rad_per_m=0.02,

--- a/sim/scenarios/rust_controller.py
+++ b/sim/scenarios/rust_controller.py
@@ -25,16 +25,31 @@ import subprocess
 import sys
 from pathlib import Path
 
+from .plant import KT_NM_PER_A
+
 REPO = Path(__file__).resolve().parents[2]
 
-#: Default gains, AMPS PER RADIAN of nose-up-positive pitch (ICD 10.1).
+#: Default gains, N*m PER RADIAN of nose-up-positive pitch (ICD 10.1).
 #:
-#: Chosen analytically, not tuned: with effective pitch inertia ~0.403 kg*m^2,
-#: restoring stiffness m*g*l = 2.354 N*m/rad and kt = 0.7 N*m/A, these place the
-#: closed-loop pole pair at omega ~= 12 rad/s with zeta ~= 0.8 -- about 5x the
-#: plant's own 2.42 rad/s. They are a starting point for a sweep, not a result.
-DEFAULT_KP_A_PER_RAD = 80.0
-DEFAULT_KD_A_PER_RAD_S = 11.0
+#: Issue #137: re-denominated from amps to torque. `kt` no longer appears in
+#: these numbers at all -- they are 80 A/rad and 11 A/(rad/s) (this module's
+#: pre-#137 defaults) multiplied through by the SAME `KT_NM_PER_A` the plant
+#: uses, so a run at `DEFAULT_KT_NM_PER_A` reproduces the pre-#137 amps
+#: exactly. Chosen analytically, not tuned: with effective pitch inertia
+#: ~0.403 kg*m^2, restoring stiffness m*g*l = 2.354 N*m/rad and kt = 0.7
+#: N*m/A, these place the closed-loop pole pair at omega ~= 12 rad/s with
+#: zeta ~= 0.8 -- about 5x the plant's own 2.42 rad/s. They are a starting
+#: point for a sweep, not a result.
+DEFAULT_KP_NM_PER_RAD = 56.0
+DEFAULT_KD_NM_PER_RAD_S = 7.7
+
+#: Motor torque constant, N*m per amp -- the controller's OWN belief about
+#: kt, used only to convert its torque law into the amps the drive accepts
+#: (issue #137). Mirrors `plant.KT_NM_PER_A` so that, by default, the
+#: controller's assumption matches the plant it is actually driving; passing
+#: a different value here is exactly how a `kt` error is modelled as a
+#: headroom error instead of a gain error.
+DEFAULT_KT_NM_PER_A = KT_NM_PER_A
 
 #: Envelope clamp, amps. Matches the model's derived ctrlrange (40 A * kt).
 DEFAULT_MAX_CURRENT_A = 40.0
@@ -64,10 +79,13 @@ _ERR = {
 
 
 class ObParams(ctypes.Structure):
+    # Field order and types MUST match `control_ffi::ObParamsV1` exactly --
+    # this is a raw C ABI struct, not a name-matched binding.
     _fields_ = [
         ("size", ctypes.c_uint32),
-        ("kp_a_per_rad", ctypes.c_float),
-        ("kd_a_per_rad_s", ctypes.c_float),
+        ("kp_nm_per_rad", ctypes.c_float),
+        ("kd_nm_per_rad_s", ctypes.c_float),
+        ("kt_nm_per_a", ctypes.c_float),
         ("max_current_a", ctypes.c_float),
         ("kp_v_rad_per_m_s", ctypes.c_float),
         ("ki_v_rad_per_m", ctypes.c_float),
@@ -153,8 +171,9 @@ class RustController:
 
     def __init__(
         self,
-        kp_a_per_rad: float = DEFAULT_KP_A_PER_RAD,
-        kd_a_per_rad_s: float = DEFAULT_KD_A_PER_RAD_S,
+        kp_nm_per_rad: float = DEFAULT_KP_NM_PER_RAD,
+        kd_nm_per_rad_s: float = DEFAULT_KD_NM_PER_RAD_S,
+        kt_nm_per_a: float = DEFAULT_KT_NM_PER_A,
         max_current_a: float = DEFAULT_MAX_CURRENT_A,
         kp_v_rad_per_m_s: float = 0.0,
         ki_v_rad_per_m: float = 0.0,
@@ -204,8 +223,9 @@ class RustController:
 
         params = ObParams(
             size=ctypes.sizeof(ObParams),
-            kp_a_per_rad=kp_a_per_rad,
-            kd_a_per_rad_s=kd_a_per_rad_s,
+            kp_nm_per_rad=kp_nm_per_rad,
+            kd_nm_per_rad_s=kd_nm_per_rad_s,
+            kt_nm_per_a=kt_nm_per_a,
             max_current_a=max_current_a,
             kp_v_rad_per_m_s=kp_v_rad_per_m_s,
             ki_v_rad_per_m=ki_v_rad_per_m,

--- a/sim/scenarios/rust_controller.py
+++ b/sim/scenarios/rust_controller.py
@@ -78,9 +78,13 @@ _ERR = {
 }
 
 
-class ObParams(ctypes.Structure):
-    # Field order and types MUST match `control_ffi::ObParamsV1` exactly --
-    # this is a raw C ABI struct, not a name-matched binding.
+class ObParamsV2(ctypes.Structure):
+    # Field order and types MUST match `control_ffi::ObParamsV2` exactly --
+    # this is a raw C ABI struct, not a name-matched binding. Named V2, not
+    # ObParams, because it IS versioned: issue #137 renamed two fields and
+    # bumped `ob_abi_version()` from 1 to 2 for exactly that reason -- an
+    # unversioned name is how the NEXT field rename gets made against a
+    # struct that looks unversioned and isn't.
     _fields_ = [
         ("size", ctypes.c_uint32),
         ("kp_nm_per_rad", ctypes.c_float),
@@ -206,7 +210,7 @@ class RustController:
         self.lib_path = path
 
         lib.ob_abi_version.restype = ctypes.c_uint32
-        lib.ob_controller_new.argtypes = [ctypes.POINTER(ObParams)]
+        lib.ob_controller_new.argtypes = [ctypes.POINTER(ObParamsV2)]
         lib.ob_controller_new.restype = ctypes.c_void_p
         lib.ob_controller_arm.argtypes = [ctypes.c_void_p]
         lib.ob_controller_arm.restype = ctypes.c_int32
@@ -221,8 +225,8 @@ class RustController:
 
         self.abi_version = int(lib.ob_abi_version())
 
-        params = ObParams(
-            size=ctypes.sizeof(ObParams),
+        params = ObParamsV2(
+            size=ctypes.sizeof(ObParamsV2),
             kp_nm_per_rad=kp_nm_per_rad,
             kd_nm_per_rad_s=kd_nm_per_rad_s,
             kt_nm_per_a=kt_nm_per_a,

--- a/sim/scenarios/shuttle_run.py
+++ b/sim/scenarios/shuttle_run.py
@@ -303,8 +303,9 @@ def run(
             # instance -- passes its own factory and says so, which makes the
             # unusual case the explicit one instead of the default.
             return RustController(
-                kp_a_per_rad=200.0,
-                kd_a_per_rad_s=30.0,
+                # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated (#137).
+                kp_nm_per_rad=140.0,
+                kd_nm_per_rad_s=21.0,
                 max_current_a=params.max_current_a,
                 kp_v_rad_per_m_s=0.05,
                 ki_v_rad_per_m=0.02,

--- a/sim/scenarios/terrain.py
+++ b/sim/scenarios/terrain.py
@@ -382,7 +382,8 @@ def run(
 
         def controller_factory():
             return RustController(
-                kp_a_per_rad=200.0, kd_a_per_rad_s=30.0,
+                # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated (#137).
+                kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0,
                 max_current_a=params.max_current_a,
                 kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02,
                 com_above_axle=True, v_ref_fn=v_ref_at,

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -74,7 +74,9 @@ def test_the_control_library_is_actually_built():
 
 
 def test_abi_version_is_the_one_this_glue_was_written_against(controller):
-    assert controller.abi_version == 1
+    # Bumped 1 -> 2 by issue #137: ObParamsV1 renamed two fields and gained
+    # kt_nm_per_a, which the `size` guard alone cannot certify as compatible.
+    assert controller.abi_version == 2
 
 
 @pytest.mark.claim(

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -165,7 +165,9 @@ def test_closed_loop_runs_are_deterministic(model):
 # --------------------------------------------------------------------------
 
 BALLAST_KG, BALLAST_M = 70.0, 0.75
-INNER = dict(kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0)
+# 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A -- the same gains this file
+# gated on before issue #137, re-denominated (200*0.7, 30*0.7).
+INNER = dict(kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0, max_current_a=40.0)
 OUTER = dict(kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02, com_above_axle=True)
 
 
@@ -267,7 +269,7 @@ def test_the_outer_loop_does_not_suit_the_driverless_plant(model):
     """
     import math
 
-    r, c = _run(model, kp_a_per_rad=80.0, kd_a_per_rad_s=11.0, max_current_a=40.0,
+    r, c = _run(model, kp_nm_per_rad=56.0, kd_nm_per_rad_s=7.7, max_current_a=40.0,
                 kp_v_rad_per_m_s=0.20, ki_v_rad_per_m=0.10, com_above_axle=False)
     assert math.degrees(c.peak_abs_pitch_ref_rad) > 4.9, (
         "expected the reference pegged at its clamp; if this now passes "

--- a/tests/test_delay_budget_stage0b.py
+++ b/tests/test_delay_budget_stage0b.py
@@ -37,7 +37,8 @@ from sim.scenarios.impulse_response import NOMINAL_IMPULSE_NS, ImpulseParams, ru
 from sim.scenarios.plant import build_model, plant_summary
 from sim.scenarios.rust_controller import RustController
 
-CASCADE = dict(kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
+# 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated in torque (#137).
+CASCADE = dict(kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0, max_current_a=40.0,
                com_above_axle=True, kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02)
 
 

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -54,7 +54,8 @@ OFF, ACTIVE, SHADOW = 0, 1, 2
 
 def _run(model, use_estimator, tau=TAU, secs=8.0, impulse=NOMINAL_IMPULSE_NS):
     with RustController(
-        kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
+        # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated (#137).
+        kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0, max_current_a=40.0,
         kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02, com_above_axle=True,
         use_estimator=use_estimator, estimator_tau_s=tau,
     ) as c:
@@ -222,7 +223,8 @@ def test_estimator_runs_are_deterministic(ridden):
 # ---------------------------------------------------------------------------
 
 SHUTTLE_GAINS = dict(
-    kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
+    # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated (#137).
+    kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0, max_current_a=40.0,
     kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02, com_above_axle=True,
 )
 

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -499,7 +499,7 @@ def test_the_default_current_source_survives_a_backend_that_reports_nothing():
     )
     assert r.metrics.nose_strike, (
         "trusting an unpopulated motor_current_a should fail LOUDLY. If this "
-        "now survives, the default in ObParamsV1 can safely become MEASURED"
+        "now survives, the default in ObParamsV2 can safely become MEASURED"
     )
 
 

--- a/tests/test_imperfections.py
+++ b/tests/test_imperfections.py
@@ -164,7 +164,9 @@ def _impulse(model, profile, delay_s=None):
         wheel_rate_quantum_rad_s=profile.wheel_rate_quantum_rad_s,
         wheel_rate_update_hz=profile.wheel_rate_update_hz,
     )
-    with RustController(kp_a_per_rad=200.0, kd_a_per_rad_s=30.0, max_current_a=40.0,
+    with RustController(
+                        # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A (#137).
+                        kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0, max_current_a=40.0,
                         kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02,
                         com_above_axle=True) as c:
         return run(ImpulseParams(magnitude_ns=NOMINAL_IMPULSE_NS, sim_seconds=8.0),


### PR DESCRIPTION
Closes #137. Gating item for #132 (this is deliberately not a retune).

## What changed

**The control law was denominated in amps while the plant's stability depends on `kt`, which never appeared anywhere the law was defined.** A `kt` error was therefore a *gain* error -- unbounded, invisible, and (per #132's oracle finding) capable of landing directly on the stability boundary.

- `control_core::PitchRegulator` now takes and returns **N·m** (`kp_nm_per_rad`, `kd_nm_per_rad_s`). `kt` appears nowhere in the law.
- **`kt` appears exactly once**, at the actuation boundary: `control-ffi::ob_controller_update` and `board-app-driverless`'s `impulse-response-rust` binary each do a single `amps = torque_nm / kt_nm_per_a` right before constructing `Command::MotorCurrent`, immediately ahead of the unchanged, amp-space `safety::Envelope` clamp.
- The 40 A clamp is unchanged in code (still an amp-space `Envelope` clamp -- the real, physical drive limit) but is now equivalent to **`tau_max = kt * I_max`**, expressed as `board_types::Params::tau_max_nm()`. Saturation still reports through the existing `Saturation` path, unchanged, so anti-windup sees it exactly as before.
- `board_types::Params` and `control-ffi`'s `ObParamsV1` **C ABI** both rename `kp_a_per_rad`/`kd_a_per_rad_s` → `kp_nm_per_rad`/`kd_nm_per_rad_s` and add `kt_nm_per_a`. **This is a breaking C ABI change** -- `sim/scenarios/rust_controller.py`'s `ObParams` ctypes mirror (and every Python caller that constructs a `RustController`) is updated in the same pass to match.

## Numerically identical at kt = 0.7 -- verified against a real baseline, not assumed

Built a `libcontrol_ffi.dylib` from `origin/master` (pre-#137) and compared it directly against this branch's library over the same scenarios (ridden cascade nominal impulse, driverless nominal impulse), same gains re-expressed (`kp_a_per_rad * 0.7 = kp_nm_per_rad`):

| | OLD (pre-#137) | NEW (this PR) | diff |
|---|---|---|---|
| ridden cascade peak pitch | 7.630383730141028° | 7.6303844389036115° | 4e-5 % |
| ridden cascade travel | 0.10824025667472949 m | 0.10822815689742385 m | 0.01 % |
| driverless peak pitch | 0.8784099671976145° | 0.8784099544531487° | 1.4e-6 % |

Not bit-exact -- the extra `kt` multiply-then-divide at f32 precision is a real, unavoidable rounding cost, and it compounds slightly over a 12 s closed-loop run through an outer integrator. But it is 4-6 orders of magnitude below every pinned threshold in this repo's gates (all stated to 2-3 significant figures with real margin), and it is not a behavioural change -- it is IEEE-754 noise from a mathematically-identical re-expression. Full `cargo test --workspace` and `pytest tests/` (273 passed, 2 pre-existing xfailed) pass unchanged; every gain-carrying call site across `tests/`, `scripts/`, and `sim/scenarios/` was re-derived (`amps * 0.7 = N·m`), not retuned.

## AC4 -- kt moves headroom, not loop gain, demonstrated

`crates/control-ffi`'s new tests (`loop_gain_the_torque_actually_commanded_is_unchanged_by_kt`, `headroom_moves_with_kt_at_a_fixed_current_limit`) and `scripts/demonstrate_kt_headroom.py` (run it: `python scripts/demonstrate_kt_headroom.py`) isolate the law from the plant (fixed pitch/rate in, no MuJoCo) and show, at fixed `kp_nm_per_rad`/`kd_nm_per_rad_s`:

```
pitch = -0.05 rad (small error, unsaturated either way)
                                  kt=0.5      kt=0.9
amps commanded                    5.6000      3.1111   <- headroom cost DIFFERS
torque realised (amps*kt)         2.8000      2.8000   <- LOOP GAIN, unchanged

pitch = -0.5 rad -> 28.0 N*m intended
                                  kt=0.5      kt=0.9
tau_max = kt * I_max                20.0        36.0   N*m  <- HEADROOM, moves
saturated                           True       False
```

(Deliberately *not* run against the real MuJoCo plant for this demonstration -- the plant has its own fixed, real `kt` = 0.7, untouched per #137's scope, so sweeping only the controller's belief against a fixed real plant would show a *model-mismatch* effect, a different and real concern, not the law's kt-independence this AC asks for.)

## Explicitly not done here (per #137's scope)

- No gain change or retune -- that's #132.
- `sim/scenarios/plant.py::KT_NM_PER_A` untouched, still 0.7, still the unfitted placeholder.
- No re-plot of the delay budget or disturbance studies on a `tau_max` axis -- flagged in #137 as a follow-up that needs this landed first.

## Turf note

`tests/test_imperfections.py` is Sr. Mechanical & Systems' file (CODEOWNERS). It needed a one-line, value-preserving rename (`kp_a_per_rad=200.0, kd_a_per_rad_s=30.0` → `kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0`, i.e. `* kt`) because this PR renames the `RustController` constructor kwargs everywhere -- leaving it unedited would break that role's test file. `TURF-OVERRIDE`'d in a separate commit with the reason stated there; `policy_check.py` passes with all hard checks green.

## Verification run this session

- `cargo test --workspace` -- clean (108 Rust tests, all crates)
- `cargo build --workspace --release` -- clean
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- `cargo fmt --all -- --check` -- clean
- `cargo run -p xtask -- gate` -- clean
- `pytest tests/` -- 273 passed, 2 xfailed (pre-existing, unrelated)
- `GITHUB_ACTIONS=1 POLICY_BRANCH=... POLICY_BASE_REF=origin/master python3 .github/policy_check.py` -- all hard checks pass (turf override applied and logged, as above)