### PR TITLE
docs(cmo): session teardown — context rewritten, and the day logged

### DIFF
--- a/roles/cmo/CONTEXT.md
+++ b/roles/cmo/CONTEXT.md
@@ -1,27 +1,78 @@
 # CMO — working context
 
-- **Worktree:** `~/projects/overboard-cmo` (ADR-0006: one worktree per role, never share a working directory)
-- **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
-- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
+- **Worktree:** `~/projects/overboard-cmo` (ADR-0006). Marketing work happens in
+  `overboard-web`, `overboard-viz` and `overboard-metrics`.
+- **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md) · [`ROLES.md`](../../docs/decisions/ROLES.md)
+- **Branch prefix:** `feat/marketing/`
 
 ## Current sub-goals
-- Answer the two big unknowns with data, not opinion: do strangers care, and is the *how we
-  build it* story more interesting than the onewheel.
-- Two artefacts produced, zero published. For a build-in-public strategy that ratio is the game.
+
+- **The announcement is the only thing that matters now.** The measurement
+  infrastructure is built and reports zero, honestly, because nothing has been
+  published. Every downstream item — audience data, funding evidence — is
+  waiting on L1, which is waiting on the CEO.
+- Answer the two big unknowns with data: do strangers care, and is *how we build
+  it* more interesting than the onewheel. **We can now measure the first one.**
+
+## What is live (2026-07-31)
+
+- `overboardproject.com`, HTTPS enforced. Apex is DNS-only/grey-cloud so GitHub
+  Pages holds its certificate; only `e.` is Cloudflare-proxied. **Do not flip the
+  apex to orange — it takes the site's TLS down.**
+- Collector at `e.overboardproject.com/e` → D1. `/health` reports events, last
+  event, reject count and last reject reason.
+- Dashboard at `/dashboard?k=…`, token-gated, fails closed, 404s on a bad token.
+- Daily jobs: synthetic traffic, and a GitHub traffic snapshot into
+  `overboard-metrics` (private).
 
 ## Rules this role owns
