### PR TITLE
A Game Engineer seat and a fourth repo for the Unreal client (ADR-0009)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,17 @@ finished, which has now happened three times in two days.
 - **This repo is controls only** — Rust, sim, hardware, design docs. The public landing page and all
   brand/marketing assets live in the sibling repo **`overboard-web`** (`~/projects/overboard-web`).
   Keep them separate: no HTML/marketing here, no control code there.
-- The two are coupled by **facts, not code**. When a capability ships or a phase turns over, the
-  `overboard-web` page status must be updated in the same pass (Requirements `SR-WEB-4`, and the
-  lock-step rule in [M0](https://app.notion.com/p/3a8472a5fb6981ffbf73ee8297e62f07)).
+- **Four repos.** `overboard` (controls + sim) · `overboard-web` (landing page, brand) ·
+  `overboard-viz` (cinematic renders) · `overboard-game` (the Unreal client — real-time,
+  gamepad-driven, ADR-0009).
+- **Nothing outside this repo computes board physics.** `overboard-viz` and `overboard-game` both
+  replay motion MuJoCo already computed. A renderer that computes a board state has broken the
+  boundary, and no control decision is ever tuned from one.
+- Each pairing is coupled by **one data contract, not by code** — neither side imports the other.
+  `overboard-viz` reads a pose track; `overboard-game` reads a live state stream and writes
+  setpoints back. When a capability ships or a phase turns over, the `overboard-web` page status
+  must be updated in the same pass (Requirements `SR-WEB-4`, and the lock-step rule in
+  [M0](https://app.notion.com/p/3a8472a5fb6981ffbf73ee8297e62f07)).
 - Local multi-repo work: open `~/projects/overboard.code-workspace` to get both folders at once.
 
 ## Git workflow — feature branches + PR, CI is the gate (HARD)

--- a/docs/decisions/ADR-0009-fourth-repo-and-game-engineer-seat.md
+++ b/docs/decisions/ADR-0009-fourth-repo-and-game-engineer-seat.md
@@ -1,0 +1,94 @@
+# ADR-0009 — Give the Unreal client its own repo, and a Game Engineer seat to own it
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+- **Ratified by:** COO
+- **Closes:** none — the CEO granted the seat and chose the repo split in session on 2026-08-01, and
+  directed ratification. Recorded here because a CEO decision that never reaches this directory
+  binds nobody, and three sessions have already been lost to exactly that gap.
+- **Constrains:** anyone adding Unreal, game or renderer code; the repo-boundary rule in
+  `CLAUDE.md`; the role registry
+- **Enforced by:** `policy` — `turf` (via the new `feat/game/` prefix in `ROLES.md`) and
+  `ownership`. Partially convention-only in the new repo; see "How this is enforced".
+
+## Context
+
+The M3 scope introduces a real-time Unreal Engine 5 client: a player drives the ballasted
+onewheel with a gamepad while MuJoCo remains the sole physics authority and runs the real Rust
+control law at 500 Hz. Unreal renders and takes input; it computes no board physics.
+
+`CLAUDE.md` says **this repo is controls only** and names one sibling, `overboard-web`. The
+registry and `ROLES.md` describe an estate of three repos. Neither anticipated an interactive
+client, and the M3 work has nowhere to legally live.
+
+There was a real candidate already in the estate. `overboard-viz` was created on 2026-07-26 with
+a charter that is almost exactly the boundary M3 needs:
+
+> The renderer never computes physics. It replays motion MuJoCo already computed. [...] One file
+> crosses the boundary: a pose track. `overboard` writes it, `overboard-viz` reads it, and neither
+> imports the other.
+
+So the question was not "what should the boundary be" — that is settled and reused — but "does the
+Unreal client belong in the repo that already holds that boundary".
+
+## Decision
+
+**A fourth repo, `overboard-game`, owned by a new `Game Engineer` role.**
+
+- The Game Engineer escalates to the **COO**, and is a **peer of Senior Controls, not subordinate
+  to it**. Branch prefix `feat/game/`.
+- It owns `overboard-game` entirely and **owns nothing in `overboard` by design**, the same way the
+  CMO owns nothing here.
+- Senior Controls owns everything on the `overboard` side of the seam — the plant variant, the
+  real-time host, the wire crate, the observer.
+- **The wire schema is the contract between them**, exactly as the pose track is the contract
+  between `overboard` and `overboard-viz`. Neither repo imports the other.
+
+A change complies with this ADR if Unreal, game-asset and renderer-client code is in
+`overboard-game`, control law and physics are in `overboard`, and the only thing crossing is a
+versioned data contract.
+
+## Options considered
+
+**1. Extend `overboard-viz`.** Its charter already states the right boundary, and the existing
+pose track is the direct ancestor of the live wire schema. Rejected on two counts, either of which
+would have been sufficient. *Lifecycle:* viz is offline, batch, Blender; the game is interactive,
+real-time, multi-gigabyte UE assets and a game engine's build system. Sharing a repo means every
+cinematic render carries the game's checkout weight and vice versa. *Turf:* `ROLES.md` gives
+`overboard-viz` to **Digital Content Production**, which sits under the marketing line. The game is
+an engineering instrument that Senior Controls depends on. Merging them puts an engineering
+deliverable under the CMO's line and makes ownership ambiguous in the one place this org has
+repeatedly paid for ambiguity.
+
+**2. Put the Unreal client inside `overboard`.** Rejected. It voids the controls-only rule, and it
+puts game assets in the repo whose CI gates the control law — the `sim` and `rust` checks would
+start carrying engine build weight, and the margin gate is the last thing in this project that
+should get slower or flakier.
+
+**3. A fourth repo.** Chosen. Cost stated below.
+
+## Consequences
+
+**Easier.** Independent lifecycles and build systems. The controls repo stays controls only, so
+the sim-in-the-loop gate cannot be slowed or destabilised by game work. The game cannot
+accidentally contaminate a controls claim, which matters because M3 deliberately ships a
+non-physical steering channel.
+
+**Harder.** The estate grows to four repos, and `overboard-game` starts with **no CODEOWNERS**, so
+path ownership there is unfalsifiable — this widens the open item already recorded in ADR-0002
+rather than introducing a new class of problem. Cross-repo version pinning now applies to the wire
+schema. One more session and worktree to keep in step, against an org that has already lost days
+to sessions waiting on each other.
+
+**Who moves.** The COO registers the seat and carries the registry → Notion mirror. Senior Controls
+picks up the `overboard`-side seam work. The Game Engineer picks up the new repo.
+
+## How this is enforced
+
+- **In `overboard`:** the `ROLES.md` row declares `feat/game/`, which makes the `turf` check live
+  for this role immediately. Because the Game Engineer owns no path here, any edit it makes in this
+  repo is a trespass and CI will say so — which is the intended behaviour, not an oversight.
+- **In `overboard-game`:** **convention only, stated honestly.** Until that repo has a CODEOWNERS
+  the ownership leg does not exist, so the seat stays `Provisional` — the same reason the Senior
+  Digital Marketer could not be ratified until `overboard-web` got one (ported in overboard-web#35).
+  The flag follows the artefact, not the other way round.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -31,6 +31,7 @@ primitive the org has.
 | [0006](ADR-0006-one-worktree-per-role.md) | One git worktree per role | Accepted | Where every session may work |
 | [0007](ADR-0007-delegation-dispatch-and-utilization.md) | Delegation: board → issues → dispatch | Accepted | How work flows downward, and the concurrency cap |
 | [0008](ADR-0008-documentation-drift.md) | Two doc tiers; drift caught at PR time | Accepted | Anyone changing code a doc describes |
+| [0009](ADR-0009-fourth-repo-and-game-engineer-seat.md) | Fourth repo for the Unreal client, and a Game Engineer seat | Accepted | Where game/renderer code may live; the repo-boundary rule |
 
 **Roles:** [`ROLES.md`](ROLES.md) is the single home for the role list — `policy` parses it.
 `python3 .github/policy_check.py --who <path>` answers "who owns this?".

--- a/docs/decisions/ROLES.md
+++ b/docs/decisions/ROLES.md
@@ -45,6 +45,7 @@ All-three-or-none is the definition of `Ratified`. It is **not** a precondition 
 | `Sr. Mechanical & Systems` | Ratified | `COO` | `feat/mech/` | BoM, platform selection, the bench rig, the sim-to-hardware fidelity contract |
 | `Senior Controls` | Ratified | `COO` | `feat/controls/` | The control law and its harness |
 | `Archivist` | Ratified | `CEO` | `feat/archive/` | Strategy-tier Notion, shared vocabulary across all three repos, drift tooling. Owns `docs/vocabulary/` and no other repo path |
+| `Game Engineer` | Provisional | `COO` | `feat/game/` | The Unreal client in `overboard-game` — rendering, gamepad input, world authoring, avatar. **Peer of Senior Controls, not subordinate to it.** Owns nothing in this repo by design; the wire schema is the seam between them. See ADR-0009 |
 
 ✅ **Branch prefixes for `Sr. Mechanical & Systems` (`feat/mech/`) and `Senior Controls`
 (`feat/controls/`) are now OBSERVED**, not inferred — both appear repeatedly in merged branch
@@ -76,6 +77,12 @@ no pretence of automation.
 
 ## Repo scope
 
-This registry covers all three repos — `overboard`, `overboard-web`, `overboard-viz`. Only
-`overboard` has a `CODEOWNERS` today, so "do not edit paths another role owns" is still
-unfalsifiable in two thirds of the estate. Open item in ADR-0002.
+This registry covers all four repos — `overboard`, `overboard-web`, `overboard-viz`, and
+`overboard-game` (added by ADR-0009). **Two of the four have a `CODEOWNERS`:** `overboard`, and
+`overboard-web` since overboard-web#35. So "do not edit paths another role owns" remains
+unfalsifiable in `overboard-viz` and `overboard-game`. Open item in ADR-0002.
+
+This is also the concrete reason `Game Engineer` is `Provisional` rather than `Ratified`: the
+ownership leg of the three cannot exist until `overboard-game` has a `CODEOWNERS`. The flag
+follows the artefact. It does not block the role from working — see "Existence is not
+ratification" above.

--- a/roles/coo/log/2026-08-01-game-engineer-seat-and-fourth-repo.md
+++ b/roles/coo/log/2026-08-01-game-engineer-seat-and-fourth-repo.md
@@ -1,0 +1,55 @@
+# 2026-08-01 — a Game Engineer seat, a fourth repo, and the M3 planning set
+
+## Headline
+
+The CEO scoped **M3 — a rider-driven Unreal client with post-ride reconstruction** — in session,
+granted a **Game Engineer** seat, and directed that the Unreal work live in its own repo. This
+entry covers the paperwork that makes those decisions bind: ADR-0009, the registry row, and the
+repo-boundary amendment.
+
+## What landed
+
+| Thread | |
+|---|---|
+| **ADR-0009** | Fourth repo `overboard-game` for the Unreal client; `Game Engineer` seat owns it |
+| **Registry** | `Game Engineer` added as `Provisional` — escalates to COO, `feat/game/`, peer of Senior Controls |
+| **`CLAUDE.md`** | Repo boundary rewritten from two named repos to four, with the "nothing outside this repo computes board physics" rule stated once for both renderers |
+| **Notion** | M3 Scope, M3 Implementation Plan, and design docs D6–D9, all under Program Plan & Roadmap |
+| **#156** | Sensor procurement raised to Sr. Mechanical & Systems — 9-axis IMU + GNSS into the BoM |
+
+## The thing worth carrying forward
+
+**The boundary M3 needs was already written down, in a repo nobody thought to look at.**
+
+`overboard-viz`'s README has stated since 2026-07-26 that the renderer never computes physics and
+that exactly one data contract crosses. That is precisely the architecture the Unreal client needs,
+and it was rediscovered from first principles in conversation before anyone checked whether it
+already existed. It did.
+
+So ADR-0009 is deliberately *not* a new boundary — it reuses viz's and says so. The only genuine
+question was whether the Unreal client belonged **in** viz, and that turned on lifecycle (offline
+Blender vs. a real-time engine with multi-gigabyte assets) and on turf (viz sits under Digital
+Content Production, on the marketing line; the game is an engineering instrument Senior Controls
+depends on). Those two, not the boundary, are what produced a fourth repo.
+
+The generalisation: **go and look at the estate before designing something the estate already has.**
+This org's repo READMEs are load-bearing documents and they are cheaper to read than to re-derive.
+
+## Registry accuracy repaired in passing
+
+`ROLES.md`'s "Repo scope" claimed only `overboard` had a `CODEOWNERS`, "unfalsifiable in two thirds
+of the estate". Stale — `overboard-web` got one in overboard-web#35, which is the same PR the SDM's
+ratification note in this very file already cites. Corrected to two of four, with `overboard-viz`
+and `overboard-game` named as the gaps.
+
+That is the second time a claim in this registry drifted from an artefact the registry itself
+mentions. Worth a check that reads the repos rather than trusting the prose, if it happens again.
+
+## Open, and owed by me
+
+- **`overboard-game` has no `CODEOWNERS`**, which is why the seat is `Provisional` and not
+  `Ratified`. The flag follows the artefact.
+- **Notion Escalations select** needs a `Game Engineer` option — registry → Notion, never back.
+- **Session start/teardown prompt** for the new role.
+- The CEO has not yet said whether M3 sits inside the **D0 ready-to-code gate**. D6–D9 carry numeric
+  acceptance criteria either way, so the answer changes the process, not the documents.


### PR DESCRIPTION
## What changed

The CEO scoped **M3 — a rider-driven Unreal client with post-ride reconstruction** in session on 2026-08-01, granted a **Game Engineer** seat, and directed that the Unreal work live in its own repo. This is the paperwork that makes those decisions bind, since a CEO decision that never reaches `docs/decisions/` binds nobody.

| File | Change |
|---|---|
| `ADR-0009` (new) | Ratifies a fourth repo, `overboard-game`, and the Game Engineer seat that owns it |
| `ROLES.md` | `Game Engineer` added as `Provisional` — escalates to **COO**, prefix `feat/game/`, peer of Senior Controls |
| `INDEX.md` | ADR-0009 row |
| `CLAUDE.md` | Repo boundary rewritten from two named repos to four |
| `roles/coo/log/` | Session entry |

## Why a fourth repo rather than extending `overboard-viz`

**The boundary M3 needs was already written down.** `overboard-viz`'s README has said since 2026-07-26 that the renderer never computes physics and that exactly one data contract crosses. ADR-0009 deliberately *reuses* that boundary rather than inventing one, and says so.

The only real question was whether the Unreal client belonged **inside** viz. Two things said no, either sufficient on its own:

- **Lifecycle** — viz is offline, batch, Blender. The game is interactive, real-time, multi-gigabyte UE assets and a game engine's build system.
- **Turf** — `ROLES.md` gives `overboard-viz` to Digital Content Production, on the marketing line. The game is an engineering instrument Senior Controls depends on.

Putting it in `overboard` was also rejected: it voids the controls-only rule and puts engine build weight on the `sim` and `rust` checks that gate the control law.

## Provisional, not Ratified

`overboard-game` has no `CODEOWNERS`, so the ownership leg of the three cannot exist yet. Same reason the SDM waited on overboard-web#35 — the flag follows the artefact. This does **not** block the role from working; see "Existence is not ratification".

## Turf override

`CLAUDE.md` is CEO-owned. The edit carries `TURF-OVERRIDE:` in the commit message with the CEO's in-session direction as the reason, and is confined to the repo-boundary section ADR-0009 amends. Local `policy` run: all hard checks pass, override recognised.

## Registry accuracy repaired in passing

`ROLES.md` claimed only `overboard` had a `CODEOWNERS` and that ownership was "unfalsifiable in two thirds of the estate". That has been wrong since overboard-web#35 — which the same file cites elsewhere. Now stated as two of four, with `overboard-viz` and `overboard-game` named as the gaps.

## Acceptance criteria touched

None moved. This is governance, not capability. The M3 requirements (`SR-GAME-*`) live in Notion and are not yet mirrored into the traceable Requirements doc — that follows scope approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)