### PR TITLE
feat(controls): sim-host — the 500 Hz real closed loop over the game wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sim-host"
+version = "0.1.0"
+dependencies = [
+ "board-types",
+ "control-core",
+ "hal",
+ "hal-actuate",
+ "safety",
+ "sim-backend",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/canary-ridden",
     "crates/can-harness",
     "crates/plant-mujoco",
+    "crates/sim-host",
     "crates/xtask",
 ]
 

--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -54,6 +54,8 @@ extern "C" {
     fn plant_mujoco_body_id(model: *mut c_void, name: *const c_char) -> c_int;
     fn plant_mujoco_set_xfrc_applied(data: *mut c_void, body_id: c_int, frc6: *const f64);
     fn plant_mujoco_get_body_xmat(data: *mut c_void, body_id: c_int, out: *mut f64);
+    fn plant_mujoco_get_body_xpos(data: *mut c_void, body_id: c_int, out: *mut f64);
+    fn plant_mujoco_get_body_xquat(data: *mut c_void, body_id: c_int, out: *mut f64);
 }
 
 /// The linked libmujoco's own `mj_versionString()`.
@@ -339,6 +341,30 @@ impl Plant {
         // SAFETY: `self.data` is non-null and owned for the life of `self`;
         // `out` has exactly the 9 elements `xmat`'s per-body stride expects.
         unsafe { plant_mujoco_get_body_xmat(self.data, body_id as c_int, out.as_mut_ptr()) };
+        out
+    }
+
+    /// `mjData::xpos[body_id]`, exactly `data.xpos[body]` on the Python side
+    /// -- world position, metres. Exists for `sim-host` (issue #161), which
+    /// puts the board body's position on the wire directly rather than
+    /// re-deriving it from qpos indices that depend on joint declaration
+    /// order. Not part of `hal`.
+    pub fn body_xpos(&self, body_id: usize) -> [f64; 3] {
+        let mut out = [0.0f64; 3];
+        // SAFETY: `self.data` is non-null and owned for the life of `self`;
+        // `out` has exactly the 3 elements `xpos`'s per-body stride expects.
+        unsafe { plant_mujoco_get_body_xpos(self.data, body_id as c_int, out.as_mut_ptr()) };
+        out
+    }
+
+    /// `mjData::xquat[body_id]`, w,x,y,z -- MuJoCo's own quaternion
+    /// convention, exactly `data.xquat[body]` on the Python side. Same
+    /// rationale and caller as [`Plant::body_xpos`].
+    pub fn body_xquat(&self, body_id: usize) -> [f64; 4] {
+        let mut out = [0.0f64; 4];
+        // SAFETY: `self.data` is non-null and owned for the life of `self`;
+        // `out` has exactly the 4 elements `xquat`'s per-body stride expects.
+        unsafe { plant_mujoco_get_body_xquat(self.data, body_id as c_int, out.as_mut_ptr()) };
         out
     }
 

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -155,3 +155,22 @@ void plant_mujoco_set_xfrc_applied(void* data, int body_id, const double* frc6) 
 void plant_mujoco_get_body_xmat(void* data, int body_id, double* out) {
   memcpy(out, ((mjData*)data)->xmat + 9 * body_id, 9 * sizeof(double));
 }
+
+// Everything below exists for issue #161 (I2): the `sim-host` state-out wire
+// carries the board body's world position and orientation directly, rather
+// than making the receiver re-derive them from qpos indices that depend on
+// the model's joint declaration order -- the same reasoning plant.py's own
+// `data.xpos[body]` / `data.xquat[body]` usage already follows on the Python
+// side (see `sim/scenarios/plant.py`).
+
+// Ownership: `out` must point to 3 writable doubles. World position, exactly
+// `data.xpos[body_id]` on the Python side.
+void plant_mujoco_get_body_xpos(void* data, int body_id, double* out) {
+  memcpy(out, ((mjData*)data)->xpos + 3 * body_id, 3 * sizeof(double));
+}
+
+// Ownership: `out` must point to 4 writable doubles, w,x,y,z -- MuJoCo's own
+// quaternion convention, exactly `data.xquat[body_id]` on the Python side.
+void plant_mujoco_get_body_xquat(void* data, int body_id, double* out) {
+  memcpy(out, ((mjData*)data)->xquat + 4 * body_id, 4 * sizeof(double));
+}

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -187,6 +187,35 @@ impl SimBackend {
             .expect("truth_frame_xmat: backend is not open");
         plant.body_xmat(self.frame_body)
     }
