### PR TITLE
ops(coo): fix the game wire for the weekend, because the two sides cannot talk (ADR-0010)

### DIFF
--- a/docs/decisions/ADR-0010-game-wire-v1-fixed-for-the-launch-weekend.md
+++ b/docs/decisions/ADR-0010-game-wire-v1-fixed-for-the-launch-weekend.md
@@ -1,0 +1,118 @@
+# ADR-0010 — The game wire v1 is fixed by the COO for the launch weekend, and expires
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+- **Ratified by:** COO
+- **Closes:** none — CEO direction, 2026-08-01 (formal approval of the M3 Revision 3 re-cut)
+- **Constrains:** `sim-host` in `overboard`; the UE client in `overboard-game`; both until superseded
+- **Enforced by:** a compile-time size assertion and a byte-size unit test in `sim-host`, plus
+  fail-loud `magic`/`schema_version` rejection on both sides
+- **Expires:** Tuesday 2026-08-04, when schema ownership reverts to Senior Controls per ADR-0009
+
+## Context
+
+M3 was re-cut on 2026-08-01 to a Monday launch ([M3 Implementation Plan § Revision 3]). The
+launch artifact is a playable game. W1 — the pose spine — is Senior Controls building a 500 Hz
+`sim-host` in `overboard` and the Game Engineer building a UE client in `overboard-game`, in
+parallel, overnight.
+
+[ADR-0009](ADR-0009-fourth-repo-and-game-engineer-seat.md) assigns the wire schema to Senior
+Controls: *"Senior Controls owns everything on the `overboard` side of the seam — the plant
+variant, the real-time host, the wire crate."* Issue [#161](https://github.com/MikePaNtZ/overboard/issues/161)
+and [#162](https://github.com/MikePaNtZ/overboard/issues/162) both instruct the two roles to
+*"talk continuously — this is not a handoff."*
+
+**They cannot.** Sessions in this org cannot message each other; that is the first line of
+[INDEX.md](INDEX.md). The two available orderings are both bad:
+
+- **Serialise** — Controls defines the wire, then Game builds against it. Costs the Game
+  Engineer the entire night, on the side whose W3 (*enjoyable*) has the least slack.
+- **Parallelise and reconcile in the morning** — each side invents a schema. The failure is not
+  a clean compile error; it is a plausible-looking float misparse. The plan names the frame
+  transform as one of three things that *"silently poison everything downstream if wrong."*
+
+A schema neither side can unilaterally change is worth more this weekend than a schema designed
+by the role that will eventually own it.
+
+## Decision
+
+**1. The COO fixes wire v1, as a coordination act, and says so.** This is a deliberate,
+time-boxed deviation from ADR-0009's ownership assignment. It is recorded rather than done
+quietly, because a seam silently re-owned is exactly the drift this record exists to catch.
+Ownership reverts to Senior Controls on Tuesday. Both roles received the schema below verbatim
+in their dispatch brief.
+
+**2. The schema.** Little-endian, `#[repr(C)]`, field order as listed.
+
+**State out** — host → renderer. Host **sends** to `127.0.0.1:9601`.
+
+| field | type | notes |
+|---|---|---|
+| `magic` | u32 | `0x4F425731` ("OBW1") |
+| `schema_version` | u16 | `1` |
+| `flags` | u16 | bit0 armed, bit1 valid, bit2 fallen |
+| `seq` | u64 | monotonic tick counter |
+| `sim_time_s` | f64 | MuJoCo sim time |
+| `pos` | f32[3] | **raw MuJoCo world frame** — metres, Z-up, right-handed |
+| `quat` | f32[4] | **w,x,y,z**, raw MuJoCo |
+| `wheel_angle_rad` | f32 | |
+| `wheel_rate_rad_s` | f32 | positive = forward |
+| `pitch_rad` | f32 | nose-up positive (ICD §10.1) |
+| `yaw_rad` | f32 | **non-physical game channel** |
+| `motor_current_a` | f32 | applied current |
+
+**Input in** — renderer → host. Host **binds** `127.0.0.1:9602`.
+
+| field | type | notes |
+|---|---|---|
+| `magic` | u32 | `0x4F424931` ("OBI1") |
+| `schema_version` | u16 | `1` |
+| `flags` | u16 | bit0 arm, bit1 reset |
+| `seq` | u64 | |
+| `weight_shift_fore_aft` | f32 | clamped [-1,1] |
+| `weight_shift_lateral` | f32 | clamped [-1,1] |
+| `steer` | f32 | clamped [-1,1] — **non-physical** |
+
+**3. The host emits the raw MuJoCo frame; the renderer owns the conversion.** MuJoCo is metres,
+Z-up, right-handed. Unreal is centimetres, Z-up, left-handed. One side owns that transform and it
+is the game side, in one named function.
+
+The reason it goes to the renderer rather than the host: the host's output is also what
+diagnostics and every later analysis path read, and those are all MuJoCo-frame consumers. A host
+that pre-converted to Unreal's basis would make the renderer cheap and every controls consumer
+pay a conversion back — and a controls number that had silently round-tripped through a
+left-handed basis is precisely the class of error that is unfalsifiable after the fact.
+
+**4. A mismatch fails loudly.** Wrong `magic` or `schema_version` is logged and dropped, never
+parsed. This is the ABI discipline of `ob_abi_version()` and `size`-tagged structs applied to the
+wire, as ADR-0009 requires.
+
+**5. The input socket must never block the 500 Hz loop.** Non-blocking; most-recent-packet-wins;
+stale input decays to zero on a documented timeout.
+
+**6. `yaw_rad` and `steer` are non-physical and must be labelled so in code.** The simulated wheel
+is a cylinder and physically cannot carve. This is not a comment-quality preference: it is the
+input to the `Playable Sim` channel declaration ([#163](https://github.com/MikePaNtZ/overboard/issues/163)),
+which is a launch blocker. A channel that is invented in code and unlabelled becomes a public
+claim that is false.
+
+## Consequences
+
+**Good.** Both sides build overnight against one contract neither can drift from. The frame
+transform has exactly one owner and one implementation. The non-physical channels are named in
+the schema itself, so the claims work downstream has a source rather than a recollection.
+
+**Bad, and accepted.** The COO has specified an interface it does not own and will not maintain.
+That is justified for 48 hours by the no-messaging constraint and by nothing else. If v1 survives
+past Tuesday unexamined, this ADR has failed and the fix is Senior Controls superseding it.
+
+**Deliberately absent.** v1 carries no rider-ballast state, no terrain, no record/replay fields
+and no MCAP mapping. All are cut from the weekend and none are cancelled. Adding a field is a
+version bump, which is cheap by construction — the schema is designed to be outgrown, not to be
+complete.
+
+**The enforcement is a test, not this document.** Per the standing lesson that documentation is a
+polling surface: the binding artifacts are the size assertion and the fail-loud version check in
+code. If those disagree with the table above, the code is right and this ADR is stale.
+
+[M3 Implementation Plan § Revision 3]: https://app.notion.com/p/3af472a5fb6981f5b6e4ec038293ad6f

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -32,6 +32,7 @@ primitive the org has.
 | [0007](ADR-0007-delegation-dispatch-and-utilization.md) | Delegation: board → issues → dispatch | Accepted | How work flows downward, and the concurrency cap |
 | [0008](ADR-0008-documentation-drift.md) | Two doc tiers; drift caught at PR time | Accepted | Anyone changing code a doc describes |
 | [0009](ADR-0009-fourth-repo-and-game-engineer-seat.md) | Fourth repo for the Unreal client, and a Game Engineer seat | Accepted | Where game/renderer code may live; the repo-boundary rule |
+| [0010](ADR-0010-game-wire-v1-fixed-for-the-launch-weekend.md) | Game wire v1, fixed by the COO for the launch weekend | Accepted ⏳ *expires Tue 2026-08-04* | `sim-host` and the UE client; the MuJoCo↔Unreal frame transform |
 
 **Roles:** [`ROLES.md`](ROLES.md) is the single home for the role list — `policy` parses it.
 `python3 .github/policy_check.py --who <path>` answers "who owns this?".

--- a/roles/coo/log/2026-08-01-w0-launch-weekend-dispatch.md
+++ b/roles/coo/log/2026-08-01-w0-launch-weekend-dispatch.md
@@ -1,0 +1,139 @@
+# 2026-08-01 — W0: the CEO's formal approval, and the launch weekend dispatched
+
+**Window:** W0 (Sat evening), per [M3 Implementation Plan § Revision 3].
+**Exit criterion:** *both sessions running against a written brief.* Met — three, not two.
+
+## The approval
+
+The CEO gave **formal approval to execute the weekend plan**, in full, on 2026-08-01. Revision 3
+had carried the design-gate waiver as *"conditionally approved by the CEO, formal approval pending
+his read of § What the CEO must read."* That condition is now discharged.
+
+What the approval actually licenses, stated plainly so no session over-reads it:
+
+- **D6–D9 do not gate W1–W4.** This waiver is for **this weekend only** and expires Monday. It is
+  not a precedent, and the design-gate rule in `CLAUDE.md` is untouched from Tuesday.
+- **The fallback ladder is live and pre-decided**, so nobody renegotiates it at 2 a.m.:
+  visuals slip → ship it ugly; roll unplayable → widen the geom further and lean on the yaw
+  limiter; **host cannot be wired → do NOT fake the physics.** Fall back to existing sim content
+  and hold the game. Both engineering briefs carry that ladder verbatim.
+- The approval does **not** touch public claims. Those are the CEO's own reserved turf and land
+  Sunday evening (W4).
+
+## What I did before dispatching, and what it changed
+
+**Went and looked rather than asking.** Three facts decided whether the weekend was real:
+
+1. **The spine already exists.** `crates/sim-backend/src/lib.rs` already couples `plant-mujoco` and
+   `control-ffi` in a closed loop at 500 Hz (`CYCLE_NS`, ICD §11.2), and
+   `tests/test_rust_hosted_impulse_response.py` proves the Rust-hosted loop runs today. W1 is a
+   real-time thread and a socket around a working system — **not new construction.** The brief says
+   so explicitly, because an agent that believes it must build a simulator will build one.
+2. **The toolchain is present.** UE 5.7 installed; `cargo` 1.97.1 — but **not on `PATH` in
+   non-interactive shells**, which is a real trap and is stated in the brief as `~/.cargo/bin/cargo`.
+3. **`overboard-game` was not cloned locally.** The repo existed on GitHub and nowhere on this
+   machine, so the Game Engineer seat had no working directory. Cloned to `~/projects/overboard-game`.
+   This was a hard W0 blocker and it was invisible from the issue tracker.
+
+## The one decision I made rather than delegated
+
+**Wire v1 is fixed by me** — [ADR-0010](../../../docs/decisions/ADR-0010-game-wire-v1-fixed-for-the-launch-weekend.md).
+
+Both briefs instruct the two roles to *"talk continuously — this is not a handoff."* They cannot:
+sessions in this org cannot message each other. Serialising costs the Game Engineer the whole
+night; parallelising without a fixed contract produces a float misparse rather than a compile
+error, and the plan itself names the frame transform as one of three things that *"silently poison
+everything downstream."*
+
+So both sides got the identical schema verbatim, plus the frame-ownership split: **the host emits
+raw MuJoCo, the renderer converts.** ADR-0009 gives the wire to Senior Controls, so this is a
+deviation — recorded, time-boxed, and reverting Tuesday. Recording it is the point; a seam quietly
+re-owned is the drift the decision record exists to catch.
+
+## Dispatched — three, which is the ADR-0007 cap
+
+Gate run first: `ops/dispatch.sh --audit` green (22 open issues, 4 repos, exactly one `role:` label
+each). All three target worktrees clean.
+
+| Role | Issue | Branch | Brief |
+|---|---|---|---|
+| Senior Controls | [#161](https://github.com/MikePaNtZ/overboard/issues/161) | `feat/controls/sim-host-spine` | `sim-host`: 500 Hz dedicated thread, real control law, UDP both ways |
+| Game Engineer | [#162](https://github.com/MikePaNtZ/overboard/issues/162) | `feat/game/pose-spine` | UE5 client, board actor, socket, frame transform |
+| Archivist | [#163](https://github.com/MikePaNtZ/overboard/issues/163) | `feat/archive/playable-sim-category` | `Playable Sim` provenance category — launch blocker |
+
+Two things I put in the briefs that the issues did not ask for, both to make the milestone
+**checkable rather than asserted**:
+
+- **A `wire-probe` binary** on the controls side — a headless receiver reporting measured tick
+  rate, inter-packet p50/p99/max, missed-deadline count and pitch bounds. The CEO can read whether
+  the board is being held up by the real controller **without Unreal building at all**, which
+  decouples the milestone from the slowest and least certain toolchain in the weekend.
+- **Prove the wire before generating the UE project** on the game side. Wire parsing and the
+  handedness flip compile and run without the editor; the editor build is the risky part. Doing
+  them in that order means a UE toolchain failure costs the schema work nothing.
+
+## The second W0 blocker, found the hard way — and the control that worked
+
+The Game Engineer came back inside three minutes, having written **nothing**. The write-guard
+hook `~/.claude/ops/overboard-guard.py` keeps a hand-vetted `VETTED_REPOS` allowlist, and
+`overboard-game` was not on it. Every `Write`/`Edit` and every Bash redirect into the repo was
+denied. `git` was not guarded, which is why the branch checkout had succeeded and the block only
+appeared at the first attempt to author file contents.
+
+**The session declined to add itself to the allowlist**, citing the guard's own comment that the
+`overboard-metrics` entry was *"vetted by the COO — deliberately NOT by the session that wanted
+the access."* That is the correct call, and worth recording for a reason beyond politeness: the
+convention was written down once, in a comment, after the fact — and it **held on first contact
+with a role that had never seen it.** That is a control that actually works, unlike the two checks
+this org shipped last week that reported green while enforcing nothing.
+
+So I vetted it, to the evidence standard that entry set — checked rather than assumed:
+repo is PUBLIC per ADR-0009 intent; two tracked files (`README.md`, `.github/CODEOWNERS`);
+**no workflows at all**, so nothing runs on checkout or push; no exec bits; zero matches for
+token/secret/key/password/PRIVATE-KEY patterns. Added it, then **verified the guard still parses
+and now admits the path** rather than assuming the edit took.
+
+Recorded a caveat with it, because this one will not stay true: the repo is **about to become an
+Unreal project**, and UE drops generated build scripts and third-party binaries that none of the
+above was checked against. The entry vets the repo *as it is today* and says so.
+
+Two follow-ups this exposes, neither launch-critical:
+
+- **`ops/dispatch.sh` cannot see this failure mode.** Its gate checks routing, cleanliness and the
+  concurrency cap — not whether the target repo is writable by the session about to be dispatched
+  into it. A dispatch that cannot write is indistinguishable from one that has not started yet.
+  Worth a pre-flight write probe.
+- **The Game Engineer's third ratification leg now exists.** `overboard-game/.github/CODEOWNERS`
+  is present and correctly `# role:`-tagged, which is the exact thing ROLES.md names as the reason
+  the seat is `Provisional`. Registry entry ✅, CODEOWNERS ✅, Notion select option unverified.
+  Not chased tonight — `Provisional` restricts none of this weekend's work — but the seat is one
+  checked box from `Ratified` and I own that paperwork.
+
+## Housekeeping done in passing
+
+My own worktree was sitting on `fix/ops/adr-0009-boundary-claim`, whose PR
+[#158](https://github.com/MikePaNtZ/overboard/pull/158) had **already merged**. Master had since
+moved on with [#164](https://github.com/MikePaNtZ/overboard/pull/164), so the stale branch's diff
+against master was a **289-line revert of the CMO's launch re-cut**. Opening a PR from it would
+have destroyed another role's work tonight, silently, while everyone was busy.
+
+Reset to `origin/master`. Filing under the standing dead end *"do not trust worktree state"* — the
+new edge is that **a merged branch is more dangerous than an unmerged one**, because it looks
+finished and its diff has quietly inverted into a revert. Worth a check in `dispatch.sh`: refuse to
+dispatch from a branch whose PR is already merged.
+
+Also noted and **not** acted on: the primary `~/projects/overboard` worktree is stale
+(`primary-current` @ 811e672, several PRs behind). It misled me once tonight — `ADR-0009` looked
+missing from `INDEX.md` and was not. Not touched, per the standing rule against working there.
+
+## Open, going into W1
+
+- The measured host numbers do not exist yet. **No claim about 500 Hz is safe until `wire-probe`
+  prints one**, and the `Playable Sim` rules make loop rate a machinery fact we are permitted to
+  state — so it will be stated, and it must therefore be measured rather than inherited from
+  `CYCLE_NS`.
+- Whether UE 5.7 builds headlessly on this machine is unknown. The briefs are sequenced so the
+  answer is cheap either way.
+- W4's claims work depends on #163 landing **before footage exists**, not before launch.
+
+[M3 Implementation Plan § Revision 3]: https://app.notion.com/p/3af472a5fb6981f5b6e4ec038293ad6f


### PR DESCRIPTION
**W0 of the [M3 Revision 3](https://app.notion.com/p/3af472a5fb6981f5b6e4ec038293ad6f) launch re-cut.** The CEO's formal approval landed today, discharging the condition Revision 3 carried and waiving the design gate **for this weekend only**.

## What changed and why

**ADR-0010 — the COO fixes game wire v1, and it expires Tuesday.**

Issues #161 and #162 both instruct Senior Controls and the Game Engineer to *"talk continuously — this is not a handoff."* **They cannot.** Sessions in this org cannot message each other; that is the first line of `INDEX.md`. Both available orderings are bad:

- **Serialise** — Controls defines the wire, then Game builds against it. Costs the Game Engineer the entire night, on the side whose W3 (*enjoyable*) has the least slack.
- **Parallelise without a contract** — each side invents a schema, and the failure is not a clean compile error but a plausible-looking float misparse. The plan names the frame transform as one of three things that *"silently poison everything downstream if wrong."*

So both sides received the identical schema verbatim in their dispatch brief.

**ADR-0009 assigns the wire to Senior Controls, so this is a deviation.** It is recorded rather than done quietly, time-boxed, and ownership reverts Tuesday — a seam silently re-owned is exactly the drift this record exists to catch.

## The frame-ownership split

The host emits **raw MuJoCo** (metres, Z-up, right-handed); the renderer owns the conversion to Unreal's left-handed centimetres, in one named function. The host's output is also what diagnostics and every later analysis path read, and those are all MuJoCo-frame consumers — a controls number that had silently round-tripped through a left-handed basis is precisely the class of error that is unfalsifiable after the fact.

## Acceptance criteria that moved

- **W0 exit — *both sessions running against a written brief*: met.** Three dispatched (#161 Senior Controls, #162 Game Engineer, #163 Archivist), which is the ADR-0007 concurrency cap. Routing audit green first.
- The `Playable Sim` channel declaration (#163) now has a **source rather than a recollection**: `yaw_rad` and `steer` are marked non-physical in the schema itself.

## Enforcement

Per the standing lesson that documentation is a polling surface, the binding artifacts are **a compile-time size assertion and a fail-loud `magic`/`schema_version` check in code** — not this ADR. If they disagree with the table, the code is right and the ADR is stale.

`policy` run as CI runs it (`GITHUB_ACTIONS=1 POLICY_BRANCH=… POLICY_BASE_REF=origin/master`) — all hard checks pass; the advisories listed are pre-existing and untouched.

The log entry also records two W0 blockers that were invisible from the issue tracker, and one near-miss: my worktree was sitting on an **already-merged** branch whose diff against master had inverted into a **289-line revert of the CMO's launch re-cut**.