### PR TITLE
fix(ops): my session-prep doc was blocking Mechanical within an hour of landing

### DIFF
--- a/docs/sim-fidelity-session-prep.md
+++ b/docs/sim-fidelity-session-prep.md
@@ -1,9 +1,17 @@
 # Sim fidelity — prep for the working session (#33)
 
 <!--
-covers:
-  - sim/scenarios/plant.py
-  - sim/scenarios/imperfections.py
+NO `covers:` MANIFEST, deliberately. ADR-0008 has two tiers: implementation-tier
+docs carry a manifest so doc-drift can force them to move when the code they
+describe moves. This is NOT one of those -- it is a dated snapshot prepared for
+one session, and it cites code the way a meeting agenda cites a report.
+
+It briefly had a manifest over plant.py and imperfections.py, and within the
+hour that blocked Sr. Mechanical & Systems' PR #128: their change to
+imperfections.py dragged this prep doc along and red-built work that had
+nothing to do with it. A manifest on a snapshot taxes everyone who touches the
+covered files, forever, to keep a document current that is meant to go stale
+the day after the session.
 -->
 
 **Requirement: `SR-SIM-3`** (no ideal-only mode in CI) and **`SR-SIM-5`** (one control loop, two


### PR DESCRIPTION
`docs/sim-fidelity-session-prep.md` (#143, merged an hour ago) declared a `covers:` manifest over `plant.py` and `imperfections.py`. **Sr. Mechanical & Systems' PR #128 changes `imperfections.py`**, so doc-drift dragged my prep doc into their PR and red-built work that had nothing to do with it.

**That is the second time today I have blocked Mechanical with my own tooling** — the first was the role-log size heuristic (#131) — and both times they were doing exactly what the conventions ask.

## The miscategorisation

ADR-0008 has two tiers. **Implementation-tier** docs carry a manifest so `doc-drift` forces them to move when the code they describe moves.

**A session prep doc is not one of those.** It is a dated snapshot that cites code the way a meeting agenda cites a report, and it is *meant* to go stale the day after the session.

A manifest on a snapshot taxes everyone who touches the covered files, **forever**, to keep current a document nobody intends to keep current.

Removed — with the reasoning written where the manifest used to be, so the next person doesn't re-add it.

**Unblocks #128 without Mechanical changing anything.**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>