### PR TITLE
fix(ci): share sim-binary build steps between sim and publish-sim-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,25 +142,15 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # The closed-loop gate loads the REAL control law over the C ABI, so the
-      # cdylib has to exist before pytest runs. If it is missing those tests
-      # FAIL rather than skip -- a closed-loop test that passes because the
-      # controller was absent would be worse than no test at all.
-      - name: Build the control library
-        run: cargo build --release -p control-ffi
-
-      # I1b (issue #106): tests/test_rust_python_plant_replay_equivalence.py shells out to this
-      # binary to compare the Rust-hosted plant against the Python-hosted one
-      # it runs in-process. Same "fail rather than skip" rule as above.
-      - name: Build the plant-mujoco replay binary
-        run: cargo build --release -p plant-mujoco --bin plant-replay
-
-      # I1c (issue #107, AC6): tests/test_rust_hosted_impulse_response.py
-      # shells out to this binary to compare the Rust-hosted closed loop
-      # (hal + sim-backend's real plant) against the Python-hosted one. Same
-      # "fail rather than skip" rule as above.
-      - name: Build the Rust-hosted impulse-response binary
-        run: cargo build --release -p board-app-driverless --bin impulse-response-rust
+      # The pytest suite shells out to these binaries and FAILS rather than
+      # skips if one is missing (I1b/I1c) -- a closed-loop gate that passes
+      # because the controller was silently absent would be worse than no
+      # test at all. `publish-sim-artifact` needs the identical set for the
+      # same reason; scripts/build_sim_binaries.py is the one place that
+      # lists them, so the two jobs cannot drift apart the way they did
+      # three times in one day (#124).
+      - name: Build sim binaries
+        run: python scripts/build_sim_binaries.py
 
       - name: Scenario acceptance gate
         run: pytest tests/ -v
@@ -257,30 +247,18 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # --compare films the SAME disturbance closed-loop as a second pane, and
-      # that pane runs the real control law over the C ABI -- so the cdylib has
-      # to exist. The script has no fallback here on purpose: publishing an
-      # "open vs closed" clip whose closed pane was quietly uncontrolled would
-      # be a lie in the most visible artifact the project produces.
-      - name: Build the control library
-        run: cargo build --release -p control-ffi
-
-      # I1b (issue #106): tests/test_rust_python_plant_replay_equivalence.py shells out to this
-      # binary, same as the `sim` job above. `Emit claims manifest` below also
-      # runs `pytest tests/`, so without this the equivalence gate's own
-      # "fail rather than pass vacuously" check (added by #117) correctly
-      # fails the suite here too.
-      - name: Build the plant-mujoco replay binary
-        run: cargo build --release -p plant-mujoco --bin plant-replay
-
-      # I1c (issue #107, AC6): tests/test_rust_hosted_impulse_response.py shells
-      # out to this binary, same as the `sim` job above. Missing here since
-      # #120 added the binary and its test without updating this job -- the
-      # same "fail rather than pass vacuously" check meant `Emit claims
-      # manifest` below has been failing on every push since, silently,
-      # because this job is not a required status check.
-      - name: Build the Rust-hosted impulse-response binary
-        run: cargo build --release -p board-app-driverless --bin impulse-response-rust
+      # Same set the `sim` job builds, via the same script (#124) -- this job
+      # needs it too: the --compare render's closed pane runs the real
+      # control law over the C ABI (publishing an "open vs closed" clip whose
+      # closed pane was quietly uncontrolled would be a lie in the most
+      # visible artifact the project produces), and `Emit claims manifest`
+      # below runs `pytest tests/`, which shells out to the other two exactly
+      # as the `sim` job's run does. This is the drift #124 was filed about:
+      # #120 added a binary to `sim` and not here, and the suite's own "fail
+      # rather than pass vacuously" check meant this step failed on every
+      # push for three runs, silently, because this job is not required.
+      - name: Build sim binaries
+        run: python scripts/build_sim_binaries.py
 
       # Only tests that PASS contribute a claim (docs/design-claims-manifest.md,
       # issue #61). A red run here still writes a manifest of whatever passed,