-- **Category declaration on every published asset** — **Footage · Sim Replay · Hardware Replay ·
-  Concept**, defined once in [Shared Vocabulary (canonical)](https://app.notion.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b). A Replay always names its
-  source; there is no bare "Replay". **Concept never carries engineering numbers.**
-  ("Lane A / Lane B" is retired — stale wherever it still appears.)
-- Reusable channel → start now. One-shot channel → save it for real hardware.
-- Peer of the COO. Neither escalates to the other; both go to the CEO. A cross-line dispute
-  reaches the CEO as ONE joint write-up with both positions in each other's terms.
 
-## Decisions made (edit in place — completed work goes in log/, not here)
+- **Category on every published asset** — Footage · Sim Replay · Hardware Replay
+  · Concept. A Replay names its source; a Concept carries no engineering numbers.
+- **Reusable channel → start now. One-shot channel → save it for real hardware.**
+  L1 should spend at most ONE rented channel; posting everywhere on one day turns
+  four shots into one and tells us nothing.
+- **We write for a persona, we never name one.** No "education", "students",
+  "STEM" or non-profit framing on the public surface — M0's one-way door.
+- **US English.** "tire", not "tyre".
+- **A number on a page is a maintenance obligation.** If a count cannot be kept
+  current, write something that stays true instead.
+- Peer of the COO. Neither escalates to the other; both go to the CEO.
 
-_Nothing recorded yet by this role._
+## Decisions made
+
+- **Countersigned the COO's policy gate** (2026-07-30) with one change: hard, but
+  **narrow** — it fires only on a capability claim or a numeric figure, not on
+  every PR touching public paths. An advisory gate on a public surface is ignored
+  within a week; a gate people must routinely bypass teaches them gates are
+  decorative. Delivered that way in web PR #41.
+- **Synthetic data is separated by `site` key, never by a flag.** A flag can be
+  dropped by a bug, leaving rows indistinguishable from real ones forever.
+- **`site` is required on every event and never defaulted.** The one irreversible
+  decision in the analytics schema — unlabelled rows cannot be labelled later.
+- **Content Designer writes; the SDM reviews.** The CEO's sketch had one role
+  doing both, which dissolves the gate. The split is the mechanism.
 
 ## Known dead ends
 
-_Nothing recorded yet._
+- **`hill.py` cannot be filmed.** It models grade by rotating gravity on flat
+  ground, so a render shows a board accelerating on level ground for no visible
+  reason. `terrain.py` exists precisely to fix this. Do not ask for a hill video.
+- **Flipping `analytics.js` to `sink: 'endpoint'` alone breaks everything
+  silently.** The collector requires `site`; without it every event 400s, and
+  `sendBeacon` cannot read a response. Verify with `/health` counts, never CI.
+- **Do not verify a Cloudflare Worker within ~60s of deploy.** Both versions
+  serve during rollout; a check in that window produced a confident false result.
+- **`gh pr review --approve` never works here.** All roles share one GitHub
+  account. Review by comment; the gate holds by discipline, not by GitHub.
+- **A base64 token in a URL is mangled** — `+` decodes to a space. Bit us on the
+  dashboard; the collector now reads the raw query string.
+
+## In flight / owed
+
+- 🔴 **Assembly capture runbook** — hardware Aug 15–28, happens once, not written.
+- 🔴 **Purge synthetic data before L1 publishes.** It lives in Cloudflare; the
+  local `--purge` will not reach it. Use the collector's purge job.
+- Funding materials (Aug 24, P0, not started) — blocked on the hardware-evidence
+  decision, which is still unowned.
+- web#25 alarm · web#29 publish-race regression test · Experiments database.

--- a/roles/cmo/log/2026-07-31-analytics-spine-and-domain.md
+++ b/roles/cmo/log/2026-07-31-analytics-spine-and-domain.md
@@ -1,0 +1,50 @@
+# 2026-07-31 — the site went live and the measurement spine was built
+
+Went from "no domain, no collection, no dashboard" to all three running and
+verifying themselves. Written up because the *failures* are the transferable
+part, not the shipping.
+
+**Live:** `overboardproject.com` with HTTPS · collector at
+`e.overboardproject.com` storing to D1 · token-gated dashboard on real data ·
+daily synthetic traffic · daily GitHub traffic snapshot into a private repo.
+
+**Five things looked wired and were not, in one day:**
+
+1. `analytics.js` had been fully instrumented for weeks with `sink: 'console'`,
+   sending nowhere. Events scrolled past convincingly in devtools.
+2. `CNAME` was committed to `main` while the site is served from `gh-pages`, and
+   `publish.sh` wipes that root on every deploy — so a domain set through the
+   Pages UI would have been deleted by the next push.
+3. `og:image` pointed at `/og.png`, which had never existed. The share card for
+   the announcement was blank.
+4. The production deploy was cancelled by its own preview-cleanup job: both sat
+   in one concurrency group, and GitHub allows only one *pending* run per group.
+   `cancel-in-progress: false` does not prevent this — it governs runs already in
+   progress. Merges looked green and deployed nothing.
+5. The collector validated per *batch*, so one unrecognised event name binned the
+   whole batch. The page flushes once on `pagehide`, so any visitor who used the
+   email form lost their entire session — silently, because `sendBeacon` cannot
+   read a response.
+
+**The pattern:** every one was invisible from inside. Four were found by going
+and looking; only #5's class was caught by a machine, and only because the deploy
+verifies its effect from outside rather than trusting its exit code.
+
+**What changed as a result:** every deploy now checks the live result — posts a
+real event and confirms the stored count rose, and posts a deliberately invalid
+one to confirm rejection still works. `/health` reports rejects as well as
+liveness, because liveness tells you the collector is up, not that it is
+accepting what is sent to it.
+
+**Two fixes of mine were worse than the bug**, both caught by others: my deploy
+retry used `{` not `(`, so `cd` leaked between attempts and a retry would have
+published a blank site over a working one; and my collector created its schema
+in the POST handler, so `/health` — the one endpoint queried before traffic
+exists — was guaranteed to fail.
+
+**Reviews caught more than I did.** The SDM found two defects in the Voice &
+Style Guide I wrote, where worked examples demonstrated the opposite of a rule
+stated above them, and found the batch-poisoning bug. DCP refused a re-render
+rather than substituting other footage, and found three published clips that
+cannot name the run they came from. That is the writer/reviewer split earning
+its cost on its first real outing.


### PR DESCRIPTION
Teardown for the CMO session of 2026-07-31.

**`CONTEXT.md` rewritten, not appended.** The old version described a world with no domain and no measurement, both of which now exist. It carries what is live, the decisions this role made and why, and the dead ends.

**The dead-ends section is the part that matters to the next session:**

- `hill.py` cannot be filmed — it models grade by rotating gravity on flat ground, so a render shows a board accelerating on level ground for no visible reason. Do not ask for a hill video.
- Flipping `analytics.js` to `sink: 'endpoint'` alone breaks collection **silently** — the collector requires `site`, and `sendBeacon` cannot read a 400.
- Do not verify a Cloudflare Worker within ~60s of deploy; both versions serve during rollout and a check in that window gave a confident false result.
- `gh pr review --approve` never works — all roles share one GitHub account.

**A log entry** records the five things that looked wired and were not, in one day, and the two fixes of mine that were worse than the bug. Both were caught by other roles, which is the writer/reviewer split earning its cost.