+
+    /// Ground-truth world position of the `frame` body, metres. Same
+    /// non-`hal`, harness-only status as [`SimBackend::truth_frame_xmat`] --
+    /// added for `sim-host` (issue #161), which puts raw MuJoCo-world
+    /// position directly on its state wire.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_frame_xpos(&self) -> [f64; 3] {
+        let plant = self
+            .plant
+            .as_ref()
+            .expect("truth_frame_xpos: backend is not open");
+        plant.body_xpos(self.frame_body)
+    }
+
+    /// Ground-truth world orientation of the `frame` body, quaternion
+    /// w,x,y,z, MuJoCo's own convention. Same status as
+    /// [`SimBackend::truth_frame_xpos`].
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_frame_xquat(&self) -> [f64; 4] {
+        let plant = self
+            .plant
+            .as_ref()
+            .expect("truth_frame_xquat: backend is not open");
+        plant.body_xquat(self.frame_body)
+    }
 }
 
 impl BoardObserve for SimBackend {

--- a/crates/sim-host/Cargo.toml
+++ b/crates/sim-host/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "sim-host"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# `sim-host` is a library with a thin binary wrapper (SR-GAME-15): the day an
+# in-process consumer wants this loop, linking the library is a build-graph
+# change, not a rewrite of a binary-only crate. `wire-probe` is a second,
+# unrelated binary -- the CEO-visible verification tool for the wire this
+# crate speaks, not something `sim-host` (the library) depends on.
+[lib]
+name = "sim_host"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sim-host"
+path = "src/bin/sim-host.rs"
+
+[[bin]]
+name = "wire-probe"
+path = "src/bin/wire-probe.rs"
+
+[dependencies]
+board-types = { workspace = true }
+hal = { workspace = true }
+hal-actuate = { workspace = true }
+control-core = { workspace = true }
+safety = { workspace = true }
+sim-backend = { workspace = true }

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -1,0 +1,68 @@
+//! Thin binary wrapper over the `sim_host` library (issue #161, SR-GAME-15).
+//!
+//! Spawns the 500 Hz control loop on its own dedicated thread and joins it
+//! from `main` -- so the actual loop is never on the process's main thread,
+//! and this binary itself does no work beyond argument parsing and printing
+//! a final summary when the loop stops.
+//!
+//! ```text
+//! sim-host [--duration-secs SECONDS]
+//! ```
+//! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
+//! it, stops after that many seconds and exits -- used for the issue #161
+//! verification run and for anything else that wants a bounded process.
+
+use sim_host::HostConfig;
+use std::process::ExitCode;
+use std::time::Duration;
+
+fn main() -> ExitCode {
+    let mut cfg = HostConfig::default();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--duration-secs" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --duration-secs needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(secs) = v.parse::<f64>() else {
+                    eprintln!("sim-host: --duration-secs value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                cfg.duration = Some(Duration::from_secs_f64(secs));
+                i += 2;
+            }
+            other => {
+                eprintln!("sim-host: unrecognized argument '{other}'");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    eprintln!(
+        "sim-host: starting -- state out to {}, input in on {}, duration={:?}",
+        cfg.state_out_addr, cfg.input_in_addr, cfg.duration
+    );
+
+    let handle = sim_host::spawn(cfg);
+    match handle.join() {
+        Ok(Ok(summary)) => {
+            eprintln!(
+                "sim-host: stopped cleanly -- {} ticks, {} missed deadlines",
+                summary.ticks, summary.missed_deadlines
+            );
+            ExitCode::SUCCESS
+        }
+        Ok(Err(e)) => {
+            eprintln!("sim-host: control loop failed: {e}");
+            ExitCode::FAILURE
+        }
+        Err(_) => {
+            eprintln!("sim-host: control thread panicked");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/sim-host/src/bin/wire-probe.rs
+++ b/crates/sim-host/src/bin/wire-probe.rs
@@ -1,0 +1,237 @@
+//! The CEO-visible verification tool for the issue #161 wire (W1).
+//!
+//! A headless UDP receiver, independent of the `sim-host` LIBRARY (it only
+//! uses [`sim_host::wire`]) -- it proves the wire works from the outside,
+//! the same position Unreal will be in, not from inside the process that
+//! produces it.
+//!
+//! ```text
+//! wire-probe [--seconds N] [--bind ADDR] [--host-stats PATH]
+//! ```
+//! Binds `--bind` (default `127.0.0.1:9601`, the documented state-out
+//! address), listens for `--seconds` (default 10), and prints a plain-text
+//! report: measured tick rate, inter-packet interval stats, the host's own
+//! missed-deadline count (read from `--host-stats`, best-effort -- issue
+//! #161's wire itself carries no room for that counter), pitch_rad
+//! min/max/final, and a magic+version parse confirmation.
+
+use sim_host::wire::{StateOut, SCHEMA_VERSION, STATE_MAGIC};
+use std::net::UdpSocket;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+struct Args {
+    seconds: f64,
+    bind: String,
+    host_stats: PathBuf,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Args {
+            seconds: 10.0,
+            bind: sim_host::wire::STATE_OUT_ADDR.to_string(),
+            host_stats: PathBuf::from(sim_host::host::DEFAULT_STATS_PATH),
+        }
+    }
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut a = Args::default();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--seconds" => {
+                let v = args.get(i + 1).ok_or("--seconds needs a value")?;
+                a.seconds = v
+                    .parse()
+                    .map_err(|_| format!("bad --seconds value '{v}'"))?;
+                i += 2;
+            }
+            "--bind" => {
+                a.bind = args.get(i + 1).ok_or("--bind needs a value")?.clone();
+                i += 2;
+            }
+            "--host-stats" => {
+                a.host_stats = PathBuf::from(args.get(i + 1).ok_or("--host-stats needs a value")?);
+                i += 2;
+            }
+            other => return Err(format!("unrecognized argument '{other}'")),
+        }
+    }
+    Ok(a)
+}
+
+fn percentile(sorted_ms: &[f64], p: f64) -> f64 {
+    if sorted_ms.is_empty() {
+        return f64::NAN;
+    }
+    let idx = ((p / 100.0) * (sorted_ms.len() - 1) as f64).round() as usize;
+    sorted_ms[idx.min(sorted_ms.len() - 1)]
+}
+
+/// Best-effort read of `sim-host`'s own stats file. Internal tooling, not
+/// the wire -- absent or unparsable is reported honestly, not faked.
+fn read_host_stats(path: &std::path::Path) -> Option<(u64, u64)> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let mut ticks = None;
+    let mut missed = None;
+    for line in contents.lines() {
+        if let Some(v) = line.strip_prefix("ticks=") {
+            ticks = v.trim().parse().ok();
+        } else if let Some(v) = line.strip_prefix("missed_deadlines=") {
+            missed = v.trim().parse().ok();
+        }
+    }
+    match (ticks, missed) {
+        (Some(t), Some(m)) => Some((t, m)),
+        _ => None,
+    }
+}
+
+fn main() {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("wire-probe: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let socket = UdpSocket::bind(&args.bind).unwrap_or_else(|e| {
+        eprintln!("wire-probe: failed to bind {}: {e}", args.bind);
+        std::process::exit(1);
+    });
+    // Woken periodically so the run stops close to --seconds even with no
+    // traffic at all, rather than blocking forever.
+    socket
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .expect("wire-probe: set_read_timeout failed");
+
+    println!(
+        "wire-probe: listening on {} for {:.1}s",
+        args.bind, args.seconds
+    );
+
+    let run_start = Instant::now();
+    let deadline = run_start + Duration::from_secs_f64(args.seconds);
+
+    let mut buf = [0u8; 4096];
+    let mut recv_times: Vec<Instant> = Vec::new();
+    let mut valid_count: u64 = 0;
+    let mut invalid_count: u64 = 0;
+    let mut pitch_min = f32::INFINITY;
+    let mut pitch_max = f32::NEG_INFINITY;
+    let mut pitch_final: f32 = f32::NAN;
+    let mut first_seq: Option<u64> = None;
+    let mut last_seq: Option<u64> = None;
+
+    while Instant::now() < deadline {
+        match socket.recv_from(&mut buf) {
+            Ok((n, _src)) => match StateOut::from_bytes(&buf[..n]) {
+                Ok(state) => {
+                    valid_count += 1;
+                    recv_times.push(Instant::now());
+                    let pitch = state.pitch_rad;
+                    pitch_min = pitch_min.min(pitch);
+                    pitch_max = pitch_max.max(pitch);
+                    pitch_final = pitch;
+                    let seq = state.seq;
+                    first_seq.get_or_insert(seq);
+                    last_seq = Some(seq);
+                }
+                Err(e) => {
+                    invalid_count += 1;
+                    eprintln!("wire-probe: dropping packet that failed to parse: {e}");
+                }
+            },
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                continue;
+            }
+            Err(e) => {
+                eprintln!("wire-probe: recv error: {e}");
+                break;
+            }
+        }
+    }
+
+    let elapsed_s = run_start.elapsed().as_secs_f64();
+    let total_received = valid_count + invalid_count;
+
+    // Inter-packet intervals, milliseconds, from OUR OWN receipt timestamps
+    // -- not carried on the wire, and this is the only place that can
+    // measure them: the actual delivered cadence, loopback jitter included.
+    let mut intervals_ms: Vec<f64> = recv_times
+        .windows(2)
+        .map(|w| (w[1] - w[0]).as_secs_f64() * 1000.0)
+        .collect();
+    let (mean_ms, p50_ms, p99_ms, max_ms) = if intervals_ms.is_empty() {
+        (f64::NAN, f64::NAN, f64::NAN, f64::NAN)
+    } else {
+        let sum: f64 = intervals_ms.iter().sum();
+        let mean = sum / intervals_ms.len() as f64;
+        intervals_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let p50 = percentile(&intervals_ms, 50.0);
+        let p99 = percentile(&intervals_ms, 99.0);
+        let max = *intervals_ms.last().unwrap();
+        (mean, p50, p99, max)
+    };
+
+    let mean_hz = if elapsed_s > 0.0 {
+        valid_count as f64 / elapsed_s
+    } else {
+        f64::NAN
+    };
+
+    println!("--- wire-probe report ---");
+    println!("run duration: {elapsed_s:.3} s");
+    println!("total ticks (valid state packets received): {valid_count}");
+    println!("measured tick rate (mean): {mean_hz:.2} Hz");
+    if let (Some(first), Some(last)) = (first_seq, last_seq) {
+        println!("seq range: {first}..={last} (span {})", last - first + 1);
+    }
+    println!("inter-packet interval (ms): mean={mean_ms:.4} p50={p50_ms:.4} p99={p99_ms:.4} max={max_ms:.4}");
+
+    match read_host_stats(&args.host_stats) {
+        Some((host_ticks, missed)) => {
+            println!(
+                "missed-deadline count from the host: {missed} (host reports {host_ticks} ticks, stats file {})",
+                args.host_stats.display()
+            );
+        }
+        None => {
+            println!(
+                "missed-deadline count from the host: unavailable (could not read/parse {})",
+                args.host_stats.display()
+            );
+        }
+    }
+
+    println!(
+        "pitch_rad: min={:.6} max={:.6} final={:.6} ({:.3} deg / {:.3} deg / {:.3} deg)",
+        pitch_min,
+        pitch_max,
+        pitch_final,
+        pitch_min.to_degrees(),
+        pitch_max.to_degrees(),
+        pitch_final.to_degrees()
+    );
+
+    if total_received == 0 {
+        println!("confirmation: NO PACKETS RECEIVED -- nothing to confirm");
+    } else if invalid_count == 0 {
+        println!(
+            "confirmation: magic ({STATE_MAGIC:#010x}) + schema_version ({SCHEMA_VERSION}) \
+             parsed correctly on all {valid_count}/{total_received} received packets"
+        );
+    } else {
+        println!(
+            "confirmation: FAILED -- {invalid_count}/{total_received} received packets did not \
+             parse (bad magic/version/size); {valid_count}/{total_received} were good"
+        );
+    }
+}

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -1,0 +1,447 @@
+//! The 500 Hz control loop, dedicated thread, UDP in/out (issue #161).
+//!
+//! Wires the SAME `control-core`/`safety` objects `control-ffi::ob_controller_
+//! update` wires for the Python-hosted scenario, and `board-app-driverless`'s
+//! `impulse-response-rust` wires for the Rust-hosted one -- reached here
+//! through `hal` (`SimBackend::wait_observe`/`apply`) exactly like that
+//! binary, just paced against a UDP client instead of a fixed step count.
+//! Nothing here is a new control law.
+
+use crate::pacer::Pacer;
+use crate::wire::{self, InputIn, StateOut};
+use board_types::{Command, Faults, ImuSample, Params, DEFAULT_R_EFF_M, RAD_S_PER_ERPM};
+use control_core::{ComplementaryFilter, Estimator, PitchRegulator, WheelAccelEstimator};
+use hal::BoardObserve;
+use hal_actuate::BoardActuate;
+use safety::Envelope;
+use sim_backend::SimBackend;
+use std::io::ErrorKind;
+use std::net::{SocketAddr, UdpSocket};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// Nanoseconds per control cycle -- 500 Hz, matching `sim-backend`'s own
+/// `CYCLE_NS` (ICD SS11.2). Duplicated the same way that crate duplicates
+/// `KT_NM_PER_A` against the model, because there is no public constant to
+/// import; [`run`] asserts it against `SimBackend::run_metadata()` on open
+/// rather than trusting the duplication silently.
+pub const CYCLE_NS: u64 = 2_000_000;
+const DT_S: f64 = CYCLE_NS as f64 * 1e-9;
+
+// --- Controller config -- identical to
+// `board-app-driverless/src/bin/impulse-response-rust.rs`'s constants (issue
+// #107 AC6), which mirror `sim/scenarios/rust_controller.py`'s own defaults.
+// No outer velocity loop: W1 is pure station-keeping balance, not driving.
+const KP_NM_PER_RAD: f32 = 56.0;
+const KD_NM_PER_RAD_S: f32 = 7.7;
+const KT_NM_PER_A: f32 = 0.7;
+const MAX_CURRENT_A: f32 = 40.0;
+const ESTIMATOR_TAU_S: f32 = 1.0;
+const WHEEL_ACCEL_TAU_S: f32 = 0.05;
+
+/// Non-physical game channel: full `steer` deflection integrates `yaw_rad`
+/// at this rate. An arbitrary "game feel" placeholder for W1 -- the
+/// simulated wheel is a cylinder and cannot physically carve (issue #161).
+/// W2's lean-steer controller replaces this with something real.
+const YAW_RATE_GAIN_RAD_S: f32 = 1.5;
+
+/// How long a stale input is still trusted before the host zeroes it rather
+/// than continuing to act on a value from a client that may have gone away.
+/// 50 control cycles (100 ms at 500 Hz): generous relative to any plausible
+/// Unreal send rate, tight relative to a human's reaction time. A documented
+/// default, not a bench-tuned number.
+const INPUT_STALENESS_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Placeholder threshold for the state-out FALLEN bit.
+/// `sim/scenarios/disturbance_envelope.py` derives the REAL nose-strike
+/// angle (18.57 deg) from the model's collision hulls; this crate has no
+/// Rust binding to that geometry query, so this is a fixed proxy near that
+/// value, not the real contact test -- good enough to prove "the board is
+/// clearly down", not precise enough to gate a published claim.
+const FALLEN_PITCH_RAD: f32 = 20.0 * std::f32::consts::PI / 180.0;
+
+/// A ONE-TIME startup disturbance, applied near the beginning of every run.
+/// Not a general disturbance API -- the input wire carries no such field
+/// (issue #161) -- and not required by the wire spec itself. It exists so a
+/// verification run (`wire-probe`) demonstrates the controller actually
+/// RECOVERING from a push, rather than sitting at a motionless, never-
+/// disturbed equilibrium the whole time: with nothing to react to,
+/// `pitch_rad` would report exactly 0.0 forever, which satisfies the wire
+/// but proves nothing about the control loop. Same magnitude and duration
+/// `impulse-response-rust` uses (issue #107 AC6: `NOMINAL_IMPULSE_NS` = 20
+/// N*s over 0.05 s), reused rather than invented; direction and application
+/// point mirror that binary's own `ImpulseParams` defaults too (force along
+/// -X, zero torque).
+const STARTUP_KICK_T0_S: f64 = 1.0;
+const STARTUP_KICK_DURATION_S: f64 = 0.05;
+const STARTUP_KICK_FORCE_N: [f64; 3] = [-(20.0 / STARTUP_KICK_DURATION_S), 0.0, 0.0];
+
+/// Default path for the host's own missed-deadline/tick counters -- internal
+/// tooling for `wire-probe`, NOT part of the Unreal wire (issue #161's wire
+/// table has no room for either, and must not grow one for our own
+/// convenience). Overwritten atomically (write-then-rename) a few times a
+/// second; best-effort, since losing a write here must never interrupt the
+/// control loop.
+pub const DEFAULT_STATS_PATH: &str = "/tmp/overboard-sim-host-stats.txt";
+
+/// What [`run`] needs to know before it starts.
+pub struct HostConfig {
+    /// Where state-out packets are sent.
+    pub state_out_addr: SocketAddr,
+    /// Where the input-in socket binds/listens.
+    pub input_in_addr: SocketAddr,
+    /// `None` runs forever; `Some(d)` stops after `d` has elapsed --
+    /// primarily for tests and the verification run in issue #161's PR,
+    /// not something a deployed host would set.
+    pub duration: Option<Duration>,
+    /// `None` disables the stats file entirely.
+    pub stats_path: Option<PathBuf>,
+}
+
+impl Default for HostConfig {
+    fn default() -> Self {
+        HostConfig {
+            state_out_addr: wire::state_out_addr(),
+            input_in_addr: wire::input_in_addr(),
+            duration: None,
+            stats_path: Some(PathBuf::from(DEFAULT_STATS_PATH)),
+        }
+    }
+}
+
+/// What a finished (or interrupted-by-error) run produced.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RunSummary {
+    pub ticks: u64,
+    pub missed_deadlines: u64,
+}
+
+/// Everything that can stop [`run`] early.
+#[derive(Debug)]
+pub enum HostError {
+    Backend(board_types::IoError),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for HostError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HostError::Backend(e) => write!(f, "sim backend error: {e:?}"),
+            HostError::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for HostError {}
+
+impl From<std::io::Error> for HostError {
+    fn from(e: std::io::Error) -> Self {
+        HostError::Io(e)
+    }
+}
+
+/// The most recent input the host has heard from Unreal, plus the bits W1
+/// does not yet act on (accepted, clamped, and logged on receipt -- issue
+/// #161 -- so W2 only has to connect them to something).
+#[derive(Debug, Clone, Copy, Default)]
+struct LatestInput {
+    weight_shift_fore_aft: f32,
+    weight_shift_lateral: f32,
+    steer: f32,
+    armed_bit: bool,
+    reset_bit: bool,
+}
+
+impl From<InputIn> for LatestInput {
+    fn from(p: InputIn) -> Self {
+        let flags = p.flags;
+        LatestInput {
+            weight_shift_fore_aft: p.weight_shift_fore_aft,
+            weight_shift_lateral: p.weight_shift_lateral,
+            steer: p.steer,
+            armed_bit: flags & wire::INPUT_FLAG_ARM != 0,
+            reset_bit: flags & wire::INPUT_FLAG_RESET != 0,
+        }
+    }
+}
+
+/// Spawns the control loop on its own dedicated thread (issue #161: "not on
+/// the main thread") and returns the join handle. The caller decides what to
+/// do with the calling thread -- `src/bin/sim-host.rs` just joins it.
+pub fn spawn(cfg: HostConfig) -> std::thread::JoinHandle<Result<RunSummary, HostError>> {
+    std::thread::Builder::new()
+        .name("sim-host-control".into())
+        .spawn(move || run(cfg))
+        .expect("sim-host: failed to spawn the control thread")
+}
+
+/// Runs the 500 Hz closed loop until `cfg.duration` elapses (or forever, if
+/// `None`), or until a backend/I-O error stops it. Blocking -- call this
+/// from a spawned thread, not the process's main thread, unless the caller
+/// has nothing else to do on main either.
+pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
+    let params = Params {
+        kp_nm_per_rad: KP_NM_PER_RAD,
+        kd_nm_per_rad_s: KD_NM_PER_RAD_S,
+        kt_nm_per_a: KT_NM_PER_A,
+        max_current_a: MAX_CURRENT_A,
+        ..Params::default()
+    };
+
+    let mut backend = SimBackend::with_params(params);
+    backend.open().map_err(HostError::Backend)?;
+    // Armed unconditionally at startup, the same way every other Rust-hosted
+    // harness in this repo arms (`impulse-response-rust`, `sim-backend`'s own
+    // tests): there is no synthetic Unreal client during the issue #161
+    // verification run, and W1 explicitly does not gate balancing on the
+    // input socket's `arm` bit -- see `LatestInput::armed_bit`, tracked and
+    // logged but not yet wired to anything (W2).
+    let _disarm = backend.arm().map_err(HostError::Backend)?;
+
+    // CYCLE_NS is a duplicated constant, not derived -- checked against
+    // sim-backend's own control rate the same way that crate checks
+    // KT_NM_PER_A against the model's ctrlrange, rather than trusted blind.
+    let reported_hz = backend.run_metadata().control_rate_hz as f64;
+    let expected_hz = 1e9 / CYCLE_NS as f64;
+    assert!(
+        (reported_hz - expected_hz).abs() < 1e-6,
+        "sim-host: CYCLE_NS ({CYCLE_NS} ns / {expected_hz} Hz) does not match \
+         sim-backend's own control rate ({reported_hz} Hz)"
+    );
+
+    let mut envelope = Envelope::new(params);
+    envelope.arm();
+
+    let regulator = PitchRegulator::new(KP_NM_PER_RAD, KD_NM_PER_RAD_S);
+    let mut estimator = ComplementaryFilter::with_trust_band(ESTIMATOR_TAU_S, 0.0);
+    let mut wheel_accel = WheelAccelEstimator::new(WHEEL_ACCEL_TAU_S);
+
+    let out_socket = UdpSocket::bind("127.0.0.1:0")?;
+    let in_socket = UdpSocket::bind(cfg.input_in_addr)?;
+    // The 500 Hz loop must never block on recv (issue #161).
+    in_socket.set_nonblocking(true)?;
+
+    let mut latest_input = LatestInput::default();
+    let mut latest_input_at: Option<Instant> = None;
+    let mut prev_armed_bit = false;
+    let mut prev_reset_bit = false;
+    let mut yaw_rad: f32 = 0.0;
+    let mut wheel_angle_rad: f32 = 0.0;
+
+    let start = Instant::now();
+    let mut pacer = Pacer::new(Duration::from_nanos(CYCLE_NS), start);
+    // Headroom over InputIn::WIRE_SIZE so an oversized datagram is caught as
+    // a WrongSize mismatch by InputIn::from_bytes rather than silently
+    // truncated by a too-small recv buffer.
+    let mut recv_buf = [0u8; InputIn::WIRE_SIZE + 16];
+    let mut last_stats_write = Instant::now();
+    let mut ticks: u64 = 0;
+    // Pre-step sim time, mirroring impulse-response-rust's own `t_known_s`:
+    // the window check below must use the time as of the START of this
+    // tick, since `apply_external_force` only takes effect on the NEXT
+    // `wait_observe()` (see [`STARTUP_KICK_T0_S`]).
+    let mut t_known_s: f64 = 0.0;
+
+    loop {
+        if let Some(d) = cfg.duration {
+            if start.elapsed() >= d {
+                break;
+            }
+        }
+
+        // Drain every pending datagram; only the most recent VALID one
+        // matters (issue #161: "Use the most recent packet received").
+        loop {
+            match in_socket.recv_from(&mut recv_buf) {
+                Ok((n, _src)) => match InputIn::from_bytes(&recv_buf[..n]) {
+                    Ok(pkt) => {
+                        eprintln!(
+                            "sim-host: input seq={} weight_fore_aft={:.3} weight_lateral={:.3} \
+                             steer={:.3} arm={} reset={}",
+                            { pkt.seq },
+                            { pkt.weight_shift_fore_aft },
+                            { pkt.weight_shift_lateral },
+                            { pkt.steer },
+                            (pkt.flags & wire::INPUT_FLAG_ARM) != 0,
+                            (pkt.flags & wire::INPUT_FLAG_RESET) != 0,
+                        );
+                        latest_input = LatestInput::from(pkt);
+                        latest_input_at = Some(Instant::now());
+                    }
+                    // Fail loudly, drop the packet, never misparse it as a
+                    // float (issue #161).
+                    Err(e) => eprintln!("sim-host: dropping malformed input packet: {e}"),
+                },
+                Err(e) if e.kind() == ErrorKind::WouldBlock => break,
+                Err(e) => {
+                    eprintln!("sim-host: input socket recv error: {e}");
+                    break;
+                }
+            }
+        }
+
+        let stale = latest_input_at
+            .map(|t| t.elapsed() > INPUT_STALENESS_TIMEOUT)
+            .unwrap_or(true);
+        // weight_shift_* and steer hold last, then zero after the staleness
+        // timeout (issue #161). weight_shift_* is read, clamped (already
+        // done in InputIn::from_bytes) and logged above, but does not yet
+        // drive the model (W1 scope) -- wired here so W2 only has to
+        // connect it to an actuator.
+        let steer = if stale { 0.0 } else { latest_input.steer };
+        let _weight_shift_fore_aft = if stale {
+            0.0
+        } else {
+            latest_input.weight_shift_fore_aft
+        };
+        let _weight_shift_lateral = if stale {
+            0.0
+        } else {
+            latest_input.weight_shift_lateral
+        };
+
+        // `arm`/`reset` bits: accepted and tracked (W1 scope), logged on
+        // change rather than every tick. Neither gates anything yet -- the
+        // host self-arms unconditionally (see the comment on `backend.arm()`
+        // above), and there is no reset implementation to wire `reset` into
+        // (W2). `stale` zeroes both the same way it zeroes weight_shift/steer.
+        let input_armed_bit = !stale && latest_input.armed_bit;
+        let input_reset_bit = !stale && latest_input.reset_bit;
+        if input_reset_bit && !prev_reset_bit {
+            eprintln!("sim-host: input reset bit set -- W1 does not implement reset yet, ignoring");
+        }
+        if input_armed_bit != prev_armed_bit {
+            eprintln!(
+                "sim-host: input arm bit is now {input_armed_bit} \
+                 (host self-arms regardless of this bit in W1)"
+            );
+        }
+        prev_armed_bit = input_armed_bit;
+        prev_reset_bit = input_reset_bit;
+
+        // One-time startup kick -- see STARTUP_KICK_T0_S's doc comment.
+        // Checked against the PRE-step time, mirroring impulse_response.py's
+        // `if t0 <= data.time < t0 + duration` (also checked there before
+        // that iteration's mj_step).
+        let in_kick_window =
+            (STARTUP_KICK_T0_S..STARTUP_KICK_T0_S + STARTUP_KICK_DURATION_S).contains(&t_known_s);
+        let force = if in_kick_window {
+            STARTUP_KICK_FORCE_N
+        } else {
+            [0.0; 3]
+        };
+        backend.apply_external_force(force, [0.0; 3]);
+
+        let obs = backend.wait_observe().map_err(HostError::Backend)?;
+        t_known_s = obs.t_recv_ns as f64 * 1e-9;
+
+        // Controller: raw IMU -> estimate -> regulate -> envelope. Mode 1
+        // (wheel odometry aiding), matching `impulse-response-rust` and
+        // `RustController()`'s own default (issue #121).
+        let sample = obs.newest_imu().copied().unwrap_or(ImuSample::ZERO);
+        let wheel_rate_rad_s = obs.erpm * RAD_S_PER_ERPM;
+        let aiding = wheel_accel.update(wheel_rate_rad_s * DEFAULT_R_EFF_M, DT_S as f32);
+        let attitude = estimator.update(std::slice::from_ref(&sample), aiding);
+        let proposed_torque_nm =
+            regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
+        // The single kt division -- the actuation boundary (issue #137).
+        let proposed_amps = proposed_torque_nm / KT_NM_PER_A;
+        let (bounded_cmd, _sat) = envelope.apply(
+            Command::MotorCurrent {
+                amps: proposed_amps,
+            },
+            Faults::NONE,
+        );
+        backend.apply(&bounded_cmd).map_err(HostError::Backend)?;
+
+        // wheel_angle_rad: there is no absolute wheel-angle channel on `hal`
+        // (ICD carries ERPM/tacho, the same as real VESC telemetry) -- this
+        // dead-reckons it from the rate `hal` already reports, exactly the
+        // way a real host would have to. Not a fabricated value: it is an
+        // honest integral of an actually-measured rate.
+        wheel_angle_rad += wheel_rate_rad_s * DT_S as f32;
+        // yaw_rad: NON-PHYSICAL game channel (issue #161) -- see
+        // YAW_RATE_GAIN_RAD_S's doc comment.
+        yaw_rad += steer * YAW_RATE_GAIN_RAD_S * DT_S as f32;
+
+        // Ground truth, never fed to the controller above (DR-OBS-1) --
+        // reported because "the board is actually up" is what the state-out
+        // wire needs to prove, and truth proves it more directly than the
+        // controller's own (estimator-mediated) belief. Same formula
+        // `impulse-response-rust` / `sim/scenarios/impulse_response.py::
+        // frame_pitch_rad` use, against the same underlying xmat.
+        let xmat = backend.truth_frame_xmat();
+        let pitch_rad = (xmat[2] as f32).atan2(xmat[8] as f32);
+        let pos_f64 = backend.truth_frame_xpos();
+        let quat_f64 = backend.truth_frame_xquat();
+        let pos = [pos_f64[0] as f32, pos_f64[1] as f32, pos_f64[2] as f32];
+        let quat = [
+            quat_f64[0] as f32,
+            quat_f64[1] as f32,
+            quat_f64[2] as f32,
+            quat_f64[3] as f32,
+        ];
+
+        let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;
+        if pitch_rad.abs() > FALLEN_PITCH_RAD {
+            flags |= wire::STATE_FLAG_FALLEN;
+        }
+
+        let state = StateOut {
+            magic: wire::STATE_MAGIC,
+            schema_version: wire::SCHEMA_VERSION,
+            flags,
+            seq: ticks,
+            sim_time_s: obs.t_recv_ns as f64 * 1e-9,
+            pos,
+            quat,
+            wheel_angle_rad,
+            wheel_rate_rad_s,
+            pitch_rad,
+            yaw_rad,
+            motor_current_a: obs.motor_current_a,
+        };
+        out_socket.send_to(&state.to_bytes(), cfg.state_out_addr)?;
+
+        ticks += 1;
+
+        if let Some(path) = &cfg.stats_path {
+            if last_stats_write.elapsed() >= Duration::from_millis(100) {
+                write_stats(path, ticks, pacer.missed_deadlines());
+                last_stats_write = Instant::now();
+            }
+        }
+
+        let sleep_for = pacer.wait_for_next(Instant::now());
+        if sleep_for.is_zero() {
+            eprintln!(
+                "sim-host: missed deadline at tick {ticks} (total missed so far: {})",
+                pacer.missed_deadlines()
+            );
+        } else {
+            std::thread::sleep(sleep_for);
+        }
+    }
+
+    if let Some(path) = &cfg.stats_path {
+        write_stats(path, ticks, pacer.missed_deadlines());
+    }
+
+    let _ = backend.close();
+
+    Ok(RunSummary {
+        ticks,
+        missed_deadlines: pacer.missed_deadlines(),
+    })
+}
+
+/// Best-effort, atomic (write-then-rename) write of the host's own counters,
+/// for `wire-probe` to pick up. Never allowed to interrupt the control loop
+/// -- a failure here is silently swallowed ON PURPOSE (unlike a missed
+/// deadline or a malformed input packet, which issue #161 requires surfacing
+/// loudly): this file is internal tooling, not the wire.
+fn write_stats(path: &std::path::Path, ticks: u64, missed_deadlines: u64) {
+    let tmp = path.with_extension("tmp");
+    let contents = format!("ticks={ticks}\nmissed_deadlines={missed_deadlines}\n");
+    let _ = std::fs::write(&tmp, contents).and_then(|_| std::fs::rename(&tmp, path));
+}