--- a/scripts/build_sim_binaries.py
+++ b/scripts/build_sim_binaries.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Build the Rust release binaries the sim test suite and sim-artifact
+publishing both need.
+
+`sim` and `publish-sim-artifact` (`.github/workflows/ci.yml`) each build this
+same set before running pytest -- the workspace suite shells out to these
+binaries and FAILS rather than skips if one is missing (I1b/I1c: a
+closed-loop gate that passes because the controller was silently absent
+would be worse than no test at all).
+
+Every time a binary was added here, `sim` picked it up and
+`publish-sim-artifact` did not -- three times in one day (#124), because the
+build step lived by hand in two workflow jobs. This list is now the one
+place to edit; both jobs call this script instead of repeating the steps.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# (package, optional --bin name). Add a new binary HERE, not in ci.yml.
+BINARIES: list[tuple[str, str | None]] = [
+    ("control-ffi", None),
+    ("plant-mujoco", "plant-replay"),
+    ("board-app-driverless", "impulse-response-rust"),
+]
+
+
+def main() -> int:
+    for package, bin_name in BINARIES:
+        cmd = ["cargo", "build", "--release", "-p", package]
+        if bin_name:
+            cmd += ["--bin", bin_name]
+        print(f"+ {' '.join(cmd)}", flush=True)
+        result = subprocess.run(cmd, cwd=REPO_ROOT)
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #124.

## What changed

`sim` and `publish-sim-artifact` (`.github/workflows/ci.yml`) both hand-maintained the same three `cargo build --release` steps for binaries the pytest suite shells out to (and fails, rather than skips, if one is missing — I1b/I1c). Every time a binary was added, `sim` got the build step and `publish-sim-artifact` didn't:

| Added by | Binary | Result |
|---|---|---|
| #117 | `plant-replay` | `publish-sim-artifact` failed |
| #120 | `impulse-response-rust` | failed again — on master, three runs, unnoticed |
| #123 | (the fix) | patched the symptom |

`scripts/build_sim_binaries.py` is now the one place that lists them (`BINARIES: list[tuple[package, bin_name]]`), invoked identically by both jobs as a single `Build sim binaries` step. Adding a binary means editing that list, not two workflow steps by hand.

## Acceptance criteria

1. **Adding a new binary requires editing one place.** Demonstrated locally (not committed): added a throwaway workspace member + binary, added one line to `BINARIES`, ran `python scripts/build_sim_binaries.py` — it built the new binary alongside the existing three with no `ci.yml` edit. Reverted before committing.
2. **`publish-sim-artifact` runs the build through the identical shared definition `sim` uses.** Both jobs now call the same script. (`publish-sim-artifact` still runs the suite itself via `scripts/emit_claims.py`, one abstraction layer up from the binary-build duplication this issue is about — see "left out" below.)
3. Not done here — see below.
4. **Offscreen-GL rationale preserved**, `publish-sim-artifact` is still not a required check. No change to that.

## Deliberately left out

- **AC3 (surface a red non-required job on master without someone happening to look).** The issue's own recommendation is to extend `ops/inbox.sh`, which is COO turf, not Senior Controls'. The issue's "Owner note" anticipates this split and says the COO would take that half in the same pass if option 3 is taken — flagging it here rather than doing a cross-turf edit.
- **Full option 2 from the issue** (stop `publish-sim-artifact` from running the suite at all, by emitting `claims.json` from the `sim` job and passing it forward as a workflow artifact). That's a real architectural change (artifact upload/download between jobs, reworking `scripts/emit_claims.py`'s invocation) beyond what caused the three actual incidents, which were all missing **build** steps, not the suite re-run itself. Landing the smaller, targeted fix for the demonstrated failure mode rather than bundling in a bigger refactor.

## Verification

- `python scripts/build_sim_binaries.py` — builds all three binaries clean.
- `pytest tests/` (Python 3.13 venv, matching CI's `requirements-sim.txt`) — 273 passed, 2 xfailed, same baseline as master.
- `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `cargo run -p xtask -- gate` — all clean.
- `GITHUB_ACTIONS=1 POLICY_BASE_REF=origin/master POLICY_BRANCH=feat/controls/shared-sim-binary-build python3 .github/policy_check.py` — all hard checks pass. `DOC-OK` noted in the commit message for the two docs whose `covers:` manifest lists `ci.yml`: neither describes the specific build-step structure this PR touches (same binaries, same cargo commands, same outputs — just invoked from one script instead of duplicated inline), so nothing either doc claims changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQGhQCac3qc37BQRKK3Lxf)_