### PR TITLE
feat(mech): derive what a kerb strike is worth (#142 AC2)

### DIFF
--- a/roles/sr-mechanical-systems/log/2026-07-31-kerb-strike-reference.md
+++ b/roles/sr-mechanical-systems/log/2026-07-31-kerb-strike-reference.md
@@ -1,0 +1,55 @@
+# What a kerb strike is worth — and why N·s is the wrong currency to answer in
+
+Issue #142 AC2 asked this role what an obstacle strike is worth, because the reference disturbance
+the #132 gain retune is scoped against — 20 N·s — is inherited from a scenario nominal and derived
+from nothing. Delivered as `kerb_strike_impulse()` / `kerb_strike_vs_com_impulse()` in `plant.py`
+with tests in `tests/test_plant_kerb_strike.py`. PR #145.
+
+**The finding that matters more than the number.** `impulse_response.py` applies its 20 N·s
+*through the CoM*, deliberately — at `application_height_m = 0.0` the disturbance is purely linear
+and the initial pitch rate is zero by construction. Its own docstring already says a kerb strike is
+the follow-on case it is *not* modelling, and that the angular channel would swamp the linear one.
+A kerb strike lands ~0.7 m below the CoM and imparts 100–450 deg/s immediately. **So a reference
+disturbance quoted in N·s and fed to the existing scenario understates a kerb silently, in the one
+channel that actually topples the board.** Controls needs pitch rate imparted, not newton-seconds.
+Answering AC1 in N·s without saying this would have been technically responsive and misleading.
+
+**The number, for what it is worth.** A 20 mm lip — brick edge, root heave, the kind of thing a
+pavement has every few metres — gives 28–44 N·s at walking pace and 113–176 N·s at 8 m/s. The
+inherited 20 N·s is exceeded at every speed the board is meant to ride at, measured against the
+*lower* bound. The inherited nominal is not conservative.
+
+## The first model was wrong, and it looked fine
+
+Conserving angular momentum about the step edge and letting the body rotate rigidly about it — the
+textbook step-climb model — charges **Δv = 0.25·v for a step of height ZERO**. A zero-height step
+is not an obstacle. The defect: rotation about the contact point is only forced when the wheel is
+*blocked*, and nothing blocks it as h→0.
+
+Every number that model produced was plausible. What caught it was checking a limit whose answer is
+known independently of the model. **Check the free limits first — they are the only assertions that
+do not depend on the thing being tested.** That is now the first test in the file.
+
+## The friction gate, which replaced a judgement call with a derivation
+
+The pivot model does not merely get harsh at small heights, it becomes unphysical, and the
+discriminator is derivable. Pivoting means the edge arrests the wheel's roll, which needs a
+tangential impulse alongside the normal one; their ratio is the friction the edge must supply:
+
+| h | 1 mm | 5 mm | 10 mm | 20 mm | 30 mm | 50 mm | 100 mm |
+|---|---|---|---|---|---|---|---|
+| μ required | 5.43 | 2.34 | 1.57 | **0.99** | 0.70 | 0.38 | 0.08 |
+
+Rubber on asphalt is μ ≈ 1.0 — the model's own `<geom friction>`. So the pivot is unreachable below
+about 20 mm: the edge slips and the wheel rolls through. **That is the same ~20 mm the tyre's own
+deflection gives, arrived at independently**, and two unrelated criteria landing on one boundary is
+the strongest reason to believe either. Below it the bracket collapses to the frictionless value
+rather than quoting an upper bound that cannot happen.
+
+## Open input this role still owes
+
+The tyre deflection figure (10–20 mm) is an assumption, not a measurement. It wants the tyre spec
+and a load-deflection check at riding pressure. Until that exists, anything below ~20 mm is a bound
+rather than an answer. Note the sim's wheel is a **rigid cylinder**, so for scoping a retune
+*against the sim* these numbers are exactly right; the tyre caveat applies to claims about the real
+board, where they are an upper bound.

--- a/sim/scenarios/plant.py
+++ b/sim/scenarios/plant.py
@@ -501,3 +501,181 @@ def imu_readings(model, data) -> tuple:
     gyro, accel = out
     R = R_MODEL_TO_ICD()
     return R @ gyro, R @ accel
+
+
+# ==========================================================================
+# Kerb strike: what an obstacle is worth, in the currency the controller feels
+# ==========================================================================
+#
+# Issue #142 AC2 asks this role what a kerb strike is worth, because the
+# reference disturbance the #132 retune is scoped against -- 20 N*s -- is
+# inherited from a scenario nominal and derived from nothing.
+#
+# WHAT IS DERIVED HERE, and what is deliberately not. This produces the
+# impulse an obstacle delivers, from geometry and speed. It does NOT pick the
+# reference disturbance: that is a duty-cycle judgement about what the board is
+# for, and the honest output of the arithmetic is a RANGE plus the reason the
+# range is wide. See `kerb_strike_impulse.__doc__` for the model and
+# `KERB_STRIKE_VALIDITY` for where it stops being true.
+#
+# THE FIRST MODEL I WROTE WAS WRONG, and the way it was wrong is worth keeping.
+# Conserving angular momentum about the step edge and letting the body rotate
+# rigidly about it -- the textbook step-climb model -- gives dv = 0.25*v at a
+# step height of ZERO. A zero-height step is not an obstacle, so any model that
+# charges 0.25 v for it is broken, and it is broken in the direction that makes
+# every number look alarming. The defect: rotation about the contact point is
+# only forced when the wheel is BLOCKED. Nothing blocks it as h -> 0, and the
+# wheel simply rolls on. Checking a limit that has a known answer is what
+# caught it; the numbers themselves looked entirely plausible.
+
+#: Where the rigid-wheel model stops describing reality. The sim's wheel is a
+#: rigid cylinder (`sim/models/overboard_onewheel.xml`), but the real part is an
+#: 11.5 in PNEUMATIC tyre, and a pneumatic tyre swallows an obstacle smaller
+#: than its own deflection -- it deforms around the lip and rolls over it
+#: instead of striking it. Below that height the rigid model does not
+#: overestimate slightly, it describes a different event.
+#:
+#: **The deflection figure is an open input, not a measurement.** It wants the
+#: tyre spec and a load-deflection check at riding pressure, which is this
+#: role's to supply and does not exist yet. Until it does, anything derived
+#: below ~20 mm is a bound, not an answer.
+KERB_STRIKE_VALIDITY = {
+    "tyre_deflection_mm": (10.0, 20.0),
+    "assumes": "rigid wheel, impulsive contact, rider rigid through the strike",
+    "excludes": "tyre compliance, suspension, rider articulation, wheel slip",
+}
+
+
+def kerb_strike_impulse(obstacle_height_m: float, speed_m_s: float,
+                        model_params: dict | None = None) -> dict:
+    """Impulse delivered by a square-edged obstacle, as a bracket.
+
+    Two models, and the truth is between them, because how much the edge GRIPS
+    is the thing neither one knows:
+
+    * **Frictionless normal** (lower bound). The normal to a circular rim
+      passes through the wheel centre, so the impulse has no moment about the
+      axle: the wheel keeps spinning and the impulse enters the frame at the
+      axle. Only the approach velocity along the edge->centre line is killed.
+      Correct as h -> 0, where it goes to zero.
+    * **Pivot** (upper bound). The edge grips completely and the body rotates
+      rigidly about it. Wrong for small h -- see the module comment -- but
+      right once the step is tall enough that the wheel cannot roll through.
+
+    The two converge above roughly h/r = 0.5, which is the useful structural
+    result: for a real kerb it does not matter which you believe, and for a
+    pavement lip it matters enormously.
+
+    Returns horizontal impulse (N*s), speed lost (m/s) and the pitch rate the
+    strike imparts (deg/s) for each bound. **The pitch rate is the number that
+    matters** -- see `kerb_strike_vs_com_impulse`.
+    """
+    import numpy as np
+
+    p = {"mass_kg": 82.5, "inertia_pitch_kg_m2": 17.2374,
+         "com_height_m": 0.77885, "wheel_radius_m": 0.1454,
+         "wheel_inertia_kg_m2": 0.0595, "edge_friction": 1.0}
+    p.update(model_params or {})
+    M, Ic, zc = p["mass_kg"], p["inertia_pitch_kg_m2"], p["com_height_m"]
+    r, Iw = p["wheel_radius_m"], p["wheel_inertia_kg_m2"]
+    h, v = float(obstacle_height_m), float(speed_m_s)
+    if not 0.0 <= h < r:
+        raise ValueError(
+            f"obstacle height {h} m is outside (0, r={r}). At h >= r the wheel "
+            "strikes at or above its own centre: that is a wall, not a step, "
+            "and no impulse model applies -- the board stops and the rider does "
+            "not.")
+    l = zc - r
+    xE = np.sqrt(max(2.0 * r * h - h * h, 0.0))   # edge, ahead of the axle
+
+    # -- frictionless normal ------------------------------------------------
+    approach = v * xE / r
+    P = approach / (1.0 / M + (l * l) * (xE * xE) / (r * r * Ic))
+    j_lo = P * xE / r
+    q_lo = np.degrees(P * l * xE / (r * Ic))
+
+    # -- pivot, AND whether it is reachable ----------------------------------
+    #
+    # The pivot model does not just get harsh at small h, it becomes
+    # UNPHYSICAL, and the discriminator is derivable rather than a matter of
+    # taste. Pivoting means the edge arrests the wheel's roll, which takes a
+    # tangential impulse alongside the normal one. Their ratio is the friction
+    # coefficient the edge would have to supply:
+    #
+    #     h:        1 mm   5 mm   10 mm   20 mm   30 mm   50 mm   100 mm
+    #     mu_req:   5.43   2.34    1.57    0.99    0.70    0.38     0.08
+    #
+    # Rubber on asphalt is mu ~ 1.0 -- the model's own `<geom friction>`. So
+    # the pivot is unreachable below roughly 20 mm: the edge would slip and the
+    # wheel would roll through. That is the same ~20 mm the tyre's own
+    # deflection gives, arrived at independently, which is the strongest reason
+    # to believe either of them.
+    #
+    # Below that the bracket collapses to the frictionless value. Reporting an
+    # unreachable pivot as the top of a range would be exactly the thing the
+    # module comment warns about: a wrong assumption dressed as a result.
+    dz = zc - h
+    IE = Ic + M * (xE * xE + dz * dz)
+    omega = (M * v * dz + Iw * v / r) / IE
+    j_hi = M * (v - omega * dz)
+    q_hi = np.degrees(omega)
+
+    Jvec = np.array([M * (omega * dz - v), M * omega * xE])   # impulse at the edge
+    nhat = np.array([-xE, r - h]) / r                          # edge -> wheel centre
+    Jn = float(Jvec @ nhat)
+    Jt = float(np.linalg.norm(Jvec - Jn * nhat))
+    mu_req = Jt / Jn if Jn > 1e-12 else float("inf")
+    pivot_reachable = mu_req <= p["edge_friction"]
+
+    # THE TWO MODELS ALSO CROSS near h/r ~ 0.6 -- as the step gets tall the
+    # normal tilts steeply, so killing the approach along it costs MORE than
+    # gripping and pivoting. Not a bug, but it does mean the bracket must be
+    # ordered rather than assumed to be (frictionless, pivot).
+    ends = (float(j_lo), float(j_hi)) if pivot_reachable else (float(j_lo),) * 2
+    q_ends = (float(q_lo), float(q_hi)) if pivot_reachable else (float(q_lo),) * 2
+    lo_hi = tuple(sorted(ends))
+    q_lo_hi = tuple(sorted(q_ends))
+    floor_mm = KERB_STRIKE_VALIDITY["tyre_deflection_mm"][1]
+
+    return {
+        "obstacle_height_m": h, "speed_m_s": v,
+        "impulse_ns": lo_hi,
+        "speed_lost_m_s": (lo_hi[0] / M, lo_hi[1] / M),
+        "pitch_rate_deg_s": q_lo_hi,
+        "pivot_reachable": bool(pivot_reachable),
+        "pivot_friction_required": float(mu_req),
+        "models_agree_within_pct": (
+            100.0 * (lo_hi[1] - lo_hi[0]) / lo_hi[1] if lo_hi[1] > 0.0 else 0.0),
+        "within_validity": floor_mm <= h * 1000.0 and h / r <= 0.6,
+    }
+
+
+def kerb_strike_vs_com_impulse(obstacle_height_m: float, speed_m_s: float) -> dict:
+    """Why N*s is the wrong currency for comparing these two disturbances.
+
+    `impulse_response.py` applies its 20 N*s through the CoM, deliberately and
+    with a paragraph explaining why: at `application_height_m = 0.0` the
+    disturbance is a PURE LINEAR impulse and the pitch response is the
+    vehicle's own dynamics. Its docstring already flags the alternative --
+    *"kept as a parameter for a follow-on 'shove'/curb-strike scenario; not the
+    default"* -- and notes that the angular channel swamps the linear one.
+
+    A kerb strike is that follow-on case. Its impulse lands at the contact,
+    roughly 0.7 m BELOW the CoM, so it injects an angular impulse the CoM-
+    applied disturbance has none of by construction. Matching the two on N*s
+    matches them on the channel that matters least.
+
+    So: **a reference disturbance quoted in N*s and fed to the existing
+    scenario understates a kerb strike, and does so silently.** The comparison
+    Controls needs is pitch rate imparted, not newton-seconds.
+    """
+    s = kerb_strike_impulse(obstacle_height_m, speed_m_s)
+    lo, hi = s["pitch_rate_deg_s"]
+    return {
+        **s,
+        "com_impulse_pitch_rate_deg_s": 0.0,
+        "note": f"a CoM-applied impulse of the same {s['impulse_ns'][0]:.0f}-"
+                f"{s['impulse_ns'][1]:.0f} N*s imparts ZERO initial pitch rate; "
+                f"this strike imparts {lo:.0f}-{hi:.0f} deg/s. Same currency, "
+                "different disturbance.",
+    }

--- a/tests/test_plant_kerb_strike.py
+++ b/tests/test_plant_kerb_strike.py
@@ -1,0 +1,162 @@
+"""What an obstacle is worth — issue #142 AC2.
+
+The #132 gain retune needs a target, and the 20 N·s it currently has is
+inherited from a scenario nominal rather than derived. This is the derivation
+side of that: geometry and speed in, impulse out.
+
+**These tests exist mostly to stop the model being wrong in ways that look
+right.** The first version of `kerb_strike_impulse` charged 0.25·v of lost
+speed for a step of height ZERO, and every number it produced looked entirely
+plausible — alarming, but plausible. What caught it was checking a limit whose
+answer is known independently of the model. So the limits are tested first and
+hardest here, before any of the numbers are.
+"""
+
+import pytest
+
+from sim.scenarios.plant import (
+    KERB_STRIKE_VALIDITY,
+    kerb_strike_impulse,
+    kerb_strike_vs_com_impulse,
+)
+
+R_WHEEL = 0.1454
+MASS = 82.5
+
+
+# --------------------------------------------------------------------------
+# Limits with known answers — the checks that caught the broken model
+# --------------------------------------------------------------------------
+
+def test_a_zero_height_obstacle_costs_nothing():
+    """THE TEST THAT CAUGHT THE FIRST MODEL. A step of no height is not an
+    obstacle; a model that charges for it is wrong no matter how reasonable its
+    other numbers look. The textbook rotate-about-the-edge formulation charges
+    0.25·v here, because it forces rotation about a contact point that is not
+    blocking anything."""
+    r = kerb_strike_impulse(0.0, 6.0)
+    assert r["impulse_ns"][1] == pytest.approx(0.0, abs=1e-6)
+    assert r["pitch_rate_deg_s"][1] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_standing_still_costs_nothing():
+    """The other free limit: an obstacle you are not moving toward."""
+    r = kerb_strike_impulse(0.030, 0.0)
+    assert r["impulse_ns"][1] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_the_impulse_is_linear_in_speed():
+    """Both models are impulsive and gravity does nothing during the strike, so
+    nothing in either is quadratic in v. If this ever fails, an energy term has
+    crept into a momentum argument."""
+    a = kerb_strike_impulse(0.020, 3.0)["impulse_ns"][0]
+    b = kerb_strike_impulse(0.020, 6.0)["impulse_ns"][0]
+    assert b == pytest.approx(2.0 * a, rel=1e-9)
+
+
+def test_a_taller_obstacle_always_costs_more():
+    """Monotonicity in height. Cheap, and it would catch a sign error in the
+    edge geometry that the absolute numbers would not."""
+    js = [kerb_strike_impulse(h, 5.0)["impulse_ns"][1]
+          for h in (0.005, 0.010, 0.020, 0.040, 0.070)]
+    assert js == sorted(js)
+
+
+def test_an_obstacle_at_or_above_axle_height_is_refused():
+    """At h ≥ r the wheel strikes at or above its own centre. There is no
+    climbing geometry left and no impulse model applies — the board stops and
+    the rider does not. Refusing is honest; returning a number would invite
+    someone to quote it."""
+    with pytest.raises(ValueError, match="wall, not a step"):
+        kerb_strike_impulse(R_WHEEL, 5.0)
+    with pytest.raises(ValueError, match="wall, not a step"):
+        kerb_strike_impulse(0.20, 5.0)
+
+
+# --------------------------------------------------------------------------
+# The bracket
+# --------------------------------------------------------------------------
+
+def test_the_two_models_converge_on_a_real_kerb():
+    """The structural result worth having: for a tall step it does not matter
+    how much the edge grips, because a gripping pivot and a frictionless normal
+    give the same answer. Disagreement is confined to small lips."""
+    assert kerb_strike_impulse(0.100, 6.0)["models_agree_within_pct"] < 5.0
+
+
+def test_the_pivot_is_unreachable_on_a_small_lip_and_is_withheld():
+    """The pivot does not merely get harsh at small heights, it becomes
+    unphysical — arresting the roll would need μ = 2.34 at 5 mm and 5.43 at
+    1 mm, against rubber-on-asphalt's ~1.0 (the model's own `<geom friction>`).
+    The edge slips and the wheel rolls through.
+
+    So the bracket collapses to the frictionless value there rather than
+    quoting an upper bound that cannot happen. This is the friction gate doing
+    its job; before it existed this height reported a 3× range whose top end
+    was an artefact."""
+    r = kerb_strike_impulse(0.005, 6.0)
+    assert not r["pivot_reachable"]
+    assert r["pivot_friction_required"] > 2.0
+    assert r["impulse_ns"][0] == r["impulse_ns"][1]
+
+
+def test_the_friction_gate_opens_around_the_tyre_deflection_height():
+    """Two independent criteria land on the same ~20 mm boundary: the friction
+    the pivot needs drops to ~1.0 there, and it is also where a pneumatic tyre
+    stops swallowing the obstacle. Neither was tuned to the other, which is the
+    main reason to believe either."""
+    assert not kerb_strike_impulse(0.010, 6.0)["pivot_reachable"]
+    assert kerb_strike_impulse(0.030, 6.0)["pivot_reachable"]
+    mu = kerb_strike_impulse(0.020, 6.0)["pivot_friction_required"]
+    assert 0.9 < mu < 1.1, f"the gate moved off the tyre-deflection height: μ={mu:.2f}"
+
+
+def test_the_bracket_is_ordered_even_where_the_models_cross():
+    """They cross near h/r ≈ 0.6: as the step gets tall the normal tilts and
+    the frictionless case stops being the gentler one. An `assert lo < hi`
+    here would be a wrong assumption dressed as a sanity check."""
+    for h in (0.005, 0.030, 0.080, 0.110, 0.140):
+        lo, hi = kerb_strike_impulse(h, 6.0)["impulse_ns"]
+        assert lo <= hi
+
+
+def test_validity_closes_at_both_ends():
+    """Below the tyre's own deflection a pneumatic tyre swallows the obstacle
+    and the rigid model describes a different event; above h/r = 0.6 the event
+    is a crash rather than a disturbance. A result outside that band is a
+    bound, not an answer, and says so."""
+    floor_mm = KERB_STRIKE_VALIDITY["tyre_deflection_mm"][1]
+    assert not kerb_strike_impulse(floor_mm / 2000.0, 6.0)["within_validity"]
+    assert kerb_strike_impulse(0.030, 6.0)["within_validity"]
+    assert not kerb_strike_impulse(0.6 * R_WHEEL + 0.001, 6.0)["within_validity"]
+
+
+# --------------------------------------------------------------------------
+# The finding that actually matters to #132
+# --------------------------------------------------------------------------
+
+def test_a_kerb_strike_is_not_a_com_impulse_of_the_same_size():
+    """THE POINT OF THE WHOLE EXERCISE. `impulse_response.py` applies its
+    20 N·s through the CoM, so the disturbance is purely linear and the initial
+    pitch rate is zero by construction — its own docstring says so, and says a
+    kerb strike is the follow-on case it is not modelling.
+
+    A kerb strike lands ~0.7 m below the CoM and imparts hundreds of deg/s
+    immediately. Quoting a reference disturbance in N·s and feeding it to the
+    existing scenario therefore understates a kerb, silently, in the one
+    channel that topples the board."""
+    r = kerb_strike_vs_com_impulse(0.020, 6.0)
+    assert r["com_impulse_pitch_rate_deg_s"] == 0.0
+    assert min(r["pitch_rate_deg_s"]) > 100.0
+    assert "different disturbance" in r["note"]
+
+
+def test_even_a_modest_lip_at_speed_exceeds_the_inherited_20_ns():
+    """The headline for #142: the inherited nominal is not conservative. A
+    20 mm lip — a brick edge, a root heave, the kind of thing a pavement has
+    every few metres — clears 20 N·s at every speed the board is meant to ride
+    at. This is measured against the LOWER bound, so it does not depend on
+    believing the harsher model."""
+    for v in (2.0, 4.0, 6.0, 8.0):
+        lo = kerb_strike_impulse(0.020, v)["impulse_ns"][0]
+        assert lo > 20.0, f"{v} m/s gives only {lo:.1f} N·s"


### PR DESCRIPTION
Closes AC2 of #142. **AC1, 3, 4 and 5 stay with Senior Controls** — this supplies the input they asked this role for, not the reference disturbance itself.

## The finding that matters more than the number

`impulse_response.py` applies its 20 N·s **through the CoM**, deliberately — at `application_height_m = 0.0` the disturbance is purely linear and the initial pitch rate is zero by construction. Its own docstring already says a kerb strike is the follow-on case it is *not* modelling, and that the angular channel would swamp the linear one.

A kerb strike lands ~0.7 m **below** the CoM and imparts **100–450 deg/s immediately**.

So a reference disturbance quoted in N·s and fed to the existing scenario **understates a kerb silently, in the one channel that topples the board.** The comparison #132 needs is pitch rate imparted, not newton-seconds. Answering AC1 in N·s without saying this would have been technically responsive and misleading.

## The number, for what it is worth

| obstacle | 2 m/s | 4 m/s | 6 m/s | 8 m/s |
|---|---|---|---|---|
| 10 mm | 17 | 35 | 52 | 70 |
| **20 mm** | **28–44** | **57–88** | **85–132** | **113–176** |
| 30 mm | 36–45 | 71–90 | 107–136 | 143–181 |
| 50 mm | 45–48 | 90–95 | 135–143 | 180–191 |

N·s. A 20 mm lip — brick edge, root heave, the kind of thing a pavement has every few metres — clears the inherited 20 N·s at **every** speed the board is meant to ride at, measured against the *lower* bound. **The inherited nominal is not conservative.**

## The first model was wrong, and it looked fine

Conserving angular momentum about the step edge and rotating rigidly about it — the textbook step-climb model — charges **Δv = 0.25·v for a step of height ZERO.** A zero-height step is not an obstacle. The defect: rotation about the contact point is only forced when the wheel is *blocked*, and nothing blocks it as h→0.

Every number that model produced was plausible. What caught it was checking a limit whose answer is known independently of the model — now the first test in the file. Recording it because the failure mode generalises: the numbers looked alarming but reasonable, and nothing about them said "this model is broken at one end."

## The friction gate — a derivation, not a judgement call

The pivot model does not merely get harsh at small heights, it becomes unphysical. Pivoting means the edge arrests the wheel's roll, which needs a tangential impulse alongside the normal one. Their ratio is the friction the edge must supply:

| h | 1 mm | 5 mm | 10 mm | 20 mm | 30 mm | 50 mm | 100 mm |
|---|---|---|---|---|---|---|---|
| μ required | 5.43 | 2.34 | 1.57 | **0.99** | 0.70 | 0.38 | 0.08 |

Rubber on asphalt is μ ≈ 1.0 — the model's own `<geom friction>`. So the pivot is **unreachable below ~20 mm**: the edge slips and the wheel rolls through. That is the same ~20 mm the tyre's own deflection gives, arrived at independently, and two unrelated criteria landing on one boundary is the strongest reason to believe either. Below it the bracket collapses to the frictionless value rather than quoting an upper bound that cannot happen.

## Validity, stated rather than implied

- **Below ~20 mm** a pneumatic tyre swallows the obstacle — the rigid model describes a different event. The deflection figure (10–20 mm) is an **assumption, not a measurement**; it wants the tyre spec and a load-deflection check at riding pressure, which this role still owes.
- **Above h/r = 0.6** the event is a crash, not a disturbance. At h ≥ r the function refuses rather than returning a number someone might quote.
- The sim's wheel is a **rigid cylinder**, so for scoping a retune *against the sim* these numbers are exactly right. The tyre caveat applies to claims about the real board, where they are an upper bound.

## Acceptance criteria

None move. Purely additive — 178 insertions to `plant.py`, 0 deletions, plus a new test file. It **supplies an input** to #142 AC1 and, through it, the #132 retune target.

## Testing

276 passed / 2 xfailed on the Python sim suite, 12 of them new. Not run locally: the three Rust-hosted tests (known macOS dylib issue, #112); CI covers them and this touches nothing on that path.