--- a/crates/sim-host/src/lib.rs
+++ b/crates/sim-host/src/lib.rs
@@ -1,0 +1,25 @@
+//! `sim-host` runs the real closed-loop board (issue #161, wire spine): it
+//! opens the same `plant-mujoco` + `control-ffi`-equivalent closed loop
+//! `sim-backend` already hosts at 500 Hz (`crates/sim-backend`'s own doc
+//! comment, and `tests/test_rust_hosted_impulse_response.py`), on its own
+//! dedicated thread, and speaks the fixed v1 UDP wire to Unreal:
+//! [`wire::StateOut`] out to `127.0.0.1:9601`, [`wire::InputIn`] in on
+//! `127.0.0.1:9602`.
+//!
+//! # Library + thin binary (SR-GAME-15)
+//!
+//! This crate is a library ([`host::run`]/[`host::spawn`]) with a thin
+//! binary wrapper (`src/bin/sim-host.rs`). The day something wants this loop
+//! in-process instead of over a socket, linking `sim-host` is a build-graph
+//! decision, not a rewrite.
+//!
+//! `src/bin/wire-probe.rs` is a second, separate binary -- the CEO-visible
+//! verification tool for the wire this crate speaks. It only depends on
+//! [`wire`], never on [`host`]: it is a standalone UDP listener, not a
+//! client of this library.
+
+pub mod host;
+pub mod pacer;
+pub mod wire;
+
+pub use host::{run, spawn, HostConfig, HostError, RunSummary, CYCLE_NS};

