### PR TITLE
feat(vocabulary): a fifth category for live game footage — Playable Sim (#163)

### DIFF
--- a/docs/vocabulary/README.md
+++ b/docs/vocabulary/README.md
@@ -25,6 +25,15 @@ Lane B          -> Concept
 Plus any term whose misuse would mislead — particularly ones that could put an unbacked
 capability claim in front of the public.
 
+**Also `provenance-marks.json`** — the inverse of the mapping above. Some on-frame marks
+carry an obligation that a tag alone cannot discharge: the mark being present *requires*
+other text to also be present. **Playable Sim** is the first of these (#163) — a
+`PLAYABLE SIM` mark with no non-physical channel declaration nearby is exactly the failure
+that category exists to prevent, because it is the only category where some of what is on
+screen is physics and some of it is not. `sweep_public.py` treats a mark with no matching
+declaration as an `error`-severity finding, scoped the same as the vocabulary check: open
+items only, never rewriting a past asset's declaration to match a later, longer one.
+
 ## What does not belong here
 
 Definitions, rationale, or the argument for a term. Those are Notion's. Keep this file
@@ -48,3 +57,10 @@ mistakes made during the sweep it was built from:
   four documents were scored "handled" on the strength of a banner at the top while still
   restating the retired definition further down, and two of those restatements had already
   gone false.
+
+**2026-08-01 — fifth category, `Playable Sim` (#163), and `provenance-marks.json`.** The four
+categories became five before any footage existed: game capture is live, unrecorded and
+unreproducible, so it fit none of `Footage · Sim Replay · Hardware Replay · Concept`. Landed
+in Shared Vocabulary § 1, mirrored here. Playable Sim also introduced the first
+required-presence check — see "What belongs here" above — because it is the only category
+where a tag alone cannot tell a viewer which part of the frame is physics.

--- a/docs/vocabulary/provenance-marks.json
+++ b/docs/vocabulary/provenance-marks.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "owner": "Archivist",
+  "canonical_definitions": "https://app.notion.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b",
+
+  "_comment": [
+    "Machine-readable record of on-frame provenance marks that carry an extra",
+    "REQUIRED-presence obligation beyond the tag itself. Data only -- no",
+    "definitions, no rationale. Those live in Shared Vocabulary (canonical) sec 1,",
+    "the page named above.",
+    "",
+    "This is the inverse of retired-terms.json. That file says a pattern must NOT",
+    "appear (or must appear only next to a canonical link). This file says a",
+    "pattern -- an on-frame mark -- being present creates an obligation for OTHER",
+    "patterns to also be present on the same page. Consumed by sweep_public.py.",
+    "",
+    "Added 2026-08-01 for the Playable Sim category (#163). Playable Sim is the",
+    "only category where a tag alone cannot tell a viewer which part of what they",
+    "are looking at is physics and which is not -- so the mark is not enough; the",
+    "full non-physical channel declaration has to travel with it, every time.",
+    "",
+    "Scope note: checked over OPEN issues only, same reasoning as retired-terms.json",
+    "-- a past asset's declaration is the record of what was known at the time and",
+    "is never rewritten to match a later, longer declaration."
+  ],
+
+  "marks": [
+    {
+      "id": "playable-sim",
+      "category": "Playable Sim",
+      "on_frame_mark": "PLAYABLE SIM",
+      "mark_pattern": "\\bPLAYABLE SIM\\b",
+      "requires_channel_declaration": true,
+      "channel_declaration": {
+        "_note": [
+          "Every channel invented or diverged from the hardware model, stated",
+          "wherever the asset appears. For Monday's launch these are the four",
+          "required lines. Extend this list as new non-physical channels are added",
+          "-- do not silently shrink it: a shorter declaration on a later asset is",
+          "itself a finding, not a simplification."
+        ],
+        "required_patterns": [
+          {
+            "id": "steering-invented",
+            "pattern": "steering[^.]{0,60}(invented|cylinder)",
+            "note": "The simulated wheel is a cylinder and physically cannot carve."
+          },
+          {
+            "id": "wheel-widened",
+            "pattern": "wheel[^.]{0,60}widened",
+            "note": "The wheel is widened for playability."
+          },
+          {
+            "id": "rigid-ballast",
+            "pattern": "rigid ballast|not a person",
+            "note": "The rider is a rigid ballast, not a person."
+          },
+          {
+            "id": "no-hardware",
+            "pattern": "no(?:body| one)[^.]{0,60}ridden|no hardware exists",
+            "note": "Nobody has ridden anything, because no hardware exists."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/vocabulary/sweep_public.py
+++ b/docs/vocabulary/sweep_public.py
@@ -33,8 +33,19 @@ vocabulary page. That is the duplication rule enforcing itself: the only legal
 way to name a retired term is to say where the current definition lives.
 
 Data lives beside this script and is owned by the Archivist:
-`retired-terms.json`, `disclosure-patterns.json`. The script is deliberately
-dumb about policy -- to change what is enforced, edit the data, not this file.
+`retired-terms.json`, `disclosure-patterns.json`, `provenance-marks.json`.
+The script is deliberately dumb about policy -- to change what is enforced,
+edit the data, not this file.
+
+PROVENANCE MARKS -- THE INVERSE CHECK
+--------------------------------------
+`retired-terms.json` says a pattern must NOT appear. `provenance-marks.json`
+(added for the Playable Sim category, #163) says the opposite: an on-frame
+mark being present creates an obligation for OTHER text -- the non-physical
+channel declaration -- to also be present on the same page. Playable Sim is
+the only category where a tag alone cannot tell a viewer which part of what
+they are looking at is physics and which is not, so a `PLAYABLE SIM` mark
+with no declaration nearby is exactly the failure this check exists to catch.
 """
 
 from __future__ import annotations
@@ -97,6 +108,54 @@ def compile_rules() -> tuple[list, list, re.Pattern | None]:
     return rules, vocab, exempt
 
 
+def compile_marks() -> list[dict]:
+    """Load provenance-marks.json. Optional -- absence just means nothing to check yet."""
+    mf = HERE / "provenance-marks.json"
+    if not mf.exists():
+        return []
+    data = json.loads(mf.read_text())
+    marks = []
+    for m in data.get("marks", []):
+        if not m.get("requires_channel_declaration"):
+            continue
+        required = [
+            (r["id"], re.compile(r["pattern"], re.I))
+            for r in m.get("channel_declaration", {}).get("required_patterns", [])
+        ]
+        marks.append({
+            "id": m["id"],
+            "category": m["category"],
+            "mark_rx": re.compile(m["mark_pattern"]),
+            "required": required,
+        })
+    return marks
+
+
+def scan_declarations(text: str, url: str, marks: list[dict]) -> list[dict]:
+    """A tagged asset must carry its FULL channel declaration wherever it appears.
+
+    Unlike `scan()` this is not line-by-line: the declaration is a list and is
+    expected to span several lines, so the check is over the whole text. A mark
+    with no `marks` entry produces no findings -- this only fires for categories
+    that opted into the extra obligation.
+    """
+    hits = []
+    text = text or ""
+    for m in marks:
+        if not m["mark_rx"].search(text):
+            continue
+        missing = [rid for rid, rx in m["required"] if not rx.search(text)]
+        if missing:
+            hits.append({
+                "rule": f"{m['id']}-missing-declaration",
+                "severity": "error",
+                "url": url,
+                "match": m["category"],
+                "line": f"on-frame mark present but declaration missing: {', '.join(missing)}",
+            })
+    return hits
+
+
 def scan(text: str, url: str, rules: list, exempt: re.Pattern | None) -> list[dict]:
     """Scan text line by line so the canonical-link exemption can apply per line."""
     hits = []
@@ -133,8 +192,14 @@ def sweep(use_timeline: bool = True) -> list[dict]:
     correctly renamed*. Every one would have been a demand to corrupt the record.
     That is exactly the cry-wolf failure the anchors exist to prevent, arriving
     by a different door.
+
+    **Provenance-mark declarations run over OPEN items only, same reasoning.**
+    A past asset's declaration is the record of what was known at the time and
+    is never rewritten to match a later, longer declaration -- see
+    provenance-marks.json.
     """
     disclosure, vocab, exempt = compile_rules()
+    marks = compile_marks()
     findings: list[dict] = []
 
     for repo in REPOS:
@@ -148,6 +213,9 @@ def sweep(use_timeline: bool = True) -> list[dict]:
             rules = disclosure + vocab if live else disclosure
             findings += scan(it.get("title", ""), url, rules, exempt)
             findings += scan(it.get("body", ""), url, rules, exempt)
+            if live and marks:
+                whole = f"{it.get('title', '')}\n{it.get('body', '')}"
+                findings += scan_declarations(whole, url, marks)
 
         # Comments carry no state of their own; treat them as record, not live
         # document. Disclosure still applies -- a leak in a comment is a leak.


### PR DESCRIPTION
## Summary

Monday's launch artifact is a playable game — MuJoCo + the real control law running **live**, driven by a person at a controller. None of the existing four categories (Footage, Sim Replay, Hardware Replay, Concept) can honestly hold it:

- **Not Sim Replay** — that requires reproducibility (rule 2), and record-and-replay is explicitly cut from the weekend (#161, #162), so game footage cannot be regenerated from a committed pose track.
- **Not Concept** — the motion isn't authored, it comes out of MuJoCo and the real control law, and Concept may never carry an engineering number — which would forbid saying "500 Hz".

This is a **launch blocker** landing before any footage exists (Sunday evening per the plan), not before Monday's launch.

## What changed

- **Notion — [Shared Vocabulary (canonical)](https://app.notion.com/p/3aa472a5fb6981ebaaa7cf2e996f1e8b) § 1**: added the `Playable Sim` row (on-frame mark `PLAYABLE SIM`), a new subsection with the numbers split (machinery facts ✅ / behavioral results 🚫) and the non-physical channel declaration requirement. Re-fetched after the write and confirmed the table and every following section (§2–§4) survived intact — the known unclosed-table hazard did not recur.
- **Notion — [Session start prompts](https://app.notion.com/p/3ab472a5fb69819984f9c1bd44be9dea)**, Digital Content Production block: the copy-paste prompt DCP actually reads to open a session enumerated only the original four categories. Updated to include Playable Sim and the four required declaration lines for Monday. Re-fetched and verified.
- **`docs/vocabulary/README.md`**: status note for the new category, plus a description of the new required-presence mechanism.
- **`docs/vocabulary/provenance-marks.json`** (new): machine-readable record that a `PLAYABLE SIM` on-frame mark *requires* the channel declaration to also be present wherever it appears — the inverse of `retired-terms.json` (which says a pattern must *not* appear). Encodes the four required lines for Monday: steering invented, wheel widened, rigid ballast, nobody has ridden anything.
- **`docs/vocabulary/sweep_public.py`**: new `compile_marks()` / `scan_declarations()`, wired into `sweep()` at the same scope as the vocabulary check (open items only — a past asset's declaration is never rewritten to match a later, longer one). Verified against synthetic full/partial/absent-declaration text and a live `--no-timeline` run against real `gh` data (no new findings beyond one known pre-existing one, unrelated).

## Acceptance criteria from #163

- [x] `Playable Sim` in Shared Vocabulary § 1, with the numbers split and the channel declaration
- [x] Mirrored into `docs/vocabulary/`
- [x] Digital Content Production session-start prompt updated
- [x] Public-surface sweep knows the new mark — a `PLAYABLE SIM` asset missing its declaration is now an `error`-severity finding
- [ ] `roles/cmo/CONTEXT.md` — **not touched here.** See turf decision below.

## Turf decision: `roles/cmo/CONTEXT.md`

The issue offered the CMO would take this one rather than have the Archivist cross into `roles/cmo/` (CODEOWNERS-owned by CMO). **Decision: leaving it to the CMO.** It's their own standing-context file, cleanly inside their turf, and they explicitly offered. Called out as an open item in a comment on #163 rather than a `TURF-OVERRIDE`.

## Test plan

- [x] `python3 docs/vocabulary/sweep_public.py --no-timeline` runs clean against the new code path (no new findings)
- [x] Synthetic unit check of `scan_declarations()` against full / partial / absent declaration text
- [x] `python3 .github/policy_check.py` — all hard checks pass
- [x] Both Notion pages re-fetched post-write and confirmed structurally intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)