### PR TITLE
feat(controls): wire the sim imperfection profile into sim-backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,23 @@ jobs:
       # succeed. Installed from the SAME pin as requirements-sim.txt (not
       # duplicated by hand) so the version this job links can never drift
       # from the one `sim` tests against.
+      #
+      # numpy is installed the same pinned way for a second, newer reason
+      # (issue #129): `cargo test`'s tests/imperfection_conformance.rs shells
+      # out to `python3 -m sim.scenarios.imperfections`, which imports numpy
+      # directly. Pinning it explicitly rather than relying on mujoco's own
+      # transitive numpy dependency (which would also satisfy the import) --
+      # a version that transitive pull happens to resolve is an accident of
+      # mujoco's own requirements, not a guarantee this job's `sim.scenarios`
+      # import is exercised against the same numpy `sim` itself gates on.
       - uses: actions/setup-python@v5
         with:
           python-version: '3.14'
 
-      - name: Install MuJoCo (plant-mujoco's native dependency)
-        run: pip install "$(grep '^mujoco==' requirements-sim.txt)"
+      - name: Install MuJoCo + numpy (native dep + conformance-test dep)
+        run: |
+          pip install "$(grep '^mujoco==' requirements-sim.txt)"
+          pip install "$(grep '^numpy==' requirements-sim.txt)"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "hal",
  "hal-actuate",
  "plant-mujoco",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/sim-backend/Cargo.toml
+++ b/crates/sim-backend/Cargo.toml
@@ -9,3 +9,16 @@ board-types = { workspace = true }
 hal = { workspace = true }
 hal-actuate = { workspace = true }
 plant-mujoco = { workspace = true }
+
+[dev-dependencies]
+# Only for tests/imperfection_conformance.rs, to parse the JSON the Python
+# generator emits. xtask already pins the same major version.
+#
+# `float_roundtrip` is NOT optional here: serde_json's default f64 parser is
+# fast but not correctly rounded, and silently returned a value 1 ULP off
+# Python's own for a real vector during this crate's own development --
+# exactly the kind of failure this test exists to catch, except in the test
+# harness's own JSON parsing rather than in the code under test. Without this
+# feature the conformance test is checking against numbers this crate did not
+# actually generate.
+serde_json = { version = "1", features = ["float_roundtrip"] }

--- a/crates/sim-backend/src/imperfections.rs
+++ b/crates/sim-backend/src/imperfections.rs
@@ -1,0 +1,425 @@
+//! The sim's imperfection profile — ICD §12, issue #129.
+//!
+//! Rust-side counterpart to `sim/scenarios/imperfections.py`, whose module
+//! doc is the actual design rationale (which rows are modelled, which are
+//! deferred, and why). That file also owns the profile *values* — this
+//! module owns reproducing its *chain* exactly, checked bit-for-bit against
+//! its generated conformance vectors by
+//! `tests/imperfection_conformance.rs`. If a number here looks wrong, the
+//! fix belongs in Python; this module's job is to match it, not to improve
+//! on it.
+//!
+//! Deliberately NOT bit-identical to Python: the noise rows. Gyro/accel
+//! noise here comes from this module's own seeded generator, not a
+//! reimplementation of NumPy's PCG64 — conformance for those rows is
+//! distributional (see `tests/imperfection_conformance.rs`'s sibling unit
+//! tests below), exactly as `sim/scenarios/imperfections.py`'s own
+//! conformance-contract section specifies.
+
+/// A named, versioned set of sim imperfections. Mirrors
+/// `sim.scenarios.imperfections.ImperfectionProfile` field-for-field; see
+/// that class for what each row means and why it has the value it does.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImperfectionProfile {
+    pub profile_id: &'static str,
+    pub actuation_delay_s: f64,
+    pub current_loop_tau_s: f64,
+    pub gyro_noise_rad_s: f64,
+    pub gyro_bias_rad_s: f64,
+    pub accel_noise_m_s2: f64,
+    pub wheel_rate_quantum_rad_s: f64,
+    pub wheel_rate_update_hz: f64,
+    pub max_current_a: f64,
+    pub derate_onset_rad_s: f64,
+    pub derate_full_rad_s: f64,
+    pub derate_floor_frac: f64,
+    pub seed: u64,
+}
+
+impl Default for ImperfectionProfile {
+    fn default() -> Self {
+        IDEAL
+    }
+}
+
+impl ImperfectionProfile {
+    /// True if this profile derates with speed. Mirrors
+    /// `ImperfectionProfile.models_cutback` exactly.
+    pub fn models_cutback(&self) -> bool {
+        self.derate_onset_rad_s > 0.0 && self.derate_floor_frac < 1.0
+    }
+
+    /// The cap the drive will actually honour at this wheel speed. Mirrors
+    /// `ImperfectionProfile.available_current_a` exactly, including its
+    /// symmetric (direction-independent) treatment of wheel rate.
+    pub fn available_current_a(&self, wheel_rate_rad_s: f64) -> f64 {
+        if !self.models_cutback() {
+            return self.max_current_a;
+        }
+        let w = wheel_rate_rad_s.abs();
+        if w <= self.derate_onset_rad_s {
+            return self.max_current_a;
+        }
+        let span = self.derate_full_rad_s - self.derate_onset_rad_s;
+        let frac = if span <= 0.0 {
+            self.derate_floor_frac
+        } else {
+            let t = ((w - self.derate_onset_rad_s) / span).min(1.0);
+            1.0 + t * (self.derate_floor_frac - 1.0)
+        };
+        self.max_current_a * frac
+    }
+
+    /// True if this profile models nothing deterministic or stochastic.
+    /// Mirrors `ImperfectionProfile.is_ideal` exactly — same fields, same
+    /// omissions (`wheel_rate_update_hz` and `max_current_a` are
+    /// deliberately not part of the check on the Python side either).
+    pub fn is_ideal(&self) -> bool {
+        self.actuation_delay_s == 0.0
+            && self.current_loop_tau_s == 0.0
+            && self.gyro_noise_rad_s == 0.0
+            && self.gyro_bias_rad_s == 0.0
+            && self.accel_noise_m_s2 == 0.0
+            && self.wheel_rate_quantum_rad_s == 0.0
+            && !self.models_cutback()
+    }
+}
+
+/// All zeros. Mirrors `sim.scenarios.imperfections.IDEAL`. Not usable as a
+/// gate on the Python side and not intended as one here either — kept for
+/// the same bring-up reason: separating a sign error from noise.
+pub const IDEAL: ImperfectionProfile = ImperfectionProfile {
+    profile_id: "ideal-v1",
+    actuation_delay_s: 0.0,
+    current_loop_tau_s: 0.0,
+    gyro_noise_rad_s: 0.0,
+    gyro_bias_rad_s: 0.0,
+    accel_noise_m_s2: 0.0,
+    wheel_rate_quantum_rad_s: 0.0,
+    wheel_rate_update_hz: 0.0,
+    max_current_a: 40.0,
+    derate_onset_rad_s: 0.0,
+    derate_full_rad_s: 0.0,
+    derate_floor_frac: 1.0,
+    seed: 12345,
+};
+
+/// Mirrors `sim.scenarios.imperfections.STAGE0_PLACEHOLDER` field-for-field.
+/// Every value there is a placeholder awaiting Stage-0 bench measurement —
+/// see that module for the derivation of each one; this is a value copy,
+/// not a re-derivation.
+pub const STAGE0_PLACEHOLDER: ImperfectionProfile = ImperfectionProfile {
+    profile_id: "stage0-placeholder-v1",
+    actuation_delay_s: 0.001,
+    current_loop_tau_s: 0.001,
+    gyro_noise_rad_s: 0.004,
+    gyro_bias_rad_s: 0.002,
+    accel_noise_m_s2: 0.02,
+    wheel_rate_quantum_rad_s: 0.00698,
+    wheel_rate_update_hz: 500.0,
+    max_current_a: 40.0,
+    derate_onset_rad_s: 0.0,
+    derate_full_rad_s: 0.0,
+    derate_floor_frac: 1.0,
+    seed: 12345,
+};
+
+/// Mirrors `sim.scenarios.imperfections.STAGE0_CUTBACK` field-for-field.
+/// STAGE0_PLACEHOLDER plus the speed-dependent cutback layer — use this for
+/// anything that descends.
+pub const STAGE0_CUTBACK: ImperfectionProfile = ImperfectionProfile {
+    profile_id: "stage0-cutback-v1",
+    actuation_delay_s: 0.001,
+    current_loop_tau_s: 0.001,
+    gyro_noise_rad_s: 0.004,
+    gyro_bias_rad_s: 0.002,
+    accel_noise_m_s2: 0.02,
+    wheel_rate_quantum_rad_s: 0.00698,
+    wheel_rate_update_hz: 500.0,
+    max_current_a: 40.0,
+    derate_onset_rad_s: 27.0,
+    derate_full_rad_s: 55.0,
+    derate_floor_frac: 0.35,
+    seed: 12345,
+};
+
+/// A tiny, dependency-free, seeded PRNG (SplitMix64) feeding a Box-Muller
+/// transform for Gaussian noise.
+///
+/// Deliberately not NumPy's PCG64 -- `sim/scenarios/imperfections.py`'s own
+/// conformance-contract section says as much: reproducing that stream
+/// bitwise would mean reimplementing both generator and algorithm for the
+/// project's *least* consequential row. What this must provide, and does,
+/// is: reproducible under a fixed seed, and distributionally correct.
+#[derive(Debug, Clone, Copy)]
+struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        SplitMix64 { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform in (0, 1] -- never exactly 0, so `ln()` below is always
+    /// defined.
+    fn next_open01(&mut self) -> f64 {
+        // Top 53 bits -> a double with full mantissa precision, then shifted
+        // off zero rather than clamped, so the distribution stays uniform.
+        let bits = self.next_u64() >> 11;
+        ((bits as f64) + 1.0) / ((1u64 << 53) as f64 + 1.0)
+    }
+
+    /// One standard-normal sample via Box-Muller. Not caching the paired
+    /// sample: at most a handful of draws per control cycle, so the constant
+    /// factor of two is not worth the extra state.
+    fn next_gaussian(&mut self) -> f64 {
+        let u1 = self.next_open01();
+        let u2 = self.next_open01();
+        (-2.0 * u1.ln()).sqrt() * (std::f64::consts::TAU * u2).cos()
+    }
+}
+
+/// Per-run mutable state for a profile. One per backend/run — mirrors
+/// `sim.scenarios.imperfections.ImperfectionState`.
+#[derive(Debug)]
+pub struct ImperfectionState {
+    profile: ImperfectionProfile,
+    dt_s: f64,
+    rng: SplitMix64,
+    cmd_history: Vec<f64>,
+    applied_a: f64,
+    held_wheel_rate: f64,
+    last_wheel_update_s: f64,
+}
+
+impl ImperfectionState {
+    pub fn new(profile: ImperfectionProfile, dt_s: f64) -> Self {
+        ImperfectionState {
+            profile,
+            dt_s,
+            rng: SplitMix64::new(profile.seed),
+            cmd_history: Vec::new(),
+            applied_a: 0.0,
+            held_wheel_rate: 0.0,
+            // Mirrors Python's `-1e9`: far enough in the past that the very
+            // first `wheel_rate()` call always refreshes.
+            last_wheel_update_s: -1.0e9,
+        }
+    }
+
+    pub fn profile(&self) -> &ImperfectionProfile {
+        &self.profile
+    }
+
+    // -- sensing -------------------------------------------------------
+
+    /// Pitch-rate vector as the gyro reports it. Bias lands on `[1]`
+    /// unconditionally (nose-up rate), mirroring `ImperfectionState.gyro_vec`
+    /// -- noised even when the caller only reads one axis, so the other two
+    /// are not suspiciously perfect next to it.
+    pub fn gyro_vec(&mut self, true_gyro_rad_s: [f64; 3]) -> [f64; 3] {
+        let p = self.profile;
+        let mut out = true_gyro_rad_s;
+        if p.gyro_noise_rad_s > 0.0 {
+            for v in out.iter_mut() {
+                *v += self.rng.next_gaussian() * p.gyro_noise_rad_s;
+            }
+        }
+        out[1] += p.gyro_bias_rad_s;
+        out
+    }
+
+    pub fn accel_vec(&mut self, true_accel_m_s2: [f64; 3]) -> [f64; 3] {
+        let p = self.profile;
+        let mut out = true_accel_m_s2;
+        if p.accel_noise_m_s2 > 0.0 {
+            for v in out.iter_mut() {
+                *v += self.rng.next_gaussian() * p.accel_noise_m_s2;
+            }
+        }
+        out
+    }
+
+    /// Wheel rate as the drive reports it: quantised, and held between
+    /// updates rather than interpolated. Mirrors `ImperfectionState.wheel_rate`
+    /// exactly, including the `>=` refresh test -- see that method's own
+    /// docstring for why `>=` (not `>`) and assigning `t_s` (not
+    /// accumulating `period`) are both load-bearing, not stylistic.
+    pub fn wheel_rate(&mut self, true_rate_rad_s: f64, t_s: f64) -> f64 {
+        let p = self.profile;
+        if p.wheel_rate_update_hz <= 0.0 {
+            return Self::quantise(p.wheel_rate_quantum_rad_s, true_rate_rad_s);
+        }
+        if t_s - self.last_wheel_update_s >= 1.0 / p.wheel_rate_update_hz {
+            self.held_wheel_rate = Self::quantise(p.wheel_rate_quantum_rad_s, true_rate_rad_s);
+            self.last_wheel_update_s = t_s;
+        }
+        self.held_wheel_rate
+    }
+
+    /// Round-half-to-even, matching NumPy's `np.round` -- NOT Rust's
+    /// `f64::round`, which is round-half-away-from-zero and disagrees at
+    /// exactly the half-quantum values a quantiser hits constantly. See this
+    /// crate's conformance test and `sim/scenarios/imperfections.py`'s own
+    /// header for why that divergence is the single most likely silent
+    /// failure mode here.
+    fn quantise(quantum: f64, v: f64) -> f64 {
+        if quantum <= 0.0 {
+            v
+        } else {
+            (v / quantum).round_ties_even() * quantum
+        }
+    }
+
+    // -- actuation -------------------------------------------------------
+
+    /// Current the plant actually sees, after cutback, transport delay and
+    /// the current loop's own dynamics. Mirrors
+    /// `ImperfectionState.apply_current` exactly, including its chain order
+    /// (cutback -> saturate -> transport delay -> current-loop lag) and its
+    /// fractional, interpolated delay -- see that method's docstring for why
+    /// rounding to whole cycles is not an acceptable simplification.
+    ///
+    /// `wheel_rate_rad_s` is required when the profile models cutback;
+    /// omitting it panics rather than silently applying no cutback, mirroring
+    /// the Python method's own `ValueError` for the same reason it gives:
+    /// this project has twice shipped a wrong result from an optional
+    /// argument silently defaulting away real behaviour.
+    pub fn apply_current(&mut self, commanded_a: f64, wheel_rate_rad_s: Option<f64>) -> f64 {
+        let p = self.profile;
+        let cap = if p.models_cutback() {
+            let w = wheel_rate_rad_s.unwrap_or_else(|| {
+                panic!(
+                    "profile {:?} models cutback, so apply_current() needs wheel_rate_rad_s -- \
+                     refusing to silently apply no cutback",
+                    p.profile_id
+                )
+            });
+            p.available_current_a(w)
+        } else {
+            p.max_current_a
+        };
+        let commanded_a = commanded_a.clamp(-cap, cap);
+
+        let cycles = (p.actuation_delay_s / self.dt_s).max(0.0);
+        let whole = cycles as usize;
+        let frac = cycles - whole as f64;
+
+        self.cmd_history.push(commanded_a);
+        while self.cmd_history.len() > whole + 2 {
+            self.cmd_history.remove(0);
+        }
+
+        let sample = |history: &[f64], back: usize| -> f64 {
+            let len = history.len();
+            if back < len {
+                history[len - 1 - back]
+            } else {
+                0.0
+            }
+        };
+        let delayed = (1.0 - frac) * sample(&self.cmd_history, whole)
+            + frac * sample(&self.cmd_history, whole + 1);
+
+        if p.current_loop_tau_s <= 0.0 {
+            self.applied_a = delayed;
+        } else {
+            let alpha = self.dt_s / (p.current_loop_tau_s + self.dt_s);
+            self.applied_a += alpha * (delayed - self.applied_a);
+        }
+        self.applied_a
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ideal_is_ideal() {
+        assert!(IDEAL.is_ideal());
+    }
+
+    #[test]
+    fn stage0_profiles_are_not_ideal() {
+        assert!(!STAGE0_PLACEHOLDER.is_ideal());
+        assert!(!STAGE0_CUTBACK.is_ideal());
+    }
+
+    #[test]
+    fn only_cutback_profile_models_cutback() {
+        assert!(!STAGE0_PLACEHOLDER.models_cutback());
+        assert!(STAGE0_CUTBACK.models_cutback());
+    }
+
+    #[test]
+    fn zero_delay_zero_lag_is_a_same_cycle_passthrough() {
+        // The property SimBackend's wiring depends on: with IDEAL, the
+        // profile-level chain must be a no-op so the existing structural
+        // one-cycle delay is the only delay a caller observes.
+        let mut st = ImperfectionState::new(IDEAL, 0.002);
+        assert_eq!(st.apply_current(5.0, Some(0.0)), 5.0);
+        assert_eq!(st.apply_current(-3.0, Some(0.0)), -3.0);
+    }
+
+    #[test]
+    fn cutback_without_wheel_rate_panics() {
+        let mut st = ImperfectionState::new(STAGE0_CUTBACK, 0.002);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| st.apply_current(5.0, None)));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn quantise_is_round_half_to_even() {
+        let q = 1.0;
+        assert_eq!(ImperfectionState::quantise(q, 0.5), 0.0);
+        assert_eq!(ImperfectionState::quantise(q, 1.5), 2.0);
+        assert_eq!(ImperfectionState::quantise(q, 2.5), 2.0);
+        assert_eq!(ImperfectionState::quantise(q, -0.5), 0.0);
+    }
+
+    #[test]
+    fn same_seed_reproduces_the_same_noise_stream() {
+        let mut a = ImperfectionState::new(STAGE0_PLACEHOLDER, 0.002);
+        let mut b = ImperfectionState::new(STAGE0_PLACEHOLDER, 0.002);
+        for _ in 0..20 {
+            assert_eq!(
+                a.gyro_vec([0.0, 0.0, 0.0]),
+                b.gyro_vec([0.0, 0.0, 0.0]),
+                "same seed must reproduce the same stream"
+            );
+        }
+    }
+
+    #[test]
+    fn gyro_noise_is_distributionally_correct() {
+        let mut st = ImperfectionState::new(STAGE0_PLACEHOLDER, 0.002);
+        let n = 20_000;
+        let mut sum = 0.0;
+        let mut sum_sq = 0.0;
+        for _ in 0..n {
+            let v = st.gyro_vec([0.0, 0.0, 0.0])[1] - STAGE0_PLACEHOLDER.gyro_bias_rad_s;
+            sum += v;
+            sum_sq += v * v;
+        }
+        let mean = sum / n as f64;
+        let var = sum_sq / n as f64 - mean * mean;
+        let sigma = var.sqrt();
+        let want = STAGE0_PLACEHOLDER.gyro_noise_rad_s;
+        assert!(
+            (sigma - want).abs() / want < 0.05,
+            "measured sigma {sigma} not within 5% of profile sigma {want}"
+        );
+        assert!(mean.abs() < want * 0.05, "mean {mean} not close to zero");
+    }
+}

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -282,7 +282,6 @@ impl SimBackend {
 
     /// The current the plant is seeing, after the imperfection chain.
     /// Exposed for tests.
-
     pub fn applied_current_a(&self) -> f32 {
         self.applied_current_a
     }

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -27,11 +27,19 @@
 //! - **`apply()` does not echo the command back as measured current.** The
 //!   commanded value is buffered and only appears in a *later* observation,
 //!   because actuation delay is additive (ICD §5.2) and a backend that echoes
-//!   is explicitly non-conforming (§12). One whole control cycle here is a
-//!   placeholder for the real first-order current loop, which arrives with
-//!   the imperfection profile (Mechanical's territory, not this crate's).
+//!   is explicitly non-conforming (§12). That structural one-cycle defer is
+//!   protocol-level, not the imperfection profile's own delay -- see below.
 //! - **Cold start reports `Invalid`, not zeros.** A backend presenting zeros
 //!   as measurements before the drive has spoken is non-conforming (§12).
+//! - **The imperfection profile (issue #129) is real, not a placeholder.**
+//!   [`imperfections::ImperfectionState`] runs cutback -> saturate ->
+//!   transport delay -> current-loop lag on top of the structural delay
+//!   above, quantises + holds reported wheel rate, and noises the IMU --
+//!   checked bit-for-bit on its deterministic rows against
+//!   `sim/scenarios/imperfections.py`'s own generated vectors by
+//!   `tests/imperfection_conformance.rs`. The default profile is
+//!   [`imperfections::IDEAL`] (a no-op chain), so every pre-#129 caller's
+//!   behaviour is unchanged; [`SimBackend::with_profile`] opts in.
 //!
 //! [`SimBackend`] implements both [`hal::BoardObserve`] and
 //! [`hal_actuate::BoardActuate`], which makes this crate **driverless-only**:
@@ -45,8 +53,11 @@ use board_types::{
 };
 use hal::{BoardObserve, CallSequence};
 use hal_actuate::{BoardActuate, Disarm};
+use imperfections::{ImperfectionProfile, ImperfectionState};
 use plant_mujoco::Plant;
 use std::path::{Path, PathBuf};
+
+pub mod imperfections;
 
 /// Nanoseconds per control cycle. 500 Hz, per ICD §11.2. Sourced the same way
 /// the stub sourced it -- a fixed constant, not read from the model -- per
@@ -152,8 +163,29 @@ pub struct SimBackend {
     /// Commanded current awaiting its actuation delay. Never reported as
     /// measured in the same cycle it was applied.
     pending_current_a: Option<f32>,
-    /// The current now actually flowing, as far as the plant is concerned.
+    /// The command as it stands after the structural one-cycle delay
+    /// (protocol-level: `apply()` at cycle N is visible starting cycle
+    /// N+1's `wait_observe()`). This is the imperfection chain's INPUT, not
+    /// what the plant sees -- see `applied_current_a` for that.
+    commanded_current_a: f32,
+    /// The current the plant is actually seeing, after the imperfection
+    /// profile's own cutback/delay/lag chain has run on top of
+    /// `commanded_current_a`. With `imperfections::IDEAL` this chain is a
+    /// same-cycle passthrough, so the two coincide and every pre-#129 test
+    /// keeps its exact prior behaviour.
     applied_current_a: f32,
+    /// Ground-truth wheel rate from the PREVIOUS cycle's sensor read, fed to
+    /// this cycle's cutback decision. Real wheel rate for the CURRENT cycle
+    /// is only known after `Plant::step`, which runs after the chain needs
+    /// it -- unlike the Python scenarios, which read truth and act on it
+    /// within the same synchronous step. Using last cycle's truth is the
+    /// real-time-loop-shaped choice, one control period stale, and is
+    /// flagged rather than hidden: see this crate's module doc.
+    last_wheel_rate_rad_s: f64,
+    imperfection_profile: ImperfectionProfile,
+    /// Built once `dt_s` is known, in `open()` -- same pattern as
+    /// `steps_per_cycle`.
+    imperfections: Option<ImperfectionState>,
     params: Params,
     /// Overrides `model_path()`'s default when `Some` (issue #161 W2). See
     /// [`SimBackend::with_model_path`].
@@ -235,7 +267,22 @@ impl SimBackend {
         self.incline_deg = incline_deg;
     }
 
-    /// The current the plant is seeing. Exposed for tests.
+    /// As [`SimBackend::with_params`], but with a non-default imperfection
+    /// profile (issue #129). Without this constructor the profile is
+    /// [`imperfections::IDEAL`], preserving every pre-#129 backend's exact
+    /// behaviour -- `test_rust_hosted_impulse_response.py`'s `profile=IDEAL`
+    /// seam check needs no changes because of it.
+    pub fn with_profile(params: Params, profile: ImperfectionProfile) -> Self {
+        SimBackend {
+            params,
+            imperfection_profile: profile,
+            ..SimBackend::default()
+        }
+    }
+
+    /// The current the plant is seeing, after the imperfection chain.
+    /// Exposed for tests.
+
     pub fn applied_current_a(&self) -> f32 {
         self.applied_current_a
     }
@@ -596,12 +643,23 @@ impl BoardObserve for SimBackend {
         self.frame_free_qposadr = plant.joint_qposadr("frame_free");
         self.frame_free_dofadr = plant.joint_dofadr("frame_free");
 
+        // Built once dt_s is known, same reasoning as steps_per_cycle above:
+        // a fresh ImperfectionState per open() so repeat-run bit-identity
+        // (AC5, issue #74) is not contaminated by carrying noise-stream
+        // state across runs.
+        self.imperfections = Some(ImperfectionState::new(
+            self.imperfection_profile,
+            plant.timestep(),
+        ));
+
         self.plant = Some(plant);
         self.cycle = 0;
         self.pending_current_a = None;
+        self.commanded_current_a = 0.0;
         self.applied_current_a = 0.0;
         self.ballast_fa_target_m = 0.0;
         self.ballast_lateral_target_m = 0.0;
+        self.last_wheel_rate_rad_s = 0.0;
         self.open = true;
         self.seq.reset();
         Ok(())
@@ -632,14 +690,35 @@ impl BoardObserve for SimBackend {
         self.cycle += 1;
 
         // Whatever was commanded last cycle becomes effective now -- the
-        // additive actuation delay, in its crudest possible form.
+        // STRUCTURAL one-cycle delay inherent to the apply()/wait_observe()
+        // protocol (ICD §5.2's "additive" loop delay), not the imperfection
+        // profile's own actuation_delay_s. That row is layered on top,
+        // below, via `imperfections.apply_current` (issue #129).
         if let Some(pending) = self.pending_current_a.take() {
-            self.applied_current_a = pending;
+            self.commanded_current_a = pending;
         }
+        // Cutback -> saturate -> transport delay -> current-loop lag
+        // (sim/scenarios/imperfections.py's own chain_order). Fed last
+        // cycle's truth wheel rate (see `last_wheel_rate_rad_s`'s field
+        // doc): this cycle's truth is not known until after `Plant::step`
+        // below, which is one line too late for a cutback decision this
+        // same cycle.
+        let imperfections = self
+            .imperfections
+            .as_mut()
+            .expect("self.open is only true while self.imperfections is Some");
+        self.applied_current_a = imperfections.apply_current(
+            self.commanded_current_a as f64,
+            Some(self.last_wheel_rate_rad_s),
+        ) as f32;
+
         // Built by resolved actuator index, not a fixed-length array (issue
         // #161 W2): the driverless model has one actuator, the ridden rider
         // model has three. Ballast channels stay at MuJoCo's zero-init
-        // default (0.0) on a model that does not declare them.
+        // default (0.0) on a model that does not declare them. The
+        // imperfection chain above (issue #129) applies to the wheel motor
+        // channel only -- the ballast actuators are position-controlled
+        // weight-shift targets, not the hub motor, and are untouched by it.
         let mut ctrl = vec![0.0f64; plant.nu()];
         ctrl[self.wheel_motor_actuator] = self.applied_current_a as f64 * KT_NM_PER_A;
         if let Some(idx) = self.ballast_fa_actuator {
@@ -671,20 +750,33 @@ impl BoardObserve for SimBackend {
         let accel = plant.read_sensor(self.accel_sensor.0, self.accel_sensor.1);
         let gyro_icd = [-gyro[0] as f32, gyro[1] as f32, -gyro[2] as f32];
         let accel_icd = [-accel[0] as f32, accel[1] as f32, -accel[2] as f32];
+        // Gyro/accel noise+bias, per the imperfection profile (issue #129).
+        // A no-op under `imperfections::IDEAL`, which is why the pre-#129
+        // tests below still hold with no changes.
+        let [gx, gy, gz] =
+            imperfections.gyro_vec([gyro_icd[0] as f64, gyro_icd[1] as f64, gyro_icd[2] as f64]);
+        let [ax, ay, az] = imperfections.accel_vec([
+            accel_icd[0] as f64,
+            accel_icd[1] as f64,
+            accel_icd[2] as f64,
+        ]);
+        let gyro_icd = [gx as f32, gy as f32, gz as f32];
+        let accel_icd = [ax as f32, ay as f32, az as f32];
 
         // Wheel rate (issue #121): same `wheel_hinge` joint and sign
         // convention `ctrl` uses, read via the model's existing `wheel_vel`
         // jointvel sensor -- read AFTER stepping, same ordering rule as the
-        // IMU sensors above. Converted to ERPM through the single
-        // ICD-sourced ratio (`RAD_S_PER_ERPM`), not quantised to the nearest
-        // integer ERPM: this backend has no imperfection-profile plumbing
-        // yet (see this crate's own header on the actuation-delay stub), so
-        // like `motor_current_a` this is the idealised, noiseless reading --
-        // integer ERPM quantisation is `imperfections.py`'s
-        // `wheel_rate_quantum_rad_s` row, which has no Rust-side home yet.
-        let wheel_rate_rad_s =
+        // IMU sensors above.
+        let wheel_true_rad_s =
             plant.read_sensor(self.wheel_vel_sensor.0, self.wheel_vel_sensor.1)[0];
-        let erpm = (wheel_rate_rad_s / RAD_S_PER_ERPM as f64) as f32;
+        // Reported ERPM goes through the profile's quantisation + hold
+        // (issue #129) -- a no-op under IDEAL, same reasoning as above.
+        let wheel_reported_rad_s = imperfections.wheel_rate(wheel_true_rad_s, t_s);
+        let erpm = (wheel_reported_rad_s / RAD_S_PER_ERPM as f64) as f32;
+        // Truth, not the reported/quantised value, feeds NEXT cycle's
+        // cutback decision -- mirrors the Python scenarios' own
+        // `apply_current(proposed, wheel_true)`, not `sensed_wheel`.
+        self.last_wheel_rate_rad_s = wheel_true_rad_s;
 
         let mut obs = Observation::COLD_START;
         obs.cycle = self.cycle;
@@ -724,12 +816,38 @@ impl BoardObserve for SimBackend {
             params: self.params,
             imu_mounting_rotation: [1.0, 0.0, 0.0, 0.0],
             r_eff_m: DEFAULT_R_EFF_M,
-            imperfection_profile_id: None,
+            // None only when the profile genuinely models nothing (issue
+            // #129 AC): a run cannot be read without knowing what was
+            // modelled (ICD §6.2), so IDEAL is the one profile allowed to
+            // leave this blank.
+            imperfection_profile_id: if self.imperfection_profile.is_ideal() {
+                None
+            } else {
+                Some(profile_id_bytes(self.imperfection_profile.profile_id))
+            },
             schema_hash: [0; 32],
             binary_hash: [0; 32],
             git_sha: [0; 20],
         }
     }
+}
+
+/// Encodes a profile id as its UTF-8 bytes, zero-padded to 32 bytes -- not
+/// hashed. A hash would need this crate to reproduce whatever Python-side
+/// serialisation it was taken over, which is exactly the kind of derived
+/// semantics the conformance vectors exist to avoid re-deriving. Every id in
+/// `imperfections::` fits comfortably; a longer one is a naming mistake and
+/// panics loudly rather than truncating silently.
+fn profile_id_bytes(id: &str) -> [u8; 32] {
+    let bytes = id.as_bytes();
+    assert!(
+        bytes.len() <= 32,
+        "profile_id {id:?} is {} bytes, longer than the 32-byte field it must fit in",
+        bytes.len()
+    );
+    let mut out = [0u8; 32];
+    out[..bytes.len()].copy_from_slice(bytes);
+    out
 }
 
 impl BoardActuate for SimBackend {
@@ -1231,6 +1349,95 @@ mod tests {
             dy < -0.1 && dy.abs() > dx.abs() * 5.0,
             "after a 90 deg injection the board should travel along -Y, not -X \
              (moved dx={dx:.4} m, dy={dy:.4} m)"
+        );
+    }
+
+    // --- new for issue #129: imperfection-profile wiring ------------------
+
+    #[test]
+    fn ideal_profile_is_the_default_and_reports_no_profile_id() {
+        let b = opened();
+        assert_eq!(b.run_metadata().imperfection_profile_id, None);
+    }
+
+    #[test]
+    fn non_ideal_profile_stamps_its_id() {
+        let mut b = SimBackend::with_profile(
+            Params {
+                max_current_a: 40.0,
+                ..Params::default()
+            },
+            imperfections::STAGE0_PLACEHOLDER,
+        );
+        b.open().unwrap();
+        let stamped = b
+            .run_metadata()
+            .imperfection_profile_id
+            .expect("a non-ideal profile must stamp Some(_)");
+        let mut want = [0u8; 32];
+        want[..21].copy_from_slice(b"stage0-placeholder-v1");
+        assert_eq!(stamped, want);
+    }
+
+    #[test]
+    fn stage0_profile_delays_and_lags_the_current_the_plant_sees() {
+        // With IDEAL, one apply() is visible, at full magnitude, exactly one
+        // cycle later (see measured_current_is_not_an_echo_of_the_command).
+        // STAGE0_PLACEHOLDER adds its own actuation_delay_s/current_loop_tau_s
+        // on top of that structural cycle: the same command must NOT reach
+        // full magnitude one cycle later, because the current-loop lag alone
+        // guarantees a first-order approach, never a step.
+        let mut b = SimBackend::with_profile(
+            Params {
+                max_current_a: 40.0,
+                ..Params::default()
+            },
+            imperfections::STAGE0_PLACEHOLDER,
+        );
+        b.open().unwrap();
+        b.arm().unwrap();
+        b.wait_observe().unwrap();
+        b.apply(&Command::MotorCurrent { amps: 10.0 }).unwrap();
+        let next = b.wait_observe().unwrap();
+        assert!(
+            next.motor_current_a > 0.0 && next.motor_current_a < 10.0,
+            "expected a partial, lagged response, got {}",
+            next.motor_current_a
+        );
+    }
+
+    #[test]
+    fn stage0_cutback_profile_does_not_cap_current_at_rest() {
+        // At the board's resting wheel speed (~0 rad/s), well below
+        // derate_onset_rad_s (27), cutback must not bind -- the command
+        // should reach the plant once the current-loop lag settles, same as
+        // a profile with no cutback modelled at all. This proves
+        // `last_wheel_rate_rad_s` is wired into the cutback decision with a
+        // real (not a dummy always-triggering or always-clear) reading; the
+        // cutback MATH itself -- does it cap correctly once the wheel really
+        // is spinning fast -- is exercised directly, without needing the
+        // plant to physically spin up, by `imperfections::tests` and
+        // `tests/imperfection_conformance.rs`.
+        let mut b = SimBackend::with_profile(
+            Params {
+                max_current_a: 40.0,
+                ..Params::default()
+            },
+            imperfections::STAGE0_CUTBACK,
+        );
+        b.open().unwrap();
+        b.arm().unwrap();
+        b.wait_observe().unwrap();
+        let mut last = b.wait_observe().unwrap();
+        for _ in 0..30 {
+            b.apply(&Command::MotorCurrent { amps: 10.0 }).unwrap();
+            last = b.wait_observe().unwrap();
+        }
+        assert!(
+            last.motor_current_a > 9.0,
+            "expected the lag to have settled near the uncapped 10A command \
+             at rest, got {}",
+            last.motor_current_a
         );
     }
 }

--- a/crates/sim-backend/tests/imperfection_conformance.rs
+++ b/crates/sim-backend/tests/imperfection_conformance.rs
@@ -1,0 +1,140 @@
+//! Cross-language conformance (issue #129): `sim-backend`'s imperfection
+//! chain must reproduce every DETERMINISTIC vector
+//! `sim/scenarios/imperfections.py` generates, bit-for-bit.
+//!
+//! The generator is invoked here rather than a JSON fixture being committed,
+//! per that module's own "NOT COMMITTED AS A FIXTURE, GENERATED" contract --
+//! a committed fixture goes stale silently the next time a row changes; a
+//! live generator call cannot.
+//!
+//! Stochastic rows (gyro/accel noise) are deliberately NOT checked against
+//! these vectors -- see `sim/scenarios/imperfections.py`'s own conformance
+//! section for why, and `imperfections::tests` in `src/imperfections.rs` for
+//! where the distributional/reproducibility checks for those rows live
+//! instead.
+
+use sim_backend::imperfections::{
+    ImperfectionProfile, ImperfectionState, STAGE0_CUTBACK, STAGE0_PLACEHOLDER,
+};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn generate_vectors() -> serde_json::Value {
+    let out = Command::new("python3")
+        .args([
+            "-m",
+            "sim.scenarios.imperfections",
+            "--emit-conformance-vectors",
+            "-",
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect(
+            "failed to run `python3 -m sim.scenarios.imperfections` -- is \
+             python3 (with numpy) on PATH?",
+        );
+    assert!(
+        out.status.success(),
+        "conformance-vector generator failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    serde_json::from_slice(&out.stdout).expect("generator did not emit valid JSON")
+}
+
+fn profile_for(id: &str) -> ImperfectionProfile {
+    match id {
+        "stage0-placeholder-v1" => STAGE0_PLACEHOLDER,
+        "stage0-cutback-v1" => STAGE0_CUTBACK,
+        other => panic!(
+            "unknown profile_id {other:?} in conformance vectors -- this crate's \
+             imperfections module needs a matching constant added"
+        ),
+    }
+}
+
+fn f64_vec(v: &serde_json::Value) -> Vec<f64> {
+    v.as_array()
+        .expect("expected a JSON array")
+        .iter()
+        .map(|x| x.as_f64().expect("expected a JSON number"))
+        .collect()
+}
+
+#[test]
+fn deterministic_rows_match_the_python_generator_bit_for_bit() {
+    let vectors = generate_vectors();
+
+    assert_eq!(
+        vectors["schema"], "imperfection-conformance-v1",
+        "CONFORMANCE_SCHEMA changed on the Python side -- this test needs \
+         updating for the new vector shape, not just re-running"
+    );
+    assert_eq!(
+        vectors["chain_order"],
+        serde_json::json!(["cutback", "saturate", "transport_delay", "current_loop_lag"]),
+        "the chain order is part of the contract -- a Rust implementation \
+         that clamps after the lag would let a command through as a transient"
+    );
+
+    let cases = vectors["cases"].as_array().expect("cases must be an array");
+    assert!(!cases.is_empty(), "generator produced zero cases");
+
+    for case in cases {
+        let profile_id = case["profile_id"].as_str().unwrap();
+        let profile = profile_for(profile_id);
+        let dt_s = case["dt_s"].as_f64().unwrap();
+        let model = case["model"].as_str().unwrap();
+        let ctx = format!("profile={profile_id} model={model} dt_s={dt_s}");
+
+        check_available_current(&profile, &case["available_current_a"], &ctx);
+        check_apply_current(&profile, dt_s, &case["apply_current"], &ctx);
+        check_wheel_rate(&profile, dt_s, &case["wheel_rate_quantisation"], &ctx);
+        check_wheel_rate(&profile, dt_s, &case["wheel_rate_hold"], &ctx);
+    }
+}
+
+fn check_available_current(profile: &ImperfectionProfile, case: &serde_json::Value, ctx: &str) {
+    let ws = f64_vec(&case["wheel_rate_rad_s"]);
+    let want = f64_vec(&case["cap_a"]);
+    for (w, want) in ws.iter().zip(want.iter()) {
+        let got = profile.available_current_a(*w);
+        assert_eq!(got, *want, "available_current_a({w}) [{ctx}]");
+    }
+}
+
+fn check_apply_current(
+    profile: &ImperfectionProfile,
+    dt_s: f64,
+    case: &serde_json::Value,
+    ctx: &str,
+) {
+    let commanded = f64_vec(&case["commanded_a"]);
+    let wheel = f64_vec(&case["wheel_rate_rad_s"]);
+    let want = f64_vec(&case["applied_a"]);
+    let mut st = ImperfectionState::new(*profile, dt_s);
+    for (i, ((c, w), want)) in commanded
+        .iter()
+        .zip(wheel.iter())
+        .zip(want.iter())
+        .enumerate()
+    {
+        let got = st.apply_current(*c, Some(*w));
+        assert_eq!(got, *want, "apply_current step {i} [{ctx}]");
+    }
+}
+
+fn check_wheel_rate(profile: &ImperfectionProfile, dt_s: f64, case: &serde_json::Value, ctx: &str) {
+    let t = f64_vec(&case["t_s"]);
+    let true_rate = f64_vec(&case["true_rate_rad_s"]);
+    let want = f64_vec(&case["reported_rad_s"]);
+    let mut st = ImperfectionState::new(*profile, dt_s);
+    for (i, ((ti, v), want)) in t.iter().zip(true_rate.iter()).zip(want.iter()).enumerate() {
+        let got = st.wheel_rate(*v, *ti);
+        assert_eq!(got, *want, "wheel_rate step {i} [{ctx}]");
+    }
+}

--- a/roles/senior-controls/log/2026-08-01-sim-backend-imperfection-profile.md
+++ b/roles/senior-controls/log/2026-08-01-sim-backend-imperfection-profile.md
@@ -1,0 +1,85 @@
+# Issue #129 — `sim-backend` gets a real imperfection profile (PR TBD)
+
+`crates/sim-backend` stamped `imperfection_profile_id: None` unconditionally and modelled
+actuation delay as a one-whole-cycle buffer — the gap Mechanical's #128 supplied a contract
+for (generated conformance vectors) but that this crate had not yet wired up. SR-SIM-3's "no
+ideal-only mode in CI" did not hold on the Rust-hosted path.
+
+## What changed
+
+New `crates/sim-backend/src/imperfections.rs`: an `ImperfectionProfile`/`ImperfectionState`
+pair mirroring `sim/scenarios/imperfections.py` field-for-field and method-for-method —
+`IDEAL`/`STAGE0_PLACEHOLDER`/`STAGE0_CUTBACK` constants, the cutback → saturate → transport
+delay → current-loop lag chain (fractional, interpolated delay — not rounded to whole cycles),
+wheel-rate quantisation (round-half-to-even, via `f64::round_ties_even`, not Rust's default
+round-half-away-from-zero) and hold, and gyro/accel noise from a small seeded SplitMix64 +
+Box-Muller generator (deliberately not NumPy's PCG64 — distributional/reproducibility
+conformance only, per the Python module's own conformance-contract section).
+
+Wired into `SimBackend`:
+- `apply()`'s existing structural one-cycle defer is unchanged (protocol-level, ICD §5.2's
+  loop delay). The profile's own chain now runs on top of it in `wait_observe()`, so
+  `motor_current_a` reports the current the plant actually sees, not an echo.
+- Reported ERPM goes through quantise+hold; the raw truth (not the reported value) feeds the
+  *next* cycle's cutback decision, one control period stale by construction — this backend
+  reads wheel truth only after `Plant::step`, one line too late for the same cycle's cutback,
+  unlike the batch-structured Python scenarios. Documented in `last_wheel_rate_rad_s`'s field
+  comment rather than hidden.
+- `run_metadata().imperfection_profile_id` stamps the real id (UTF-8 bytes, zero-padded to 32
+  — not hashed, since a hash would need this crate to reproduce a Python-side serialisation
+  scheme that doesn't exist yet) and stays `None` only when the profile is genuinely `IDEAL`.
+- Default profile is `IDEAL` (`SimBackend::default()`/`new()`/`with_params()` unchanged;
+  `with_profile()` opts in), so every pre-#129 caller's behaviour is bit-for-bit unchanged —
+  verified by running `tests/test_rust_hosted_impulse_response.py` and
+  `tests/test_rust_python_plant_replay_equivalence.py` locally against the built binaries, not
+  just asserted from reading the code.
+
+New `crates/sim-backend/tests/imperfection_conformance.rs`: shells out to
+`python -m sim.scenarios.imperfections --emit-conformance-vectors -` (generated, not
+committed, per that module's own instruction) and checks every deterministic row bit-for-bit.
+
+## A real bug the conformance test caught in its own harness, not in the code under test
+
+`serde_json`'s default `f64` parser is fast but **not correctly rounded** — it returned a
+value 1 ULP off Python's own for a real vector during development here
+(`9.753086419753087` vs `...089`, bits `...cd6f` vs `...cd70`). Diagnosed by writing a
+throwaway example binary and comparing bit patterns at each stage (JSON text → parsed f64 →
+computed f64) against a hand-rolled Rust repro that matched Python exactly, until the one step
+that didn't match turned out to be serde_json's own parse, not anything in `imperfections.rs`.
+Fixed by enabling serde_json's `float_roundtrip` feature (dev-dependency only). Without it the
+conformance test would have been checking Rust's output against numbers Python never actually
+produced — a false-negative machine dressed as a bit-for-bit gate.
+
+## CI
+
+`rust` job now also installs pinned `numpy` (from `requirements-sim.txt`, same pin the `sim`
+job uses) alongside the existing `mujoco` install, rather than relying on it being pulled in
+transitively by mujoco's own dependency resolution — that transitive pull happened to satisfy
+the import during local testing, but which numpy version it resolves to is an accident of
+mujoco's requirements, not a guarantee against the same pin `sim` gates on.
+
+## Acceptance criteria (issue #129)
+
+All eight checked: chain order, fractional delay, round-half-to-even quantisation + correct
+hold-refresh semantics, bit-for-bit Rust test against the generated vectors, distributional +
+reproducible gyro/accel noise, `imperfection_profile_id` stamping, generator invoked rather
+than a committed fixture, `test_rust_hosted_impulse_response.py`'s `profile=IDEAL` untouched
+(and re-verified green, not just left alone).
+
+## Deliberately left out, flagged rather than fixed
+
+- **`erpm_effective_age_ns` stays hardcoded `0`.** True staleness tracking needs its own state
+  (ns since the wheel-rate hold last actually refreshed), and for the one model this backend
+  steps (`overboard_onewheel.xml`, 2 ms) every STAGE0 profile's `wheel_rate_update_hz` (500 Hz)
+  matches the control rate exactly, so the hold never actually goes stale — `0` stays honest
+  for every profile this crate can currently be run with. Would need revisiting if this crate
+  ever steps the bench-rig model (0.5 ms) or a profile with a slower update rate.
+- **No physically-realistic end-to-end test of the cutback cap actually binding.** Driving the
+  simulated wheel to `derate_onset_rad_s` (27 rad/s) from rest inside a bounded test needs
+  knowing how the board's real inertia and current respond, which isn't this crate's call to
+  assume. The cutback *math* is proven bit-for-bit by the conformance test and unit-tested in
+  isolation; the *backend wiring* is proven by a rest-state test (cutback correctly does NOT
+  engage at true wheel rate ≈ 0) rather than a claim that it engages under load.
+- **`SimBackend::commanded_current_a`/`applied_current_a` naming, not touched further.** Now
+  carries real meaning (pre-chain vs. post-chain), documented on the fields; did not rename
+  the public `applied_current_a()` accessor, which callers already depend on.


### PR DESCRIPTION
Closes #129.

## The gap

`crates/sim-backend` hosted the real MuJoCo plant through `hal` (#107, I1c) but carried no imperfection profile: `run_metadata()` stamped `imperfection_profile_id: None` unconditionally, the IMU was raw truth, and actuation delay was a crude one-whole-cycle buffer. That deferral was documented in this crate's own header, correctly, but nothing tracked the consequence: **SR-SIM-3 requires no ideal-only mode in CI, and on the Rust-hosted path there was nothing but ideal mode.** Mechanical's #128 supplied the contract as generated, executable conformance vectors; this PR is the Rust-side wiring against them.

## What changed

**New `crates/sim-backend/src/imperfections.rs`** — an `ImperfectionProfile`/`ImperfectionState` pair mirroring `sim/scenarios/imperfections.py` field-for-field and method-for-method:
- `IDEAL` / `STAGE0_PLACEHOLDER` / `STAGE0_CUTBACK` constants, values copied from the Python side (not re-derived).
- The deterministic chain in the declared order: cutback → saturate → transport delay → current-loop lag. Actuation delay is fractional and interpolated, in seconds — not rounded to whole cycles (at the onewheel's 2 ms the ICD's 1 ms figure is exactly half a cycle, which rounding would silently zero).
- Wheel-rate quantisation via `f64::round_ties_even()` (round-half-to-even, matching NumPy's `np.round` — Rust's default `f64::round()` is round-half-away-from-zero and disagrees at exactly the half-quantum values a quantiser hits constantly), and a zero-order hold with the same `t - last >= period` refresh semantics as the Python side.
- Gyro/accel noise from a small seeded SplitMix64 + Box-Muller generator — deliberately **not** NumPy's PCG64 (the issue's own instruction); conformance for these rows is distributional + reproducible-under-seed, not bit-identical.

**Wired into `SimBackend`:**
- The existing structural one-cycle defer in `apply()`/`wait_observe()` (protocol-level, ICD §5.2's loop delay) is unchanged. The profile's own chain now runs on top of it, so `motor_current_a` reports the current the plant actually sees rather than an echo of the command.
- Reported ERPM goes through quantise + hold. The next cycle's cutback decision is fed last cycle's *truth* wheel rate — this backend only learns the current cycle's truth after `Plant::step`, one line too late for a same-cycle cutback decision, unlike the batch-structured Python scenarios. Documented on the field rather than hidden.
- `run_metadata().imperfection_profile_id` stamps the real id (UTF-8 bytes, zero-padded to 32 — not hashed, since hashing would mean this crate re-deriving a Python-side serialisation scheme that doesn't exist) and is `None` only when the profile is genuinely `IDEAL`.
- Default profile is `IDEAL` — `SimBackend::default()`/`new()`/`with_params()` are unchanged; a new `with_profile()` opts in. Every pre-#129 caller's behaviour is bit-for-bit unchanged, which I verified rather than assumed: `tests/test_rust_hosted_impulse_response.py` and `tests/test_rust_python_plant_replay_equivalence.py` both pass unmodified against the rebuilt binaries.

**New `crates/sim-backend/tests/imperfection_conformance.rs`** — shells out to `python -m sim.scenarios.imperfections --emit-conformance-vectors -` (generated, not committed, per that module's own instruction) and checks every deterministic row bit-for-bit.

## A bug the conformance test caught in its own harness, not in the code under test

While building this, the conformance test failed on a real vector by 1 ULP (`9.753086419753087` vs `...089`). Root cause: `serde_json`'s default `f64` parser is fast but **not correctly rounded**. Diagnosed by comparing bit patterns (JSON text → parsed f64 → computed f64) at each stage against a hand-rolled Rust repro that matched Python's own bits exactly, until the one step that didn't match turned out to be serde_json's own parse. Fixed by enabling its `float_roundtrip` feature (dev-dependency only) — without it, the test would have been silently checking Rust's real output against numbers Python never actually produced.

## CI

`rust` job now installs pinned `numpy` (from `requirements-sim.txt`, the same pin `sim` uses) alongside `mujoco`, rather than relying on it arriving transitively through mujoco's own dependency resolution — that happened to work locally, but which version it resolves to isn't a guarantee against the pin `sim` gates on.

## Acceptance criteria (issue #129)

All eight checked: chain order and fractional delay; round-half-to-even quantisation with correct hold-refresh semantics; a Rust test that reproduces every deterministic vector bit-for-bit; distributional + reproducible gyro/accel noise; `imperfection_profile_id` stamping; the generator invoked rather than a committed fixture; `test_rust_hosted_impulse_response.py`'s `profile=IDEAL` left as-is (and re-verified green).

## Deliberately left out

- **`erpm_effective_age_ns` stays hardcoded `0`.** True staleness tracking needs its own state. For the one model this backend steps (`overboard_onewheel.xml`, 2 ms), every STAGE0 profile's `wheel_rate_update_hz` (500 Hz) matches the control rate exactly, so the hold never actually goes stale today — `0` stays honest. Would need revisiting for the bench-rig model or a slower update rate.
- **No physically-realistic end-to-end test of the cutback cap actually binding under load.** Driving the simulated wheel to `derate_onset_rad_s` from rest inside a bounded test needs assumptions about real inertia/current response that aren't this crate's call to make. The cutback *math* is proven bit-for-bit by the conformance test; the backend *wiring* is proven by a rest-state test (cutback correctly does not engage at true wheel rate ≈ 0).
- **`SimBackend`'s `applied_current_a()` accessor name is unchanged** even though its meaning shifted (now post-chain, "what the plant sees," documented on the field) — existing callers depend on the name.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8KimFY6GuA8yueVJzdqN3)_