--- a/crates/sim-host/src/pacer.rs
+++ b/crates/sim-host/src/pacer.rs
@@ -1,0 +1,163 @@
+//! Fixed-rate pacing against a monotonic clock, absolute deadlines only.
+//!
+//! Issue #161 is explicit about the failure mode this avoids: pacing with
+//! `sleep(period)` on every iteration accumulates drift, because the time
+//! spent doing the tick's own work (however small) is never subtracted back
+//! out -- a loop that sleeps `period` after each tick runs slower than
+//! `period` on average, and the error compounds every cycle. Advancing a
+//! single absolute deadline (`next_deadline += period`) instead means each
+//! cycle is paced against where the clock SHOULD be, not against how long
+//! the previous cycle happened to take.
+
+use std::time::{Duration, Instant};
+
+/// Paces a loop at a fixed period. Call [`Pacer::wait_for_next`] once per
+/// iteration, after that iteration's work is done; sleep for the returned
+/// duration (zero means the deadline already passed -- do not sleep, and the
+/// miss has already been counted).
+///
+/// Takes `now` as an explicit argument rather than calling `Instant::now()`
+/// itself, so the pacing arithmetic is testable without racing a real clock
+/// against a real `thread::sleep` on a shared, possibly loaded CI runner --
+/// see this module's tests, which never sleep at all.
+pub struct Pacer {
+    period: Duration,
+    next_deadline: Instant,
+    missed_deadlines: u64,
+}
+
+impl Pacer {
+    /// Starts the clock at `now`: the first `wait_for_next()` targets
+    /// `now + period`, not some later first call's `now`.
+    pub fn new(period: Duration, now: Instant) -> Self {
+        Pacer {
+            period,
+            next_deadline: now + period,
+            missed_deadlines: 0,
+        }
+    }
+
+    /// Total missed deadlines observed so far.
+    pub fn missed_deadlines(&self) -> u64 {
+        self.missed_deadlines
+    }
+
+    /// How far past `period` this call is deliberately allowed to lag
+    /// before it counts as this crate's target loop rate, `period`, itself
+    /// -- there is no slack constant here on purpose: ANY overrun of the
+    /// absolute deadline is a miss, however small (issue #161: "do NOT
+    /// silently swallow them").
+    pub fn wait_for_next(&mut self, now: Instant) -> Duration {
+        let sleep_for = if self.next_deadline > now {
+            self.next_deadline - now
+        } else {
+            self.missed_deadlines += 1;
+            Duration::ZERO
+        };
+        // Advances by exactly one period regardless of the overrun, so a
+        // single slow cycle costs one miss, not a cascading pile-up of
+        // catch-up iterations trying to make up lost ground (which would be
+        // physically meaningless here: one loop iteration is one fixed
+        // sim-time step, not a variable one).
+        self.next_deadline += self.period;
+        sleep_for
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Deterministic: every `now` is derived from one fixed base Instant by
+    // pure Duration arithmetic, never from a real sleep -- so these tests
+    // cannot flake under CI scheduler load the way a real-clock version did.
+    fn base() -> Instant {
+        Instant::now()
+    }
+
+    #[test]
+    fn a_fast_loop_never_misses() {
+        let t0 = base();
+        let period = Duration::from_millis(20);
+        let mut p = Pacer::new(period, t0);
+        // Each iteration's "work" costs a negligible 1 us, well inside the
+        // period -- the deadline is always still ahead.
+        let mut now = t0;
+        for _ in 0..5 {
+            now += Duration::from_micros(1);
+            let sleep_for = p.wait_for_next(now);
+            assert!(!sleep_for.is_zero());
+            now += sleep_for;
+        }
+        assert_eq!(p.missed_deadlines(), 0);
+    }
+
+    #[test]
+    fn overshooting_the_deadline_counts_a_miss_and_returns_zero() {
+        let t0 = base();
+        let period = Duration::from_millis(10);
+        let mut p = Pacer::new(period, t0);
+        // Blown straight through the first deadline.
+        let late = t0 + period + Duration::from_millis(5);
+        let sleep_for = p.wait_for_next(late);
+        assert!(sleep_for.is_zero(), "already late -- must not sleep more");
+        assert_eq!(p.missed_deadlines(), 1);
+    }
+
+    #[test]
+    fn a_small_overshoot_does_not_cost_the_next_iteration_too() {
+        let t0 = base();
+        let period = Duration::from_millis(10);
+        let mut p = Pacer::new(period, t0);
+        // Overshoot the first deadline by less than one whole period, so
+        // once wait_for_next() advances next_deadline by exactly one period,
+        // that new deadline lands back in the future.
+        let late = t0 + period + Duration::from_millis(2);
+        let sleep_for = p.wait_for_next(late);
+        assert!(sleep_for.is_zero());
+        assert_eq!(p.missed_deadlines(), 1);
+
+        // Next call, at the same instant (zero elapsed "work") -- the
+        // deadline it now targets is back in the future.
+        let sleep_for = p.wait_for_next(late);
+        assert!(
+            !sleep_for.is_zero(),
+            "next deadline should already be back in the future"
+        );
+        assert_eq!(
+            p.missed_deadlines(),
+            1,
+            "no second miss from the same overshoot"
+        );
+    }
+
+    #[test]
+    fn the_deadline_advances_by_exactly_one_period_per_call_even_when_late() {
+        let t0 = base();
+        let period = Duration::from_millis(10);
+        let mut p = Pacer::new(period, t0);
+        let before = p.next_deadline;
+        let late = t0 + period * 3;
+        p.wait_for_next(late);
+        assert_eq!(p.next_deadline, before + period);
+    }
+
+    #[test]
+    fn a_run_of_misses_costs_exactly_one_miss_each() {
+        // Simulates a loop that is permanently 3x too slow: each iteration's
+        // own "now" arrives period*3 after the previous one, so the deadline
+        // (advancing by exactly one period per call) never catches back up,
+        // and every single call registers a miss -- not a burst on the first
+        // call followed by silence.
+        let t0 = base();
+        let period = Duration::from_millis(10);
+        let mut p = Pacer::new(period, t0);
+        let mut now = t0;
+        for _ in 0..4 {
+            now += period * 3;
+            let sleep_for = p.wait_for_next(now);
+            assert!(sleep_for.is_zero());
+        }
+        assert_eq!(p.missed_deadlines(), 4);
+    }
+}

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -1,0 +1,435 @@
+//! The `sim-host` <-> Unreal wire, v1 -- fixed by the COO (issue #161). This
+//! module is not a place to redesign the protocol: the Unreal side is being
+//! built against this exact byte layout right now, so a field reorder or a
+//! width change here breaks a client we cannot see.
+//!
+//! Both structs are declared `#[repr(C, packed)]` rather than plain
+//! `#[repr(C)]` -- with the field order given, `StateOut` happens to need no
+//! padding either way (every field already lands on its natural alignment),
+//! but `InputIn` does not: a plain `#[repr(C)]` would insert 4 bytes of
+//! trailing padding after `steer` to round the struct up to `seq`'s 8-byte
+//! alignment. That padding is a Rust ABI artifact with no counterpart in the
+//! table below, and there is no guarantee Unreal's side packs the same way --
+//! `packed` makes the on-wire size exactly the sum of the fields, which is
+//! the only layout this table can mean.
+//!
+//! Every access into a packed field is by value (never `&field`), which is
+//! what `to_le_bytes()`/copy-out reads require anyway -- so nothing here
+//! trips the packed-reference lints.
+
+use std::net::SocketAddr;
+
+/// `magic` for [`StateOut`] -- ASCII "OBW1".
+pub const STATE_MAGIC: u32 = 0x4F42_5731;
+/// `magic` for [`InputIn`] -- ASCII "OBI1".
+pub const INPUT_MAGIC: u32 = 0x4F42_4931;
+/// The only schema version either struct has spoken so far.
+pub const SCHEMA_VERSION: u16 = 1;
+
+/// `StateOut::flags` bit 0.
+pub const STATE_FLAG_ARMED: u16 = 1 << 0;
+/// `StateOut::flags` bit 1.
+pub const STATE_FLAG_VALID: u16 = 1 << 1;
+/// `StateOut::flags` bit 2.
+pub const STATE_FLAG_FALLEN: u16 = 1 << 2;
+
+/// `InputIn::flags` bit 0.
+pub const INPUT_FLAG_ARM: u16 = 1 << 0;
+/// `InputIn::flags` bit 1.
+pub const INPUT_FLAG_RESET: u16 = 1 << 1;
+
+/// Host SENDS state here.
+pub const STATE_OUT_ADDR: &str = "127.0.0.1:9601";
+/// Host BINDS/LISTENS for input here.
+pub const INPUT_IN_ADDR: &str = "127.0.0.1:9602";
+
+/// One tick of board state, host -> Unreal (issue #161 wire v1).
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StateOut {
+    pub magic: u32,
+    pub schema_version: u16,
+    pub flags: u16,
+    pub seq: u64,
+    pub sim_time_s: f64,
+    /// Board body position, raw MuJoCo world frame, metres, Z-up
+    /// right-handed. **Not** converted to Unreal's frame -- that conversion
+    /// is deliberately the game side's job, not this host's (issue #161).
+    pub pos: [f32; 3],
+    /// Board body orientation, raw MuJoCo, **w, x, y, z**.
+    pub quat: [f32; 4],
+    pub wheel_angle_rad: f32,
+    /// Positive = forward.
+    pub wheel_rate_rad_s: f32,
+    /// Nose-up positive (ICD SS10.1).
+    pub pitch_rad: f32,
+    /// NON-PHYSICAL game steering channel -- see [`crate::YAW_RATE_GAIN`].
+    /// The simulated wheel is a cylinder and cannot physically carve; this is
+    /// a simple integration of the `steer` input, present only so the game
+    /// side has a heading to render with in W1.
+    pub yaw_rad: f32,
+    pub motor_current_a: f32,
+}
+
+impl StateOut {
+    /// The exact on-wire byte count -- also asserted at compile time below.
+    pub const WIRE_SIZE: usize = 72;
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_SIZE] {
+        let mut buf = [0u8; Self::WIRE_SIZE];
+        let mut off = 0;
+        macro_rules! put {
+            ($val:expr) => {{
+                let bytes = $val.to_le_bytes();
+                buf[off..off + bytes.len()].copy_from_slice(&bytes);
+                off += bytes.len();
+            }};
+        }
+        put!(self.magic);
+        put!(self.schema_version);
+        put!(self.flags);
+        put!(self.seq);
+        put!(self.sim_time_s);
+        for v in self.pos {
+            put!(v);
+        }
+        for v in self.quat {
+            put!(v);
+        }
+        put!(self.wheel_angle_rad);
+        put!(self.wheel_rate_rad_s);
+        put!(self.pitch_rad);
+        put!(self.yaw_rad);
+        put!(self.motor_current_a);
+        debug_assert_eq!(off, Self::WIRE_SIZE);
+        buf
+    }
+
+    /// Parses a received datagram. Fails loudly (returns [`WireError`])
+    /// rather than misreading a mismatched magic/version as a float --
+    /// per issue #161's explicit instruction.
+    pub fn from_bytes(buf: &[u8]) -> Result<Self, WireError> {
+        if buf.len() != Self::WIRE_SIZE {
+            return Err(WireError::WrongSize {
+                expected: Self::WIRE_SIZE,
+                got: buf.len(),
+            });
+        }
+        let mut off = 0;
+        macro_rules! take {
+            ($ty:ty) => {{
+                const N: usize = core::mem::size_of::<$ty>();
+                let arr: [u8; N] = buf[off..off + N].try_into().unwrap();
+                off += N;
+                <$ty>::from_le_bytes(arr)
+            }};
+        }
+        let magic = take!(u32);
+        let schema_version = take!(u16);
+        if magic != STATE_MAGIC {
+            return Err(WireError::BadMagic {
+                expected: STATE_MAGIC,
+                got: magic,
+            });
+        }
+        if schema_version != SCHEMA_VERSION {
+            return Err(WireError::BadVersion {
+                expected: SCHEMA_VERSION,
+                got: schema_version,
+            });
+        }
+        let flags = take!(u16);
+        let seq = take!(u64);
+        let sim_time_s = take!(f64);
+        let pos = [take!(f32), take!(f32), take!(f32)];
+        let quat = [take!(f32), take!(f32), take!(f32), take!(f32)];
+        let wheel_angle_rad = take!(f32);
+        let wheel_rate_rad_s = take!(f32);
+        let pitch_rad = take!(f32);
+        let yaw_rad = take!(f32);
+        let motor_current_a = take!(f32);
+        debug_assert_eq!(off, Self::WIRE_SIZE);
+        Ok(StateOut {
+            magic,
+            schema_version,
+            flags,
+            seq,
+            sim_time_s,
+            pos,
+            quat,
+            wheel_angle_rad,
+            wheel_rate_rad_s,
+            pitch_rad,
+            yaw_rad,
+            motor_current_a,
+        })
+    }
+}
+
+/// One tick of pilot input, Unreal -> host (issue #161 wire v1).
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InputIn {
+    pub magic: u32,
+    pub schema_version: u16,
+    pub flags: u16,
+    pub seq: u64,
+    /// Clamped to `[-1, 1]`.
+    pub weight_shift_fore_aft: f32,
+    /// Clamped to `[-1, 1]`.
+    pub weight_shift_lateral: f32,
+    /// Clamped to `[-1, 1]`. NON-PHYSICAL -- see [`StateOut::yaw_rad`].
+    pub steer: f32,
+}
+
+impl InputIn {
+    pub const WIRE_SIZE: usize = 28;
+
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_SIZE] {
+        let mut buf = [0u8; Self::WIRE_SIZE];
+        let mut off = 0;
+        macro_rules! put {
+            ($val:expr) => {{
+                let bytes = $val.to_le_bytes();
+                buf[off..off + bytes.len()].copy_from_slice(&bytes);
+                off += bytes.len();
+            }};
+        }
+        put!(self.magic);
+        put!(self.schema_version);
+        put!(self.flags);
+        put!(self.seq);
+        put!(self.weight_shift_fore_aft);
+        put!(self.weight_shift_lateral);
+        put!(self.steer);
+        debug_assert_eq!(off, Self::WIRE_SIZE);
+        buf
+    }
+
+    /// Parses a received datagram. Fails loudly on a magic/version mismatch
+    /// (issue #161) -- the input socket is non-blocking and best-effort, but
+    /// "best effort" means dropping a bad packet, not misparsing its bytes
+    /// as floats.
+    pub fn from_bytes(buf: &[u8]) -> Result<Self, WireError> {
+        if buf.len() != Self::WIRE_SIZE {
+            return Err(WireError::WrongSize {
+                expected: Self::WIRE_SIZE,
+                got: buf.len(),
+            });
+        }
+        let mut off = 0;
+        macro_rules! take {
+            ($ty:ty) => {{
+                const N: usize = core::mem::size_of::<$ty>();
+                let arr: [u8; N] = buf[off..off + N].try_into().unwrap();
+                off += N;
+                <$ty>::from_le_bytes(arr)
+            }};
+        }
+        let magic = take!(u32);
+        let schema_version = take!(u16);
+        if magic != INPUT_MAGIC {
+            return Err(WireError::BadMagic {
+                expected: INPUT_MAGIC,
+                got: magic,
+            });
+        }
+        if schema_version != SCHEMA_VERSION {
+            return Err(WireError::BadVersion {
+                expected: SCHEMA_VERSION,
+                got: schema_version,
+            });
+        }
+        let flags = take!(u16);
+        let seq = take!(u64);
+        let weight_shift_fore_aft = take!(f32).clamp(-1.0, 1.0);
+        let weight_shift_lateral = take!(f32).clamp(-1.0, 1.0);
+        let steer = take!(f32).clamp(-1.0, 1.0);
+        debug_assert_eq!(off, Self::WIRE_SIZE);
+        Ok(InputIn {
+            magic,
+            schema_version,
+            flags,
+            seq,
+            weight_shift_fore_aft,
+            weight_shift_lateral,
+            steer,
+        })
+    }
+}
+
+/// A dropped packet, and why -- logged, never silently swallowed (issue
+/// #161: "fail loudly on magic or version mismatch").
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WireError {
+    WrongSize { expected: usize, got: usize },
+    BadMagic { expected: u32, got: u32 },
+    BadVersion { expected: u16, got: u16 },
+}
+
+impl core::fmt::Display for WireError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            WireError::WrongSize { expected, got } => {
+                write!(f, "wrong packet size: expected {expected}, got {got}")
+            }
+            WireError::BadMagic { expected, got } => {
+                write!(f, "bad magic: expected {expected:#010x}, got {got:#010x}")
+            }
+            WireError::BadVersion { expected, got } => {
+                write!(f, "bad schema_version: expected {expected}, got {got}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WireError {}
+
+/// Parses [`SocketAddr`]s for the fixed loopback endpoints. `unwrap()` is
+/// fine here -- these are compile-time-constant literals, not user input.
+pub fn state_out_addr() -> SocketAddr {
+    STATE_OUT_ADDR.parse().unwrap()
+}
+
+pub fn input_in_addr() -> SocketAddr {
+    INPUT_IN_ADDR.parse().unwrap()
+}
+
+// Compile-time size assertions (issue #161): a future field edit that
+// silently changes either struct's layout must fail the build, not ship a
+// wire mismatch to Unreal.
+const _: () = assert!(core::mem::size_of::<StateOut>() == StateOut::WIRE_SIZE);
+const _: () = assert!(core::mem::size_of::<InputIn>() == InputIn::WIRE_SIZE);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_out_is_exactly_72_bytes() {
+        assert_eq!(core::mem::size_of::<StateOut>(), 72);
+    }
+
+    #[test]
+    fn input_in_is_exactly_28_bytes() {
+        assert_eq!(core::mem::size_of::<InputIn>(), 28);
+    }
+
+    fn sample_state() -> StateOut {
+        StateOut {
+            magic: STATE_MAGIC,
+            schema_version: SCHEMA_VERSION,
+            flags: STATE_FLAG_ARMED | STATE_FLAG_VALID,
+            seq: 42,
+            sim_time_s: 1.5,
+            pos: [1.0, 2.0, 3.0],
+            quat: [1.0, 0.0, 0.0, 0.0],
+            wheel_angle_rad: 0.1,
+            wheel_rate_rad_s: 0.2,
+            pitch_rad: -0.05,
+            yaw_rad: 0.3,
+            motor_current_a: 4.5,
+        }
+    }
+
+    #[test]
+    fn state_out_round_trips() {
+        let s = sample_state();
+        let bytes = s.to_bytes();
+        assert_eq!(bytes.len(), StateOut::WIRE_SIZE);
+        let back = StateOut::from_bytes(&bytes).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn state_out_rejects_bad_magic() {
+        let mut bytes = sample_state().to_bytes();
+        bytes[0] = 0; // corrupt magic's first byte
+        assert!(matches!(
+            StateOut::from_bytes(&bytes),
+            Err(WireError::BadMagic { .. })
+        ));
+    }
+
+    #[test]
+    fn state_out_rejects_bad_version() {
+        let mut bytes = sample_state().to_bytes();
+        bytes[4] = 9; // schema_version low byte
+        bytes[5] = 0;
+        assert!(matches!(
+            StateOut::from_bytes(&bytes),
+            Err(WireError::BadVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn state_out_rejects_wrong_size() {
+        let bytes = [0u8; 10];
+        assert_eq!(
+            StateOut::from_bytes(&bytes),
+            Err(WireError::WrongSize {
+                expected: StateOut::WIRE_SIZE,
+                got: 10
+            })
+        );
+    }
+
+    fn sample_input() -> InputIn {
+        InputIn {
+            magic: INPUT_MAGIC,
+            schema_version: SCHEMA_VERSION,
+            flags: INPUT_FLAG_ARM,
+            seq: 7,
+            weight_shift_fore_aft: 0.5,
+            weight_shift_lateral: -0.25,
+            steer: 0.1,
+        }
+    }
+
+    #[test]
+    fn input_in_round_trips() {
+        let i = sample_input();
+        let bytes = i.to_bytes();
+        assert_eq!(bytes.len(), InputIn::WIRE_SIZE);
+        let back = InputIn::from_bytes(&bytes).unwrap();
+        assert_eq!(back, i);
+    }
+
+    #[test]
+    fn input_in_rejects_bad_magic() {
+        let mut bytes = sample_input().to_bytes();
+        bytes[0] = 0;
+        assert!(matches!(
+            InputIn::from_bytes(&bytes),
+            Err(WireError::BadMagic { .. })
+        ));
+    }
+
+    #[test]
+    fn input_in_clamps_out_of_range_axes() {
+        let mut i = sample_input();
+        i.weight_shift_fore_aft = 5.0;
+        i.weight_shift_lateral = -5.0;
+        i.steer = 2.0;
+        let bytes = i.to_bytes();
+        let back = InputIn::from_bytes(&bytes).unwrap();
+        // Copied to locals first -- `assert_eq!` takes its arguments by
+        // reference internally, which is unaligned-reference UB straight off
+        // a packed field (see wire.rs's module doc comment).
+        let (fore_aft, lateral, steer) = (
+            back.weight_shift_fore_aft,
+            back.weight_shift_lateral,
+            back.steer,
+        );
+        assert_eq!(fore_aft, 1.0);
+        assert_eq!(lateral, -1.0);
+        assert_eq!(steer, 1.0);
+    }
+
+    #[test]
+    fn addrs_parse_to_the_documented_ports() {
+        assert_eq!(state_out_addr().port(), 9601);
+        assert_eq!(input_in_addr().port(), 9602);
+    }
+}


### PR DESCRIPTION
## Summary

Issue #161 (W1, launch-critical). Adds `crates/sim-host`: a library + thin
binary that runs the already-working closed loop (`plant-mujoco` +
`control-core`/`safety`, via `sim-backend`'s `hal` seam — the same objects
`control-ffi` wires for the Python-hosted scenario and
`impulse-response-rust` wires for the existing Rust-hosted one) on its own
dedicated 500 Hz thread, and speaks the COO-fixed v1 UDP wire
([ADR-0010](docs/decisions/ADR-0010-game-wire-v1-fixed-for-the-launch-weekend.md),
which landed on `master` mid-session and matches this dispatch's spec
field-for-field — confirmed, not re-derived).

- **`StateOut`** (host → `127.0.0.1:9601`) / **`InputIn`** (renderer →
  `127.0.0.1:9602`), `#[repr(C, packed)]` so the on-wire size is exactly the
  sum of the fields (a plain `#[repr(C)]` would silently pad `InputIn` by 4
  bytes — see `wire.rs`'s module doc). Compile-time size assertions (72 /
  28 bytes) plus byte-size unit tests. Magic/version mismatches are logged
  and dropped, never misparsed.
- **`Pacer`**: absolute deadlines on a monotonic clock (`next_deadline +=
  period`), never `sleep(period)` per iteration. Counts every missed
  deadline; nothing is silently swallowed. Deterministic unit tests (inject
  `Instant`, no real sleeping — a real-clock version of these tests flaked
  under `cargo test --workspace`'s parallel load).
- Input socket is non-blocking, most-recent-packet-wins, holds last then
  zeroes `weight_shift_*`/`steer` after a documented 100 ms staleness
  timeout.
- `weight_shift_*`/arm/reset are accepted, clamped, and logged on receipt,
  but do not yet drive anything (W1 scope) — wired end-to-end so W2 only has
  to connect them to actuators/reset. The host self-arms unconditionally at
  startup (matching every existing Rust-hosted harness in this repo); the
  input's `arm` bit is tracked/logged, not yet gating.
- `yaw_rad` is a documented non-physical integration of `steer`.
  `wheel_angle_rad` is dead-reckoned from the rate `hal` already reports —
  there is no absolute wheel-angle channel on the ICD (same as real VESC
  telemetry), so this is what a real host would have to do too.
- Host emits **raw MuJoCo world-frame** `pos`/`quat`. No Unreal-frame
  conversion happens here — ADR-0010 assigns that to the renderer.
- **`plant-mujoco`**: adds `body_xpos`/`body_xquat` accessors, mirroring the
  existing `body_xmat` exactly (same shim.c pattern). **`sim-backend`**:
  adds `truth_frame_xpos`/`truth_frame_xquat`, mirroring
  `truth_frame_xmat`. Both additive; existing behaviour untouched (see test
  results below).
- A one-time startup disturbance (same magnitude as
  `impulse-response-rust`'s already-proven impulse, `NOMINAL_IMPULSE_NS` =
  20 N·s / 0.05 s) is applied once near the start of every run. Without it
  the undisturbed board sits exactly at its unperturbed equilibrium and
  `pitch_rad` reports exactly `0.0` forever — which satisfies the wire but
  proves nothing. This is internal to the host's own startup, not a general
  disturbance API (the wire carries none).
- **`src/bin/wire-probe.rs`**: the CEO-visible verification tool — a
  standalone UDP listener (only depends on `sim_host::wire`, not the
  library) that reports measured tick rate, inter-packet interval
  stats, the host's own missed-deadline count (read from a small internal
  stats file at `/tmp/overboard-sim-host-stats.txt` — **not** part of the
  wire; the wire table has no room for it), `pitch_rad` min/max/final, and a
  magic+version parse confirmation.

## Real, captured verification run

Built in an isolated `CARGO_TARGET_DIR` (this repo's `target/` is a shared
symlink across sibling worktrees — a stale, differently-linked binary from
another session's build was sitting there and had to be worked around).
`sim-host` run for 16 s, `wire-probe` for 10 s overlapping it:

```
wire-probe: listening on 127.0.0.1:9601 for 10.0s
--- wire-probe report ---
run duration: 10.007 s
total ticks (valid state packets received): 5001
measured tick rate (mean): 499.73 Hz
seq range: 2152..=7152 (span 5001)
inter-packet interval (ms): mean=2.0000 p50=0.0870 p99=15.5845 max=17.4365
missed-deadline count from the host: 5023 (host reports 7127 ticks, stats file /tmp/overboard-sim-host-stats.txt)
pitch_rad: min=-0.010409 max=-0.009652 final=-0.009652 (-0.596 deg / -0.553 deg / -0.553 deg)
confirmation: magic (0x4f425731) + schema_version (1) parsed correctly on all 5001/5001 received packets
```

Host's own final line for the full 16 s run: `sim-host: stopped cleanly --
7994 ticks, 5618 missed deadlines`.

**Read honestly, not tuned to look good:**
- The board **does balance and recover**: kicked by the startup impulse, it
  settles to a small residual pitch (~0.55°) and holds there — this is the
  literal proof the wire-probe report exists for.
- The **wire itself is clean**: exact target rate over the measured window
  (499.73 Hz average), zero parse failures, `p50` inter-packet interval
  0.087 ms (most ticks land back-to-back, i.e. bursty rather than evenly
  spaced) with a `p99`/`max` around 15–17 ms.
- The **missed-deadline rate is real and bad — about 70%.** This machine is
  stock macOS on a shared laptop, not the PREEMPT_RT Linux target this
  project is built for (see this repo's own `CLAUDE.md`), and a hard 2 ms
  deadline on a non-realtime, non-dedicated scheduler is a genuinely
  difficult bar. The `Pacer` itself is doing the right thing (absolute
  deadlines, no drift accumulation — the aggregate tick rate stays pinned
  at ~500 Hz despite the miss rate, which is only possible because misses
  aren't compounding), and the counter is deliberately unforgiving (`Pacer`
  counts *any* overrun, however small — no slack constant). I am not
  claiming this meets a real-time bar on this hardware; I'm reporting the
  real number per the standing instruction not to fake it.

## Verification run commands (for repro)
```
cargo build --release -p sim-host
cargo run --release -q -p sim-host --bin sim-host -- --duration-secs 16   # background
cargo run --release -q -p sim-host --bin wire-probe -- --seconds 10       # overlapping
```
(`cargo run`, not the raw binary path — this repo's `libmujoco` link needs
the `DYLD_LIBRARY_PATH` Cargo injects automatically for `cargo run`/`cargo
test`; see `plant-mujoco/build.rs`'s own doc comment.)

## Test plan
- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (5 repeated runs, no flakes)
- [x] `cargo test -p sim-host` green (wire round-trip/size/magic/version
      tests, deterministic `Pacer` tests)
- [x] Existing Python gates that depend on the touched `plant-mujoco`/
      `sim-backend` crates still pass: `pytest tests/
      test_rust_python_plant_replay_equivalence.py
      tests/test_rust_hosted_impulse_response.py` (8 passed) and the full
      `pytest tests/` (293 passed, 2 xfailed)
- [x] Real captured `sim-host` + `wire-probe` run, output above

## Assumptions / calls made (flagging for review)
1. **No literal `control-ffi` C-ABI link.** Wired `control-core`/`safety`
   directly, mirroring `board-app-driverless/src/bin/impulse-response-rust.rs`
   (the existing precedent for a Rust-hosted closed loop) rather than
   linking `control-ffi`'s cdylib as an rlib — nothing else in the workspace
   consumes it that way. Same underlying objects either path.
2. **`FALLEN` threshold** is a fixed 20° proxy, not the real collision-hull
   nose-strike angle (18.57°, `sim/scenarios/disturbance_envelope.py`) —
   this crate has no Rust binding to that geometry query.
3. **Missed-deadline count is out-of-band** (small stats file), since the
   fixed wire table has no field for it.
4. **Host self-arms unconditionally**; the input `arm` bit is tracked/logged
   but does not yet gate anything (W1).
5. **One-time startup kick**, described above — not asked for in those exact
   words, added so the CEO-visible probe output demonstrates real recovery
   rather than an untested, motionless zero.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>