### PR TITLE
ops(coo): teardown for 2026-07-31

### DIFF
--- a/roles/coo/CONTEXT.md
+++ b/roles/coo/CONTEXT.md
@@ -5,16 +5,25 @@
 - **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
 
 ## Current sub-goals
-- **Review latency is the worst number on my board.** It is the bottleneck, not throughput.
-  Clear finished PRs before starting new work; a green unqueued PR looks identical to
-  work in progress.
-- **[#91](https://github.com/MikePaNtZ/overboard/issues/91) I1 — Rust owns the control loop.**
-  CEO-approved 2026-07-29. Top priority; status it at every board.
-- Land the delegation layer: issues → dispatch → PR review (ADR-0007).
-- Get a real daily usage number in front of the CEO (`python3 ops/usage.py`), and a ceiling —
-  CEO has said he trusts the recommendation and it is a two-way door
-  ([#79](https://github.com/MikePaNtZ/overboard/issues/79)).
-- Keep ops under 10% of spend and say so on every board if it is not.
+
+**Everything the previous list named is closed.** SR-SIM-5 satisfied (#91→#107), the delegation
+layer landed and proved (#38), and the usage gate is live and verified to refuse. Deleting them
+here in the same pass, per Mechanical's rule — a stale priority list is read as the current one
+by the next session.
+
+- **[#33](https://github.com/MikePaNtZ/overboard/issues/33) sim-fidelity session.** Prep is
+  WRITTEN (`docs/sim-fidelity-session-prep.md`, #143) — this is now genuinely waiting on the
+  CEO's time, which it was not before. Mechanical asked to attend (#128) and should.
+- **[#151](https://github.com/MikePaNtZ/overboard/issues/151) cron decision.** Deliberately NOT
+  taken as a consequence of the gate going live. The number is a floor; cron runs exactly the
+  agents it cannot see. CEO's call.
+- **Two doc manifests are becoming decorative.** `docs/design-claims-manifest.md` and
+  `docs/web-artifact-pipeline.md` both declare `covers: .github/workflows/ci.yml`, so every CI
+  change trips both and gets a routine `DOC-OK`. Four times today. Narrow them to what they
+  actually describe, or drop them. Both are mine.
+- Keep ops under 10% of spend and say so on every board if it is not. **Now measurable:** COO is
+  21.3% of attributed spend, which is not the same statistic and should not be reported as if
+  it were.
 
 ## What this role must not do
 - Dispatch more than 3 workers at once, or dispatch from a dirty tree (`ops/dispatch.sh`).
@@ -23,6 +32,13 @@
   Broke this on 2026-07-28 (#77 shipped a convention as prose) and it stalled a PR inside
   24 hours. Repaired by #92.
 - **Ship a check without watching it fail on purpose.** See dead ends.
+- **Add a gate without asking what it costs the person who did nothing wrong.** Four of mine
+  landed on other roles before they landed on me — the role-log heuristic blocked DCP and
+  Mechanical with a 0% true-positive rate, and a `covers:` manifest on a session-prep doc
+  red-built Mechanical within the hour. "Is this check correct?" is the wrong first question.
+- **Assert someone broke a convention without reading what they wrote.** Did this to DCP on
+  #105. They had not. A gate asserting fault is bad; its owner repeating the assertion
+  unchecked is how people stop trusting the tooling.
 - Discuss strategy, funding or role tags in GitHub issues/PRs — public channel, CEO
   direction 2026-07-28. Cross-role comms go in Notion.
 
@@ -47,6 +63,15 @@
   two mutually-blocking escalation rows for hours; the moment it became a GitHub issue with an
   acceptance criterion, Controls closed it unprompted and without dispatch.
 
+- **2026-07-31 — a diff-based check that cannot resolve its base must FAIL in CI, not skip.**
+  `turf` and `doc-drift` had never once executed. A skip that reports green is a lie the whole
+  org builds on. #83.
+- **2026-07-31 — calibrate from the DELTA of two readings, never one absolute reading.** The
+  trailing-7-day window and the weekly meter are different windows; a single reading taken after
+  a reset implies a ceiling ~14x too large. #127.
+- **2026-07-31 — when two TURF-OVERRIDEs land on the same file in a row, the map is wrong, not
+  the author.** Fixed by moving the file to its real owner (#136), not by more paperwork.
+
 ## Known dead ends
 
 - **`python3 .github/policy_check.py` on `master` proves nothing.** `turf` skips (no branch
@@ -57,6 +82,14 @@
   file was a free pass to append forever, and a commit message that merely *quoted* an
   override token activated it (the regexes were unanchored). Anchor override tokens to line
   start; measure net growth, not additions.
+- **`git reset --hard` discards uncommitted work in the SAME worktree.** Lost a fix mid-test on
+  2026-07-31 and briefly misread the result as a code failure.
+- **The Overboard guard denies the WHOLE bash call.** A blocked `cp` chained after a real patch
+  meant the patch never ran — and a later syntax check passing was misread as confirmation.
+  Never chain a possibly-blocked command after real work.
+- **`gh pr create --body "..."` mangles backticked shell metacharacters.** `kt`, `0.2/p`,
+  `p99.9`, `docs/` all got evaluated; four PR bodies needed repair. Write the body to a file and
+  use `--body-file`.
 - **Do not `git checkout` in the primary `~/projects/overboard` worktree.** It sits on
   `master` and a compound `cd` in a shell call does not always persist, so edits meant for
   this worktree land there instead. Verify with `git -C <path> branch --show-current` before

--- a/roles/coo/log/2026-07-31-usage-gate-live-and-the-checks-that-were-not-checking.md
+++ b/roles/coo/log/2026-07-31-usage-gate-live-and-the-checks-that-were-not-checking.md
@@ -1,0 +1,82 @@
+# 2026-07-31 — the usage gate went live, and most of my own checks turned out not to be checking
+
+## Headline
+
+**29 PRs merged.** `SR-SIM-5` satisfied — Rust now steps MuJoCo through the `hal` seam. The usage
+gate is calibrated and **verified to refuse**, closing #38. And roughly half my own tooling was
+found to be enforcing nothing, or enforcing the wrong thing on the wrong people.
+
+## What shipped
+
+| Thread | |
+|---|---|
+| **SR-SIM-5** | I1a→I1b→I1c: Rust calls `mj_step` via a C shim, proves bit-identical open-loop equivalence with Python, then hosts the real plant through the seam |
+| **Torque denomination** | #137/#140 — `kt` no longer reaches the loop gain; a wrong `kt` is now a headroom error, not a gain error |
+| **Usage** | derived per-role attribution, delta calibration, persisted threshold, gate proven to refuse |
+| **Governance** | dispatch reaches all four repos, role labels everywhere, SDM ratified, Content Designer registered |
+
+## The pattern worth carrying forward
+
+**Every gate I added landed on other roles before it landed on me.**
+
+- `role-log` size heuristic: fired four times, **wrong four times**, blocked DCP and Mechanical.
+  Downgraded to advisory (#131). Worse, I told DCP they had broken a convention *without reading
+  what they wrote*. They hadn't.
+- Session-prep doc: I gave it a `covers:` manifest and it red-built Mechanical's PR **within the
+  hour** (#144). A dated snapshot is not implementation-tier.
+- `turf` matched the literal registry prefix, so every `fix/` and `docs/` branch **skipped it
+  entirely** — seven live branches, three of them mine (#110).
+- `--who` reported the wrong owner for every path under `.github/` — `lstrip("./")` strips
+  *characters*, not a prefix (#83).
+
+The question I kept asking was "is this check correct?". The question that would have caught all
+four is **"what does this cost the person who did nothing wrong?"**
+
+## The other recurring shape: a green light that meant nothing
+
+`turf` and `doc-drift` had **never once executed in CI** — depth-1 checkout, no merge-base, and a
+detached HEAD that made the branch name read as the literal string `"HEAD"`. The gate printed
+"all hard checks pass" on every PR for its entire existence (#83).
+
+Fixing the wiring was one line. The fix that matters is that **a diff-based check which cannot
+resolve its base is now a hard failure in CI rather than a skip.** A skip that reports green is a
+lie the whole org then builds on.
+
+Same disease, three more places: `publish-sim-artifact` failed on every master push for hours
+because it is not a required check (#123); I merged two PRs while it was pending and shipped the
+regression twice. And I nearly queued #119 on a diff that looked right — waiting to watch the job
+it fixes actually run is what caught that it was still broken for a different reason.
+
+## Escalations that changed the answer
+
+Two oracle calls, both of which corrected me rather than confirming me:
+
+1. **MuJoCo binding** — I framed a third-party crate as a licensing risk. It is not; the real
+   reason to reject it is version skew. *"If you write licence in the decision record as the
+   reason, the record will be wrong and someone will later reverse it on correct grounds."*
+2. **Gain margin / delay budget** — I asked whether to derive or measure first. False dilemma: the
+   derivation is a day's arithmetic and the expensive artifacts were the sweep and the notebook.
+   It also found the thing neither issue saw — **the controller's stability depends on a `kt` it
+   never sees**, because gains are denominated in amps. That became #137 and it went first.
+
+Both times the distilled packet was what made the answer useful. Both times I was wrong in a way
+I could not have seen from inside the problem.
+
+## Numbers worth keeping
+
+- **Delegating is 3.6× cheaper per turn** — 58.1k weighted/turn main-thread vs 16.0k dispatched.
+  ~90% of weighted cost is cache read + creation; **cost is carrying context, not generating text.**
+- Attribution coverage rose 0% → 65% across the week as branch/worktree discipline took hold.
+- Weekly meter ~44%, threshold 80%, gate verified to refuse at exit 1.
+
+## Dead ends
+
+- **`git reset --hard` discards uncommitted work in the same worktree** — lost a fix mid-test and
+  misread the result as a code failure.
+- **The Overboard guard denies the *whole* bash call.** A blocked `cp` chained after a real patch
+  meant the patch never ran, and I read a later syntax check as confirmation it had.
+- **Shell mangling in `gh` PR bodies.** Backticks around `kt`, `0.2/p`, `p99.9` get evaluated.
+  Write bodies to a file and use `--body-file`; four PR bodies needed repair.
+- **`cd` does not persist between tool calls.** Cost me four separate incidents, including patches
+  applied to the primary worktree and an empty branch pushed to origin. Use `git -C` and absolute
+  paths, always.


### PR DESCRIPTION
Session log as a new file per the convention; `CONTEXT.md` **edited**, with every finished sub-goal deleted rather than accumulated.

That last part is Mechanical's rule, and it is the sharpest line anyone wrote in this repo today:

> *If you finish a sub-goal, delete it here in the same pass — a stale priority list is read as the current one by the next session.*

## Sub-goals

All four previous ones are closed — SR-SIM-5, the delegation layer, the usage number, the ceiling. Replaced with what is actually live:

- **#33** is now *genuinely* waiting on the CEO's time rather than on prep I owed and kept not doing.
- **#151** cron, as an explicit undecided rather than a drift.
- **Two doc manifests of mine that are becoming decorative** — `design-claims-manifest.md` and `web-artifact-pipeline.md` both cover `ci.yml`, so every CI change trips both and collects a routine `DOC-OK`. Four times today.

## Two additions to "what this role must not do"

Both learned the hard way:

- **Add a gate without asking what it costs the person who did nothing wrong.** Four of mine landed on other roles before they landed on me. The role-log heuristic blocked DCP and Mechanical with a **0% true-positive rate**, and a `covers:` manifest on a session-prep doc red-built Mechanical *within the hour*.
- **Assert someone broke a convention without reading what they wrote.** I did this to Digital Content Production on #105 and was wrong. A gate asserting fault is bad; its owner repeating the assertion unchecked is how people stop trusting the tooling.

## Also recorded

Three decisions — diff-based checks must fail rather than skip in CI; calibrate from a delta, never one absolute reading; two turf overrides in a row on the same file means the *map* is wrong.

Four dead ends — including that the Overboard guard denies the **whole** bash call (so a blocked command chained after real work means the work never ran), and that `gh pr create --body` evaluates backticked shell metacharacters.

## One thing worth noticing in this PR's own CI

The `role-log` advisory fires on this diff (+43/-10) and **does not block** — it names both readings and says "if it is standing context, this is exactly right and there is nothing to do." That is #131 working as intended, on the author who wrote it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>