### PR TITLE
feat(controls): W2 -- ridden rider model, lean-to-drive, roll-shaped yaw limiter

### DIFF
--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -56,6 +56,7 @@ extern "C" {
     fn plant_mujoco_get_body_xmat(data: *mut c_void, body_id: c_int, out: *mut f64);
     fn plant_mujoco_get_body_xpos(data: *mut c_void, body_id: c_int, out: *mut f64);
     fn plant_mujoco_get_body_xquat(data: *mut c_void, body_id: c_int, out: *mut f64);
+    fn plant_mujoco_actuator_id(model: *mut c_void, name: *const c_char) -> c_int;
 }
 
 /// The linked libmujoco's own `mj_versionString()`.
@@ -324,6 +325,23 @@ impl Plant {
         let name_c = CString::new(name).expect("body name must not contain a NUL byte");
         // SAFETY: see `sensor_adr_dim`.
         let id = unsafe { plant_mujoco_body_id(self.model, name_c.as_ptr()) };
+        if id < 0 {
+            None
+        } else {
+            Some(id as usize)
+        }
+    }
+
+    /// `mjModel`'s actuator id for `name`, or `None` if there is no such
+    /// actuator. Exists for issue #161 W2: `sim-host` now drives models with
+    /// a variable actuator count (the driverless model's single
+    /// `wheel_motor` vs. the rider model's `wheel_motor` plus two ballast
+    /// position actuators), so `hal`'s `wait_observe()` no longer assumes a
+    /// fixed `ctrl` layout -- see `sim-backend`'s own resolve-by-name.
+    pub fn actuator_id(&self, name: &str) -> Option<usize> {
+        let name_c = CString::new(name).expect("actuator name must not contain a NUL byte");
+        // SAFETY: see `sensor_adr_dim`.
+        let id = unsafe { plant_mujoco_actuator_id(self.model, name_c.as_ptr()) };
         if id < 0 {
             None
         } else {

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -174,3 +174,12 @@ void plant_mujoco_get_body_xpos(void* data, int body_id, double* out) {
 void plant_mujoco_get_body_xquat(void* data, int body_id, double* out) {
   memcpy(out, ((mjData*)data)->xquat + 4 * body_id, 4 * sizeof(double));
 }
+
+// Actuator lookup by NAME, for issue #161 W2: `sim-host` now drives models
+// with a variable actuator count (the driverless model's single wheel_motor
+// vs. the rider model's wheel_motor + two ballast position actuators), so
+// `ctrl` must be built by resolving each channel's index rather than
+// assuming a fixed layout -- same reasoning as plant_mujoco_sensor_id.
+int plant_mujoco_actuator_id(void* model, const char* name) {
+  return mj_name2id((const mjModel*)model, mjOBJ_ACTUATOR, name);
+}

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -64,9 +64,19 @@ const CYCLE_NS: u64 = 2_000_000;
 /// below pins it against the compiled model so the two cannot silently drift.
 const KT_NM_PER_A: f64 = 0.7;
 
-/// The model this backend steps. Fixed, not configurable -- this crate's own
-/// header has always named it "the MuJoCo onewheel model", and I1c does not
-/// introduce a model-selection surface.
+/// The model this backend steps BY DEFAULT -- the driverless onewheel plant,
+/// unchanged since I1c. Every existing caller (this crate's own tests,
+/// `impulse-response-rust`, the driverless `hal` seam) keeps stepping exactly
+/// this model, because `open()` only reaches for it when
+/// [`SimBackend::model_path_override`] is `None`.
+///
+/// CHANGED from "fixed, not configurable" (I1c's original claim, now stale):
+/// issue #161 W2 needs a second model -- a ridden variant carrying a
+/// physically jointed rider ballast (`overboard_rider.xml`) -- and
+/// `sim-backend` has no Python binding to patch a model string at runtime
+/// the way the Python scenarios do, so a real per-instance override is the
+/// only way `sim-host` can point this backend at it. See
+/// [`SimBackend::with_model_path`].
 fn model_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sim/models/overboard_onewheel.xml")
 }
@@ -105,6 +115,22 @@ pub struct SimBackend {
     /// `mjModel` body id of the `frame` body, resolved once in `open()`.
     /// Only used by [`SimBackend::apply_external_force`], not by `hal`.
     frame_body: usize,
+    /// `mjModel` actuator id of `wheel_motor`, resolved BY NAME in `open()`
+    /// (issue #161 W2). Previously assumed to be `ctrl` index 0 outright --
+    /// only ever correct because the driverless model has exactly one
+    /// actuator. A model with more (the ridden rider model's two ballast
+    /// actuators) makes that assumption wrong, silently.
+    wheel_motor_actuator: usize,
+    /// `mjModel` actuator ids of the two ballast position actuators, if the
+    /// open model declares them -- `None` for the driverless onewheel model,
+    /// which has no ballast at all. Resolved once in `open()`.
+    ballast_fa_actuator: Option<usize>,
+    ballast_lateral_actuator: Option<usize>,
+    /// Commanded ballast actuator targets, metres -- see
+    /// [`SimBackend::set_ballast_targets`]. Zero (centred) until set, and
+    /// reset to zero on every `open()`.
+    ballast_fa_target_m: f32,
+    ballast_lateral_target_m: f32,
     cycle: u64,
     open: bool,
     armed: bool,
@@ -115,6 +141,9 @@ pub struct SimBackend {
     /// The current now actually flowing, as far as the plant is concerned.
     applied_current_a: f32,
     params: Params,
+    /// Overrides `model_path()`'s default when `Some` (issue #161 W2). See
+    /// [`SimBackend::with_model_path`].
+    model_path_override: Option<PathBuf>,
 }
 
 impl SimBackend {
@@ -127,6 +156,35 @@ impl SimBackend {
             params,
             ..SimBackend::default()
         }
+    }
+
+    /// Like [`SimBackend::with_params`], but steps `model_path` instead of
+    /// the default driverless onewheel model (issue #161 W2) -- `sim-host`'s
+    /// ridden configuration uses this to open `overboard_rider.xml`.
+    pub fn with_model_path(params: Params, model_path: PathBuf) -> Self {
+        SimBackend {
+            params,
+            model_path_override: Some(model_path),
+            ..SimBackend::default()
+        }
+    }
+
+    /// Sets the two ballast position-actuator targets, metres, taking effect
+    /// on the next [`BoardObserve::wait_observe`] call (issue #161 W2) -- the
+    /// ridden rider model's physically-simulated fore/aft and lateral
+    /// weight-shift channels. **Not part of `hal`**: real hardware has no
+    /// ballast. A no-op on a model that declares neither actuator (e.g. the
+    /// driverless onewheel model) rather than an error -- same tolerance
+    /// [`SimBackend::apply_external_force`] has for a body/site a model does
+    /// not declare.
+    ///
+    /// Buffered like `apply_external_force`: overwrites whatever was set for
+    /// the current step rather than accumulating, so a caller must call this
+    /// every cycle (with the current weight-shift value, or zero) or a stale
+    /// target will persist.
+    pub fn set_ballast_targets(&mut self, fore_aft_m: f32, lateral_m: f32) {
+        self.ballast_fa_target_m = fore_aft_m;
+        self.ballast_lateral_target_m = lateral_m;
     }
 
     /// The current the plant is seeing. Exposed for tests.
@@ -220,7 +278,8 @@ impl SimBackend {
 
 impl BoardObserve for SimBackend {
     fn open(&mut self) -> Result<(), IoError> {
-        let mut plant = Plant::open(&model_path()).map_err(|e| {
+        let path = self.model_path_override.clone().unwrap_or_else(model_path);
+        let mut plant = Plant::open(&path).map_err(|e| {
             eprintln!("sim-backend: Plant::open failed: {e}");
             IoError::Fatal(FaultCode::ConfigMismatch)
         })?;
@@ -270,11 +329,21 @@ impl BoardObserve for SimBackend {
         self.frame_body = plant
             .body_id("frame")
             .expect("overboard_onewheel.xml must declare a frame body");
+        self.wheel_motor_actuator = plant
+            .actuator_id("wheel_motor")
+            .expect("the model must declare a wheel_motor actuator");
+        // `None` on the driverless model, which declares neither -- resolved
+        // by name so a model that DOES declare them (the ridden rider model,
+        // issue #161 W2) does not depend on ctrl-array position.
+        self.ballast_fa_actuator = plant.actuator_id("ballast_fa");
+        self.ballast_lateral_actuator = plant.actuator_id("ballast_lat");
 
         self.plant = Some(plant);
         self.cycle = 0;
         self.pending_current_a = None;
         self.applied_current_a = 0.0;
+        self.ballast_fa_target_m = 0.0;
+        self.ballast_lateral_target_m = 0.0;
         self.open = true;
         self.seq.reset();
         Ok(())
@@ -309,7 +378,18 @@ impl BoardObserve for SimBackend {
         if let Some(pending) = self.pending_current_a.take() {
             self.applied_current_a = pending;
         }
-        let ctrl = [self.applied_current_a as f64 * KT_NM_PER_A];
+        // Built by resolved actuator index, not a fixed-length array (issue
+        // #161 W2): the driverless model has one actuator, the ridden rider
+        // model has three. Ballast channels stay at MuJoCo's zero-init
+        // default (0.0) on a model that does not declare them.
+        let mut ctrl = vec![0.0f64; plant.nu()];
+        ctrl[self.wheel_motor_actuator] = self.applied_current_a as f64 * KT_NM_PER_A;
+        if let Some(idx) = self.ballast_fa_actuator {
+            ctrl[idx] = self.ballast_fa_target_m as f64;
+        }
+        if let Some(idx) = self.ballast_lateral_actuator {
+            ctrl[idx] = self.ballast_lateral_target_m as f64;
+        }
 
         // AC3: sim time comes from mjData::time, read after stepping, never
         // a parallel counter.

--- a/crates/sim-host/Cargo.toml
+++ b/crates/sim-host/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/bin/sim-host.rs"
 name = "wire-probe"
 path = "src/bin/wire-probe.rs"
 
+[[bin]]
+name = "send-input"
+path = "src/bin/send-input.rs"
+
 [dependencies]
 board-types = { workspace = true }
 hal = { workspace = true }

--- a/crates/sim-host/src/bin/send-input.rs
+++ b/crates/sim-host/src/bin/send-input.rs
@@ -1,0 +1,116 @@
+//! A scripted UDP input SENDER, for verification runs only (issue #161 W2).
+//!
+//! **Not** part of the wire consumer set Unreal implements -- this is this
+//! crate's own dev/verification tool, standing in for a player until the
+//! real UE client exists. It reuses [`sim_host::wire::InputIn`] directly
+//! rather than re-implementing the byte layout in a second language, so the
+//! encoding is guaranteed correct the same way `wire-probe` guarantees its
+//! decoding is.
+//!
+//! Sends one `InputIn` packet every 20 ms (50 Hz, comfortably above
+//! `sim-host`'s 100 ms staleness timeout) to `127.0.0.1:9602`, stepping
+//! through the fixed schedule below: settle, lean forward (accelerate),
+//! release (coast), lean back (decelerate then reverse), release again,
+//! lean+steer (turn) -- the sequence issue #161 W2's acceptance criterion
+//! asks for ("drives forward, slows and reverses under lean, and turns").
+//!
+//! ```text
+//! send-input [--target ADDR]
+//! ```
+
+use sim_host::wire::{InputIn, INPUT_MAGIC, SCHEMA_VERSION};
+use std::net::UdpSocket;
+use std::time::{Duration, Instant};
+
+/// `(start_s, end_s, weight_shift_fore_aft, weight_shift_lateral, steer, label)`.
+/// Values are within `[-1, 1]`; `sim-host` scales them onto the model's
+/// actual ballast/yaw ranges.
+const SCHEDULE: &[(f64, f64, f32, f32, f32, &str)] = &[
+    (0.0, 1.5, 0.0, 0.0, 0.0, "settle"),
+    (1.5, 4.5, 0.6, 0.0, 0.0, "lean forward (accelerate)"),
+    (4.5, 6.5, 0.0, 0.0, 0.0, "release (coast)"),
+    (
+        6.5,
+        10.0,
+        -0.6,
+        0.0,
+        0.0,
+        "lean back (decelerate, then reverse)",
+    ),
+    (10.0, 12.0, 0.0, 0.0, 0.0, "release (coast reversed)"),
+    (12.0, 14.0, 0.0, 0.8, 0.6, "lean right + steer (turn)"),
+    (14.0, 15.0, 0.0, 0.0, 0.0, "release"),
+];
+
+fn total_duration_s() -> f64 {
+    SCHEDULE.iter().map(|s| s.1).fold(0.0, f64::max)
+}
+
+fn value_at(t: f64) -> (f32, f32, f32, &'static str) {
+    for &(t0, t1, fa, lat, steer, label) in SCHEDULE {
+        if t0 <= t && t < t1 {
+            return (fa, lat, steer, label);
+        }
+    }
+    (0.0, 0.0, 0.0, "end")
+}
+
+fn main() {
+    let mut target = sim_host::wire::INPUT_IN_ADDR.to_string();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--target" => {
+                target = args.get(i + 1).cloned().unwrap_or_else(|| {
+                    eprintln!("send-input: --target needs a value");
+                    std::process::exit(1);
+                });
+                i += 2;
+            }
+            other => {
+                eprintln!("send-input: unrecognized argument '{other}'");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("send-input: bind failed");
+    let duration = total_duration_s();
+    eprintln!("send-input: sending to {target} for {duration:.1}s per the fixed schedule");
+
+    let start = Instant::now();
+    let period = Duration::from_millis(20);
+    let mut seq: u64 = 0;
+    let mut last_label = "";
+
+    loop {
+        let t = start.elapsed().as_secs_f64();
+        if t > duration {
+            break;
+        }
+        let (fore_aft, lateral, steer, label) = value_at(t);
+        if label != last_label {
+            eprintln!(
+                "send-input: t={t:6.2}s -> {label} (fore_aft={fore_aft:+.2} lateral={lateral:+.2} steer={steer:+.2})"
+            );
+            last_label = label;
+        }
+        let pkt = InputIn {
+            magic: INPUT_MAGIC,
+            schema_version: SCHEMA_VERSION,
+            flags: 0,
+            seq,
+            weight_shift_fore_aft: fore_aft,
+            weight_shift_lateral: lateral,
+            steer,
+        };
+        if let Err(e) = socket.send_to(&pkt.to_bytes(), &target) {
+            eprintln!("send-input: send failed: {e}");
+        }
+        seq += 1;
+        std::thread::sleep(period);
+    }
+
+    eprintln!("send-input: schedule complete ({seq} packets sent)");
+}

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -6,11 +6,16 @@
 //! a final summary when the loop stops.
 //!
 //! ```text
-//! sim-host [--duration-secs SECONDS]
+//! sim-host [--duration-secs SECONDS] [--startup-kick]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
-//! it, stops after that many seconds and exits -- used for the issue #161
-//! verification run and for anything else that wants a bounded process.
+//! it, stops after that many seconds and exits -- used for verification runs
+//! and anything else that wants a bounded process.
+//!
+//! `--startup-kick` is OFF by default (issue #169): a normal run must not
+//! shove the board before a player has touched anything. Pass it explicitly
+//! for a `wire-probe` diagnostic run that wants a guaranteed disturbance to
+//! show recovery from.
 
 use sim_host::HostConfig;
 use std::process::ExitCode;
@@ -35,6 +40,10 @@ fn main() -> ExitCode {
                 cfg.duration = Some(Duration::from_secs_f64(secs));
                 i += 2;
             }
+            "--startup-kick" => {
+                cfg.startup_kick = true;
+                i += 1;
+            }
             other => {
                 eprintln!("sim-host: unrecognized argument '{other}'");
                 return ExitCode::FAILURE;
@@ -43,8 +52,8 @@ fn main() -> ExitCode {
     }
 
     eprintln!(
-        "sim-host: starting -- state out to {}, input in on {}, duration={:?}",
-        cfg.state_out_addr, cfg.input_in_addr, cfg.duration
+        "sim-host: starting -- state out to {}, input in on {}, duration={:?}, startup_kick={}",
+        cfg.state_out_addr, cfg.input_in_addr, cfg.duration, cfg.startup_kick
     );
 
     let handle = sim_host::spawn(cfg);

--- a/crates/sim-host/src/bin/wire-probe.rs
+++ b/crates/sim-host/src/bin/wire-probe.rs
@@ -6,7 +6,7 @@
 //! produces it.
 //!
 //! ```text
-//! wire-probe [--seconds N] [--bind ADDR] [--host-stats PATH]
+//! wire-probe [--seconds N] [--bind ADDR] [--host-stats PATH] [--csv PATH]
 //! ```
 //! Binds `--bind` (default `127.0.0.1:9601`, the documented state-out
 //! address), listens for `--seconds` (default 10), and prints a plain-text
@@ -14,6 +14,12 @@
 //! missed-deadline count (read from `--host-stats`, best-effort -- issue
 //! #161's wire itself carries no room for that counter), pitch_rad
 //! min/max/final, and a magic+version parse confirmation.
+//!
+//! `--csv PATH` (issue #161 W2 / #169) additionally writes one row per
+//! received packet -- seq, sim_time_s, pos_x/y, pitch/yaw/roll_rad,
+//! wheel_rate_rad_s, motor_current_a -- because "the board balances" is no
+//! longer the claim W2 needs evidence for; "speed responds to lean" is, and
+//! that needs a real trace, not a min/max/final summary.
 
 use sim_host::wire::{StateOut, SCHEMA_VERSION, STATE_MAGIC};
 use std::net::UdpSocket;
@@ -24,6 +30,7 @@ struct Args {
     seconds: f64,
     bind: String,
     host_stats: PathBuf,
+    csv: Option<PathBuf>,
 }
 
 impl Default for Args {
@@ -32,6 +39,7 @@ impl Default for Args {
             seconds: 10.0,
             bind: sim_host::wire::STATE_OUT_ADDR.to_string(),
             host_stats: PathBuf::from(sim_host::host::DEFAULT_STATS_PATH),
+            csv: None,
         }
     }
 }
@@ -57,10 +65,26 @@ fn parse_args() -> Result<Args, String> {
                 a.host_stats = PathBuf::from(args.get(i + 1).ok_or("--host-stats needs a value")?);
                 i += 2;
             }
+            "--csv" => {
+                a.csv = Some(PathBuf::from(args.get(i + 1).ok_or("--csv needs a value")?));
+                i += 2;
+            }
             other => return Err(format!("unrecognized argument '{other}'")),
         }
     }
     Ok(a)
+}
+
+/// One `--csv` output row -- see the module doc comment.
+struct CsvRow {
+    seq: u64,
+    sim_time_s: f64,
+    pos_x_m: f32,
+    pos_y_m: f32,
+    pitch_rad: f32,
+    yaw_rad: f32,
+    wheel_rate_rad_s: f32,
+    motor_current_a: f32,
 }
 
 fn percentile(sorted_ms: &[f64], p: f64) -> f64 {
@@ -126,6 +150,10 @@ fn main() {
     let mut pitch_final: f32 = f32::NAN;
     let mut first_seq: Option<u64> = None;
     let mut last_seq: Option<u64> = None;
+    // Buffered in memory and written once at the end, not appended live:
+    // this run is at most a few thousand packets, and a single write avoids
+    // interleaving I/O with the receive loop's own timing.
+    let mut csv_rows: Vec<CsvRow> = Vec::new();
 
     while Instant::now() < deadline {
         match socket.recv_from(&mut buf) {
@@ -140,6 +168,19 @@ fn main() {
                     let seq = state.seq;
                     first_seq.get_or_insert(seq);
                     last_seq = Some(seq);
+                    if args.csv.is_some() {
+                        let pos = state.pos;
+                        csv_rows.push(CsvRow {
+                            seq,
+                            sim_time_s: state.sim_time_s,
+                            pos_x_m: pos[0],
+                            pos_y_m: pos[1],
+                            pitch_rad: pitch,
+                            yaw_rad: state.yaw_rad,
+                            wheel_rate_rad_s: state.wheel_rate_rad_s,
+                            motor_current_a: state.motor_current_a,
+                        });
+                    }
                 }
                 Err(e) => {
                     invalid_count += 1;
@@ -233,5 +274,28 @@ fn main() {
             "confirmation: FAILED -- {invalid_count}/{total_received} received packets did not \
              parse (bad magic/version/size); {valid_count}/{total_received} were good"
         );
+    }
+
+    if let Some(path) = &args.csv {
+        let mut out = String::from(
+            "seq,sim_time_s,pos_x_m,pos_y_m,pitch_rad,yaw_rad,wheel_rate_rad_s,motor_current_a\n",
+        );
+        for r in &csv_rows {
+            out.push_str(&format!(
+                "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6}\n",
+                r.seq,
+                r.sim_time_s,
+                r.pos_x_m,
+                r.pos_y_m,
+                r.pitch_rad,
+                r.yaw_rad,
+                r.wheel_rate_rad_s,
+                r.motor_current_a
+            ));
+        }
+        match std::fs::write(path, out) {
+            Ok(()) => println!("csv: wrote {} rows to {}", csv_rows.len(), path.display()),
+            Err(e) => println!("csv: FAILED to write {}: {e}", path.display()),
+        }
     }
 }

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -6,18 +6,41 @@
 //! through `hal` (`SimBackend::wait_observe`/`apply`) exactly like that
 //! binary, just paced against a UDP client instead of a fixed step count.
 //! Nothing here is a new control law.
+//!
+//! # W2 (issue #161/#169): the RIDDEN plant, and why it does not station-keep
+//!
+//! This host steps `sim/models/overboard_rider.xml`, not the driverless
+//! onewheel model W1 used -- a ridden plant with a rider-scale ballast on
+//! two slide joints. `weight_shift_fore_aft` drives the fore/aft joint
+//! DIRECTLY AND PHYSICALLY (see that model's own header for the full
+//! rationale and the sign convention): shifting the ballast forward moves
+//! the effective centre of mass ahead of the axle, and the inner pitch loop
+//! below -- which only ever holds the FRAME level, never a ground-speed
+//! setpoint -- answers that by accelerating the wheel forward to keep the
+//! frame upright. That is the entire mechanism. There is no outer velocity
+//! loop here, and none is coming this weekend: `control_core::VelocityLoop`
+//! exists and is deliberately unused.
+//!
+//! **The board does not station-keep, and is not supposed to.** A real
+//! onewheel does not either -- lean forward to accelerate, level off to
+//! coast at whatever speed that reached, lean back to decelerate or
+//! reverse. An earlier revision of this file's controller-config comment
+//! called this loop "pure station-keeping balance", which was true of W1's
+//! driverless-plant, `pitch_ref`-only inner loop but became actively wrong
+//! the moment this file switched to a ridden plant with a driven ballast --
+//! nothing in this loop opposes net forward motion, and nothing should.
 
 use crate::pacer::Pacer;
 use crate::wire::{self, InputIn, StateOut};
-use board_types::{Command, Faults, ImuSample, Params, DEFAULT_R_EFF_M, RAD_S_PER_ERPM};
-use control_core::{ComplementaryFilter, Estimator, PitchRegulator, WheelAccelEstimator};
+use board_types::{Command, Faults, ImuSample, Params, RAD_S_PER_ERPM};
+use control_core::{CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator};
 use hal::BoardObserve;
 use hal_actuate::BoardActuate;
 use safety::Envelope;
 use sim_backend::SimBackend;
 use std::io::ErrorKind;
 use std::net::{SocketAddr, UdpSocket};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 /// Nanoseconds per control cycle -- 500 Hz, matching `sim-backend`'s own
@@ -28,22 +51,57 @@ use std::time::{Duration, Instant};
 pub const CYCLE_NS: u64 = 2_000_000;
 const DT_S: f64 = CYCLE_NS as f64 * 1e-9;
 
-// --- Controller config -- identical to
-// `board-app-driverless/src/bin/impulse-response-rust.rs`'s constants (issue
-// #107 AC6), which mirror `sim/scenarios/rust_controller.py`'s own defaults.
-// No outer velocity loop: W1 is pure station-keeping balance, not driving.
-const KP_NM_PER_RAD: f32 = 56.0;
-const KD_NM_PER_RAD_S: f32 = 7.7;
+/// The ridden rider model this host steps (issue #161 W2) -- NOT the
+/// driverless onewheel model `sim-backend::SimBackend::with_params` defaults
+/// to. Same env-macro pattern `sim-backend`'s own (private) `model_path()`
+/// uses, since this crate is at the same `crates/<name>` depth.
+fn rider_model_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sim/models/overboard_rider.xml")
+}
+
+// --- Controller config, ridden variant (issue #161 W2) -- REUSED verbatim
+// from `sim/scenarios/shuttle_run.py`'s own `controller_factory`, the repo's
+// only existing tuned cascade config for a rider-scale plant. That scenario
+// also runs an outer `VelocityLoop` this host does NOT enable (see this
+// file's header) -- the inner-loop gains and estimator config below are
+// reused unchanged regardless, because they are the closest available
+// precedent for THIS plant's mass/inertia, not for the outer loop's absence.
+const KP_NM_PER_RAD: f32 = 140.0;
+const KD_NM_PER_RAD_S: f32 = 21.0;
 const KT_NM_PER_A: f32 = 0.7;
 const MAX_CURRENT_A: f32 = 40.0;
-const ESTIMATOR_TAU_S: f32 = 1.0;
-const WHEEL_ACCEL_TAU_S: f32 = 0.05;
+const ESTIMATOR_TAU_S: f32 = 2.0;
+/// Command-feedforward gain, m/s^2 per amp. `control_ffi::ob_controller_new`'s
+/// own hardcoded fallback for `kt` 0.7 N*m/A / (`r_eff` 0.1454 m * 82.5 kg
+/// total ridden mass) -- 8 kg frame + 4.5 kg wheel + 0.5 kg ballast carrier +
+/// 70 kg rider = 82.5 kg, matching `overboard_rider.xml` exactly.
+/// `shuttle_run.py`'s tuned controller relies on this same FFI fallback
+/// rather than passing its own gain, so this host does too, duplicated here
+/// because this host does not link `control-ffi`.
+const ACCEL_FF_GAIN_M_S2_PER_A: f32 = 0.0584;
+
+/// `weight_shift_fore_aft` / `weight_shift_lateral`, both clamped to
+/// `[-1, 1]` on the wire, map linearly onto this range -- the SAME +/-0.05 m
+/// range `overboard_rider.xml`'s `ballast_fa` / `ballast_lat` joints
+/// declare, so full-stick deflection lands exactly on the joint's own limit
+/// rather than a separately chosen number that could silently drift from it.
+const BALLAST_RANGE_M: f32 = 0.05;
 
 /// Non-physical game channel: full `steer` deflection integrates `yaw_rad`
-/// at this rate. An arbitrary "game feel" placeholder for W1 -- the
+/// at this rate, SHAPED by [`ROLL_FULL_YAW_AUTHORITY_RAD`] below -- the
 /// simulated wheel is a cylinder and cannot physically carve (issue #161).
-/// W2's lean-steer controller replaces this with something real.
+/// The real lean-steer controller is Tuesday.
 const YAW_RATE_GAIN_RAD_S: f32 = 1.5;
+
+/// Roll magnitude, radians, at which the roll-shaped yaw limiter reaches
+/// full authority (issue #161 W2 item 4 -- the cheap stopgap: `steer`'s
+/// authority is scaled by how much the rider is actually leaning, so a
+/// player has to lean to turn hard, rather than `steer` alone doing
+/// everything regardless of stance). Not derived from the widened wheel's
+/// exact tip angle -- this crate has no Rust binding to that collision-hull
+/// geometry query, same caveat as [`FALLEN_PITCH_RAD`] below -- a documented
+/// round placeholder, not a bench-tuned number.
+const ROLL_FULL_YAW_AUTHORITY_RAD: f32 = 10.0 * std::f32::consts::PI / 180.0;
 
 /// How long a stale input is still trusted before the host zeroes it rather
 /// than continuing to act on a value from a client that may have gone away.
@@ -60,14 +118,14 @@ const INPUT_STALENESS_TIMEOUT: Duration = Duration::from_millis(100);
 /// clearly down", not precise enough to gate a published claim.
 const FALLEN_PITCH_RAD: f32 = 20.0 * std::f32::consts::PI / 180.0;
 
-/// A ONE-TIME startup disturbance, applied near the beginning of every run.
-/// Not a general disturbance API -- the input wire carries no such field
-/// (issue #161) -- and not required by the wire spec itself. It exists so a
-/// verification run (`wire-probe`) demonstrates the controller actually
-/// RECOVERING from a push, rather than sitting at a motionless, never-
-/// disturbed equilibrium the whole time: with nothing to react to,
-/// `pitch_rad` would report exactly 0.0 forever, which satisfies the wire
-/// but proves nothing about the control loop. Same magnitude and duration
+/// A ONE-TIME startup disturbance, applied near the beginning of a run when
+/// [`HostConfig::startup_kick`] is set. Not a general disturbance API -- the
+/// input wire carries no such field (issue #161) -- and OFF BY DEFAULT
+/// (issue #169): on the ridden plant, an ungated kick was measured handing
+/// the board roughly 1.1 m/s before a player had touched anything, which is
+/// enough to leave a finite Unreal level in the first few seconds of load.
+/// Kept available, not deleted, for `wire-probe`/diagnostic runs that want a
+/// guaranteed disturbance to show recovery from. Same magnitude and duration
 /// `impulse-response-rust` uses (issue #107 AC6: `NOMINAL_IMPULSE_NS` = 20
 /// N*s over 0.05 s), reused rather than invented; direction and application
 /// point mirror that binary's own `ImpulseParams` defaults too (force along
@@ -91,11 +149,14 @@ pub struct HostConfig {
     /// Where the input-in socket binds/listens.
     pub input_in_addr: SocketAddr,
     /// `None` runs forever; `Some(d)` stops after `d` has elapsed --
-    /// primarily for tests and the verification run in issue #161's PR,
-    /// not something a deployed host would set.
+    /// primarily for tests and verification runs, not something a deployed
+    /// host would set.
     pub duration: Option<Duration>,
     /// `None` disables the stats file entirely.
     pub stats_path: Option<PathBuf>,
+    /// Applies the one-time startup disturbance if true. See
+    /// [`STARTUP_KICK_T0_S`]'s doc comment for why this defaults to false.
+    pub startup_kick: bool,
 }
 
 impl Default for HostConfig {
@@ -105,6 +166,7 @@ impl Default for HostConfig {
             input_in_addr: wire::input_in_addr(),
             duration: None,
             stats_path: Some(PathBuf::from(DEFAULT_STATS_PATH)),
+            startup_kick: false,
         }
     }
 }
@@ -140,9 +202,9 @@ impl From<std::io::Error> for HostError {
     }
 }
 
-/// The most recent input the host has heard from Unreal, plus the bits W1
-/// does not yet act on (accepted, clamped, and logged on receipt -- issue
-/// #161 -- so W2 only has to connect them to something).
+/// The most recent input the host has heard from Unreal, plus the bits this
+/// host does not yet act on (accepted, clamped, and logged on receipt --
+/// issue #161 -- so a later pass only has to connect them to something).
 #[derive(Debug, Clone, Copy, Default)]
 struct LatestInput {
     weight_shift_fore_aft: f32,
@@ -188,14 +250,14 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         ..Params::default()
     };
 
-    let mut backend = SimBackend::with_params(params);
+    let mut backend = SimBackend::with_model_path(params, rider_model_path());
     backend.open().map_err(HostError::Backend)?;
     // Armed unconditionally at startup, the same way every other Rust-hosted
     // harness in this repo arms (`impulse-response-rust`, `sim-backend`'s own
-    // tests): there is no synthetic Unreal client during the issue #161
-    // verification run, and W1 explicitly does not gate balancing on the
-    // input socket's `arm` bit -- see `LatestInput::armed_bit`, tracked and
-    // logged but not yet wired to anything (W2).
+    // tests): there is no synthetic Unreal client during a verification run,
+    // and this host does not gate balancing on the input socket's `arm` bit
+    // -- see `LatestInput::armed_bit`, tracked and logged but not wired to
+    // anything.
     let _disarm = backend.arm().map_err(HostError::Backend)?;
 
     // CYCLE_NS is a duplicated constant, not derived -- checked against
@@ -214,7 +276,13 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
 
     let regulator = PitchRegulator::new(KP_NM_PER_RAD, KD_NM_PER_RAD_S);
     let mut estimator = ComplementaryFilter::with_trust_band(ESTIMATOR_TAU_S, 0.0);
-    let mut wheel_accel = WheelAccelEstimator::new(WHEEL_ACCEL_TAU_S);
+    let accel_ff = CommandFeedforward::new(ACCEL_FF_GAIN_M_S2_PER_A);
+    // Last cycle's POST-envelope commanded current, amps -- the feedforward's
+    // input (mode 2 / "commanded", matching `shuttle_run.py`'s own default
+    // `accel_ff_current_source`, rather than the measured-current mode
+    // `control-ffi`'s doc recommends for hardware). One cycle old by
+    // construction, same as `control-ffi::ObController::last_amps`.
+    let mut last_amps: f32 = 0.0;
 
     let out_socket = UdpSocket::bind("127.0.0.1:0")?;
     let in_socket = UdpSocket::bind(cfg.input_in_addr)?;
@@ -283,48 +351,57 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let stale = latest_input_at
             .map(|t| t.elapsed() > INPUT_STALENESS_TIMEOUT)
             .unwrap_or(true);
-        // weight_shift_* and steer hold last, then zero after the staleness
-        // timeout (issue #161). weight_shift_* is read, clamped (already
-        // done in InputIn::from_bytes) and logged above, but does not yet
-        // drive the model (W1 scope) -- wired here so W2 only has to
-        // connect it to an actuator.
+        // weight_shift_*/steer hold last, then zero after the staleness
+        // timeout (issue #161).
         let steer = if stale { 0.0 } else { latest_input.steer };
-        let _weight_shift_fore_aft = if stale {
+        let weight_shift_fore_aft = if stale {
             0.0
         } else {
             latest_input.weight_shift_fore_aft
         };
-        let _weight_shift_lateral = if stale {
+        let weight_shift_lateral = if stale {
             0.0
         } else {
             latest_input.weight_shift_lateral
         };
 
-        // `arm`/`reset` bits: accepted and tracked (W1 scope), logged on
-        // change rather than every tick. Neither gates anything yet -- the
-        // host self-arms unconditionally (see the comment on `backend.arm()`
-        // above), and there is no reset implementation to wire `reset` into
-        // (W2). `stale` zeroes both the same way it zeroes weight_shift/steer.
+        // `arm`/`reset` bits: accepted and tracked, logged on change rather
+        // than every tick. Neither gates anything yet -- the host self-arms
+        // unconditionally (see the comment on `backend.arm()` above), and
+        // there is no reset implementation to wire `reset` into. `stale`
+        // zeroes both the same way it zeroes weight_shift/steer.
         let input_armed_bit = !stale && latest_input.armed_bit;
         let input_reset_bit = !stale && latest_input.reset_bit;
         if input_reset_bit && !prev_reset_bit {
-            eprintln!("sim-host: input reset bit set -- W1 does not implement reset yet, ignoring");
+            eprintln!("sim-host: input reset bit set -- not implemented yet, ignoring");
         }
         if input_armed_bit != prev_armed_bit {
             eprintln!(
                 "sim-host: input arm bit is now {input_armed_bit} \
-                 (host self-arms regardless of this bit in W1)"
+                 (host self-arms regardless of this bit)"
             );
         }
         prev_armed_bit = input_armed_bit;
         prev_reset_bit = input_reset_bit;
 
-        // One-time startup kick -- see STARTUP_KICK_T0_S's doc comment.
-        // Checked against the PRE-step time, mirroring impulse_response.py's
-        // `if t0 <= data.time < t0 + duration` (also checked there before
-        // that iteration's mj_step).
-        let in_kick_window =
-            (STARTUP_KICK_T0_S..STARTUP_KICK_T0_S + STARTUP_KICK_DURATION_S).contains(&t_known_s);
+        // Ballast targets -- weight_shift_fore_aft/lateral drive
+        // overboard_rider.xml's two ballast actuators DIRECTLY AND
+        // PHYSICALLY (see this file's header). Set every cycle, mirroring
+        // apply_external_force's own "call every cycle or a stale value
+        // persists" convention.
+        backend.set_ballast_targets(
+            weight_shift_fore_aft * BALLAST_RANGE_M,
+            weight_shift_lateral * BALLAST_RANGE_M,
+        );
+
+        // One-time startup kick, only when explicitly enabled (issue #169)
+        // -- see STARTUP_KICK_T0_S's doc comment. Checked against the
+        // PRE-step time, mirroring impulse_response.py's `if t0 <= data.time
+        // < t0 + duration` (also checked there before that iteration's
+        // mj_step).
+        let in_kick_window = cfg.startup_kick
+            && (STARTUP_KICK_T0_S..STARTUP_KICK_T0_S + STARTUP_KICK_DURATION_S)
+                .contains(&t_known_s);
         let force = if in_kick_window {
             STARTUP_KICK_FORCE_N
         } else {
@@ -335,12 +412,14 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let obs = backend.wait_observe().map_err(HostError::Backend)?;
         t_known_s = obs.t_recv_ns as f64 * 1e-9;
 
-        // Controller: raw IMU -> estimate -> regulate -> envelope. Mode 1
-        // (wheel odometry aiding), matching `impulse-response-rust` and
-        // `RustController()`'s own default (issue #121).
+        // Controller: raw IMU -> estimate -> regulate -> envelope. Mode 2
+        // (command feedforward), matching `shuttle_run.py`'s tuned ridden
+        // config -- "the recommended configuration" per that scenario's own
+        // comment. `pitch_ref` is always 0: no outer loop (see this file's
+        // header).
         let sample = obs.newest_imu().copied().unwrap_or(ImuSample::ZERO);
         let wheel_rate_rad_s = obs.erpm * RAD_S_PER_ERPM;
-        let aiding = wheel_accel.update(wheel_rate_rad_s * DEFAULT_R_EFF_M, DT_S as f32);
+        let aiding = accel_ff.predict(last_amps);
         let attitude = estimator.update(std::slice::from_ref(&sample), aiding);
         let proposed_torque_nm =
             regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
@@ -353,6 +432,13 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             Faults::NONE,
         );
         backend.apply(&bounded_cmd).map_err(HostError::Backend)?;
+        // POST-envelope current, not the proposal -- the plant only ever
+        // sees the clamped value (same reasoning `control-ffi`'s own
+        // `ctl.last_amps` update carries).
+        last_amps = match bounded_cmd {
+            Command::MotorCurrent { amps } => amps,
+            Command::RemoteSpeed { .. } => 0.0,
+        };
 
         // wheel_angle_rad: there is no absolute wheel-angle channel on `hal`
         // (ICD carries ERPM/tacho, the same as real VESC telemetry) -- this
@@ -360,9 +446,6 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // way a real host would have to. Not a fabricated value: it is an
         // honest integral of an actually-measured rate.
         wheel_angle_rad += wheel_rate_rad_s * DT_S as f32;
-        // yaw_rad: NON-PHYSICAL game channel (issue #161) -- see
-        // YAW_RATE_GAIN_RAD_S's doc comment.
-        yaw_rad += steer * YAW_RATE_GAIN_RAD_S * DT_S as f32;
 
         // Ground truth, never fed to the controller above (DR-OBS-1) --
         // reported because "the board is actually up" is what the state-out
@@ -372,6 +455,15 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // frame_pitch_rad` use, against the same underlying xmat.
         let xmat = backend.truth_frame_xmat();
         let pitch_rad = (xmat[2] as f32).atan2(xmat[8] as f32);
+        // Roll (rotation about the frame's forward/-X axis) -- the same
+        // atan2-of-a-tilted-axis derivation `pitch_rad` uses, applied to the
+        // Y-Z plane (roll, about local X) instead of the X-Z plane (pitch,
+        // about local Y). Exact only when pitch is near zero, since 3D
+        // rotations don't commute and this is not a true Euler decomposition
+        // -- acceptable for the roll-shaped yaw limiter's "cheap stopgap"
+        // status (issue #161 W2 item 4); the real lean-steer controller
+        // (Tuesday) needs a better one.
+        let roll_rad = (xmat[5] as f32).atan2(xmat[8] as f32);
         let pos_f64 = backend.truth_frame_xpos();
         let quat_f64 = backend.truth_frame_xquat();
         let pos = [pos_f64[0] as f32, pos_f64[1] as f32, pos_f64[2] as f32];
@@ -381,6 +473,14 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             quat_f64[2] as f32,
             quat_f64[3] as f32,
         ];
+
+        // yaw_rad: NON-PHYSICAL game channel (issue #161), roll-shaped
+        // (issue #161 W2 item 4) -- `steer`'s authority scales with how much
+        // the rider is actually leaning (roll_authority in [0, 1]), zero at
+        // zero roll, full at ROLL_FULL_YAW_AUTHORITY_RAD or beyond. `steer`
+        // still supplies the SIGN/direction; only the magnitude is limited.
+        let roll_authority = (roll_rad.abs() / ROLL_FULL_YAW_AUTHORITY_RAD).clamp(0.0, 1.0);
+        yaw_rad += steer * YAW_RATE_GAIN_RAD_S * roll_authority * DT_S as f32;
 
         let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;
         if pitch_rad.abs() > FALLEN_PITCH_RAD {

--- a/crates/sim-host/src/pacer.rs
+++ b/crates/sim-host/src/pacer.rs
@@ -54,11 +54,27 @@ impl Pacer {
             self.missed_deadlines += 1;
             Duration::ZERO
         };
-        // Advances by exactly one period regardless of the overrun, so a
-        // single slow cycle costs one miss, not a cascading pile-up of
-        // catch-up iterations trying to make up lost ground (which would be
-        // physically meaningless here: one loop iteration is one fixed
-        // sim-time step, not a variable one).
+        // Advances by exactly one period regardless of the overrun, so the
+        // loop never skips a physics step or accelerates sim-time to "catch
+        // up" -- one call to wait_for_next() is always exactly one hal
+        // cycle, whatever real time it actually took.
+        //
+        // CORRECTION (issue #168): an earlier revision of this comment
+        // claimed this arithmetic avoids "a cascading pile-up of catch-up
+        // iterations". It does not, and #168 measured exactly that: OS timer
+        // coalescing (observed on macOS, not this crate's doing -- p50 ~0.09
+        // ms, p99 ~15 ms) can turn a requested ~2 ms sleep into an actual
+        // ~16 ms one, so the next wait_for_next() finds next_deadline
+        // roughly 8 periods behind `now`. Because this only ever advances
+        // the deadline by ONE period per call, the loop then runs ~8
+        // back-to-back iterations with essentially no sleep between them --
+        // each one legitimately a miss (each really did blow its own 2 ms
+        // window) and each legitimately counted, but that IS a burst, not
+        // smoothed-away drift. What this arithmetic actually guarantees is
+        // narrower, and still worth having: the burst is bounded by how far
+        // behind the clock fell, it does not compound further across calls,
+        // and no physics step is ever skipped or doubled up to fake being
+        // caught up.
         self.next_deadline += self.period;
         sleep_for
     }

--- a/sim/models/overboard_rider.xml
+++ b/sim/models/overboard_rider.xml
@@ -1,0 +1,232 @@
+<mujoco model="overboard_rider">
+  <!--
+    Overboard onewheel plant model — RIDDEN configuration (issue #161 W2).
+
+    A NEW file, not an edit to overboard_onewheel.xml -- that model carries
+    the bit-identity replay gate (`tests/test_rust_python_plant_replay_equivalence.py`)
+    and this project has already lost time to a model edit that silently
+    invalidated it once. Everything below duplicates that file's frame/wheel/
+    sensor declarations (same names, same signs) with two differences:
+
+    1. A ballast body carrying rider-scale mass, on two chained SLIDE joints
+       (fore/aft then lateral) instead of the Python scenarios' rigid weld
+       (`sim/scenarios/plant.py::build_model`). A rigid weld cannot be driven
+       by a weight-shift input at all; this can.
+
+       `weight_shift_fore_aft` drives `ballast_fa` DIRECTLY AND PHYSICALLY --
+       this is issue #161's original spec, restored after a same-night
+       reversal that briefly tried mapping it to a `v_ref` outer-loop
+       setpoint instead. **The board does not station-keep.** Shifting the
+       ballast forward moves the effective centre of mass forward of the
+       axle, which the inner pitch loop (holding the FRAME level, not the
+       ballast) answers by accelerating the wheel forward -- exactly how a
+       real onewheel responds to a forward lean, and exactly why releasing
+       the lean coasts at the resulting speed rather than returning to rest.
+       See `crates/sim-host/src/host.rs`'s own header for the Rust side of
+       this.
+
+       `weight_shift_lateral` drives `ballast_lat`, and its purpose is
+       different: it is what produces the physically-simulated ROLL the
+       `sim-host` yaw limiter is shaped from (see that crate). Both
+       actuators are position-controlled with a first-order (`dyntype=
+       "filter"`) rate limit, so a step input on the wire arrives at the
+       joint smoothed rather than instantaneously -- "rate-limited position
+       actuators" per the W2 dispatch.
+
+       Ranges are +/-0.05 m on each axis. NOT bench-measured -- at 70 kg /
+       0.75 m (this file's ballast mass/height, matching
+       `sim/scenarios/shuttle_run.py::ShuttleParams`'s own defaults, reused
+       rather than invented), that is a 34.3 N*m disturbance torque at full
+       deflection (70 kg * 9.81 m/s^2 * 0.05 m), already past the drive's own
+       28 N*m ceiling (40 A * KT_NM_PER_A). Full-stick weight shift is
+       therefore ABLE to tip the board over, deliberately -- the same way it
+       can on a real one -- not a bug to be tuned away.
+
+       The fore/aft carrier body's own mass (0.5 kg) is a placeholder for the
+       linkage/foot-shift mechanism, not rider mass -- the full 70 kg rider
+       mass sits on the innermost (lateral) body, which the carrier's slide
+       drags along with it, so both joints are actually reacting against the
+       full rider mass, not the carrier's own.
+
+    2. The wheel geom is WIDENED for playability: half-width 0.075 m -> 0.15
+       m (full width 0.15 m -> 0.30 m), radius UNCHANGED at 0.1454 m. This is
+       a labelled, deliberate divergence from the real vehicle's geometry --
+       required input to the `Playable Sim` channel declaration (issue #163),
+       a launch blocker, not a cosmetic choice. It exists because the
+       original geometry's lateral tip angle (~5 deg) closes almost no roll
+       authority for weight_shift_lateral to work with. Radius is untouched
+       so r_eff_m, the wheel_motor gear ratio and ctrlrange all stay exactly
+       as derived in overboard_onewheel.xml. Wheel inertial is recomputed for
+       the new width using the SAME hoop-model formula that file documents
+       (Iyy = m*a^2, unaffected by width; Ixx = Izz = m*a^2/2 + m*w^2/12,
+       recomputed for w = 0.30 m) -- mass is left at 4.5 kg, i.e. this does
+       NOT model the extra tire rubber a genuinely wider tire would carry,
+       consistent with this being a playability widening, not a claim about
+       the real vehicle.
+
+    Everything else -- frame mass/CoM, wheel radius, motor sign, sensor set,
+    nose-strike bumper geometry -- is copied verbatim from
+    overboard_onewheel.xml. See that file for the full provenance notes this
+    header does not repeat.
+  -->
+  <compiler angle="degree" meshdir="meshes/openwheel"/>
+
+  <option gravity="0 0 -9.81" timestep="0.002" integrator="RK4"/>
+
+  <visual>
+    <global offwidth="1280" offheight="720"/>
+    <headlight ambient="0.28 0.29 0.31" diffuse="0.32 0.32 0.32" specular="0.08 0.08 0.08"/>
+    <quality shadowsize="4096" offsamples="8"/>
+    <map shadowclip="2" shadowscale="1.5"/>
+  </visual>
+
+  <default>
+    <geom friction="1.0 0.005 0.0001"/>
+    <default class="visual">
+      <geom contype="0" conaffinity="0" group="2"/>
+    </default>
+    <default class="collision">
+      <geom group="3"/>
+    </default>
+  </default>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.82 0.87 0.90" rgb2="0.35 0.44 0.52"
+             width="512" height="512"/>
+    <texture name="grid" type="2d" builtin="checker" rgb1="0.720 0.730 0.720"
+             rgb2="0.560 0.580 0.570" width="512" height="512"/>
+    <material name="ground_mat" texture="grid" texrepeat="160 160" reflectance="0.05" specular="0.1"/>
+
+    <material name="shell_mat" rgba="0.086 0.137 0.180 1" specular="0.35" shininess="0.45"/>
+    <material name="bumper_mat" rgba="0.949 0.635 0.290 1" specular="0.25" shininess="0.3"/>
+    <material name="footpad_mat" rgba="0.059 0.098 0.133 1" specular="0.05" shininess="0.05"/>
+    <material name="platform_mat" rgba="0.165 0.682 0.592 1" specular="0.3" shininess="0.3"/>
+    <material name="tire_mat" rgba="0.078 0.106 0.137 1" specular="0.12" shininess="0.15"/>
+    <!-- Rider-proxy material -- same amber the Python ballast proxy uses
+         (sim/scenarios/plant.py's _AMBER), so a render (overboard-viz) reads
+         this ballast the same way. -->
+    <material name="rider_mat" rgba="0.949 0.635 0.290 1" specular="0.2" shininess="0.2"/>
+
+    <mesh name="front_enclosure" file="front_enclosure.stl" scale="0.001 0.001 0.001"/>
+    <mesh name="rear_enclosure" file="rear_enclosure.stl" scale="0.001 0.001 0.001"/>
+    <mesh name="front_bumper" file="front_bumper.stl" scale="0.001 0.001 0.001"/>
+    <mesh name="rear_bumper" file="rear_bumper.stl" scale="0.001 0.001 0.001"/>
+    <mesh name="front_footpad" file="front_footpad.stl" scale="0.001 0.001 0.001"/>
+    <mesh name="rear_footpad" file="rear_footpad.stl" scale="0.001 0.001 0.001"/>
+    <mesh name="electronics_platform" file="electronics_platform.stl" scale="0.001 0.001 0.001"/>
+  </asset>
+
+  <worldbody>
+    <light name="key" directional="true" pos="-1.5 -2.0 4.0" dir="0.35 0.45 -1"
+           diffuse="0.75 0.74 0.72" specular="0.25 0.25 0.25" castshadow="true"/>
+    <light name="fill" directional="true" pos="2.5 2.5 3.0" dir="-0.5 -0.5 -1"
+           diffuse="0.30 0.32 0.36" specular="0.05 0.05 0.05" castshadow="false"/>
+
+    <geom name="ground" type="plane" size="20 20 0.1" material="ground_mat"/>
+
+    <body name="frame" pos="0 0 0.1454">
+      <freejoint name="frame_free"/>
+      <inertial pos="0 0 -0.03" mass="8.0" diaginertia="0.040 0.400 0.420"/>
+
+      <site name="imu" pos="-0.06 0 -0.007" size="0.008" group="4"/>
+
+      <geom name="front_enclosure_geom" class="visual" type="mesh" mesh="front_enclosure" material="shell_mat"/>
+      <geom name="rear_enclosure_geom" class="visual" type="mesh" mesh="rear_enclosure" material="shell_mat"/>
+      <geom name="front_footpad_geom" class="visual" type="mesh" mesh="front_footpad" euler="0 0 180" material="footpad_mat"/>
+      <geom name="rear_footpad_geom" class="visual" type="mesh" mesh="rear_footpad" material="footpad_mat"/>
+      <geom name="electronics_platform_geom" class="visual" type="mesh" mesh="electronics_platform" material="platform_mat"/>
+
+      <geom name="front_bumper_geom" type="mesh" mesh="front_bumper" material="bumper_mat"
+            group="2" condim="3" friction="0.6 0.005 0.0001"/>
+      <geom name="rear_bumper_geom" type="mesh" mesh="rear_bumper" material="bumper_mat"
+            group="2" condim="3" friction="0.6 0.005 0.0001"/>
+
+      <!--
+        Hub wheel -- WIDENED for playability, see this file's header. Radius
+        0.1454 m is unchanged from overboard_onewheel.xml; half-width is
+        doubled from 0.075 m to 0.15 m. Inertial recomputed for the new
+        width with the same hoop-model formula that file documents (mass
+        left at 4.5 kg -- this is a geometry widening, not a claim that a
+        real tire this wide would weigh the same).
+      -->
+      <body name="wheel" pos="0 0 0">
+        <joint name="wheel_hinge" type="hinge" axis="0 -1 0" pos="0 0 0" damping="0.08"/>
+        <inertial pos="0 0 0" mass="4.5" diaginertia="0.0635 0.0595 0.0635"/>
+        <geom name="wheel_geom" type="cylinder" size="0.1454 0.15" euler="90 0 0"
+              material="tire_mat" condim="4"/>
+      </body>
+
+      <!--
+        Ballast: rider-scale mass on two chained slide joints. See this
+        file's header for the full rationale, ranges and the fore/aft
+        vs. lateral drive split.
+
+        `ballast_fa_carrier` is the near-massless fore/aft stage; `ballast`,
+        nested inside it, carries the actual rider mass and slides laterally.
+        Both joints react against the SAME 70 kg -- the carrier's own 0.5 kg
+        is a placeholder for the shift linkage, not rider mass.
+
+        Axis signs: `ballast_fa`'s axis is -X so a POSITIVE joint value (and
+        therefore a positive weight_shift_fore_aft, forwarded by sim-host as
+        the actuator's ctrl) moves the ballast toward -X, i.e. FORWARD --
+        matching this model's "forward = -X" convention and ICD 7.3's
+        positive-is-forward sign. `ballast_lat`'s axis is +Y (right, per the
+        IMU site comment above), so positive weight_shift_lateral shifts the
+        rider to the RIGHT.
+      -->
+      <body name="ballast_fa_carrier" pos="0 0 0.75">
+        <joint name="ballast_fa" type="slide" axis="-1 0 0" pos="0 0 0"
+               range="-0.05 0.05" damping="600"/>
+        <inertial pos="0 0 0" mass="0.5" diaginertia="0.001 0.001 0.001"/>
+        <body name="ballast">
+          <joint name="ballast_lat" type="slide" axis="0 1 0" pos="0 0 0"
+                 range="-0.05 0.05" damping="600"/>
+          <!-- Same diaginertia formula plant.py's rigid ballast uses
+               (mass*0.15, mass*0.15, mass*0.08) at 70 kg. -->
+          <inertial pos="0 0 0" mass="70.0" diaginertia="10.5000 10.5000 5.6000"/>
+          <!-- Visual proxy only -- a rigid ballast is not a rider (no ankle/
+               knee compliance), so this is a plain sphere, not a figure,
+               the same honesty plant.py's own rider_geoms() docstring
+               argues for. contype/conaffinity 0: collides with nothing. -->
+          <geom name="ballast_mass_geom" type="sphere" size="0.12" material="rider_mat"
+                contype="0" conaffinity="0" group="1"/>
+        </body>
+      </body>
+
+      <camera name="side" mode="trackcom" pos="0 2.6 0.30" xyaxes="-1 0 0 0 0 1" fovy="24"/>
+      <camera name="beauty" mode="trackcom" pos="-1.7 2.0 0.85"
+              xyaxes="-2.0 -1.7 0 1.445 -1.700 6.89" fovy="26"/>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <motor name="wheel_motor" joint="wheel_hinge" gear="1" ctrlrange="-28 28" ctrllimited="true"/>
+
+    <!--
+      Ballast position actuators. `timeconst` gives the raw `ctrl` value
+      (the wire's weight_shift_*, straight through) a first-order lag before
+      it reaches the position servo's target -- the "rate-limited" part of
+      "rate-limited position actuators" (MuJoCo's `<position>` shortcut
+      compiles this to `dyntype="filterexact"`, `dynprm[0] = timeconst`).
+      `kp` and the 0.15 s time constant are chosen, not bench-tuned:
+      `kp=3000` N/m against the 70 kg rider mass both joints react against
+      gives a ~1 Hz undamped natural frequency, and `damping` on the joints
+      above (600 N*s/m) is close to critical for that mass/kp pair -- a
+      responsive but not violent weight-shift feel, nothing more precise is
+      claimed.
+    -->
+    <position name="ballast_fa" joint="ballast_fa" kp="3000" ctrlrange="-0.05 0.05"
+              ctrllimited="true" timeconst="0.15"/>
+    <position name="ballast_lat" joint="ballast_lat" kp="3000" ctrlrange="-0.05 0.05"
+              ctrllimited="true" timeconst="0.15"/>
+  </actuator>
+
+  <sensor>
+    <framequat name="frame_quat" objtype="body" objname="frame"/>
+    <gyro name="frame_gyro" site="imu"/>
+    <accelerometer name="frame_accel" site="imu"/>
+    <jointpos name="wheel_pos" joint="wheel_hinge"/>
+    <jointvel name="wheel_vel" joint="wheel_hinge"/>
+    <actuatorfrc name="motor_torque" actuator="wheel_motor"/>
+  </sensor>
+</mujoco>


### PR DESCRIPTION
## Summary

Issue #161 (W2) / #169. Closes the loop the CEO actually wants: **lean to
accelerate, level off to coast, lean back to decelerate/reverse** -- not
station-keeping. This reverses an earlier same-night attempt (within this
same dispatch) at mapping `weight_shift_fore_aft` to an outer-loop `v_ref`
setpoint; that mapping is withdrawn, `v_ref` stays unused, and no
`control_core::VelocityLoop` is enabled.

### What changed and why

- **`sim/models/overboard_rider.xml`** -- a NEW file (does **not** touch
  `overboard_onewheel.xml`; the bit-identity replay gate stays green, verified
  below). A rider-scale ballast (70 kg / 0.75 m, reusing
  `sim/scenarios/shuttle_run.py::ShuttleParams`'s own defaults rather than
  inventing new ones) on two chained slide joints -- fore/aft, then lateral --
  with rate-limited position actuators (`timeconst`). `weight_shift_fore_aft`
  drives the fore/aft joint **directly and physically**: shifting the ballast
  forward moves the effective centre of mass ahead of the axle, and the inner
  pitch loop (which only ever holds the FRAME level) answers by accelerating
  the wheel forward to stay upright -- the actual mechanism a real onewheel
  uses. `weight_shift_lateral` drives the lateral joint, which is what
  produces the physically-simulated roll the yaw limiter is shaped from.
  Ranges (+/-0.05 m each axis) are sized so full-stick deflection (34.3 N*m at
  70 kg) exceeds the drive's own 28 N*m ceiling -- full lean can genuinely tip
  the board, deliberately, the same way it can on a real one.
- **Widened wheel geom**, half-width 0.075 m -> 0.15 m, radius unchanged
  (0.1454 m, so `r_eff_m`/gear ratio/`ctrlrange` are untouched). Labelled in
  the file as a playability widening, not the real vehicle's geometry --
  required input to the `Playable Sim` channel declaration (issue #163), a
  launch blocker.
- **`crates/plant-mujoco`**: adds `actuator_id()` lookup by name, mirroring
  the existing `body_id`/`sensor_id` pattern.
- **`crates/sim-backend`**: `SimBackend::with_model_path()` -- the model path
  was hardcoded ("fixed, not configurable" per I1c's own doc, now stale and
  fixed); `ctrl` is now built by resolved actuator index rather than a
  fixed-length array (the driverless model has 1 actuator, the rider model
  has 3); `set_ballast_targets()` for the two ballast position actuators.
  Fully additive -- the driverless default path and every existing behaviour
  are unchanged, verified by the full existing test/pytest suite staying
  green.
- **`crates/sim-host`**: ridden-tuned inner-loop gains and estimator config
  (`kp_nm_per_rad=140`, `kd_nm_per_rad_s=21`, `estimator_tau_s=2.0`,
  command-feedforward aiding, gain 0.0584) reused **verbatim** from
  `shuttle_run.py`'s own tuned `controller_factory` -- "the recommended
  configuration" per that scenario's own comment -- not re-derived or
  guessed at. A **roll-shaped yaw limiter**: `steer`'s yaw-rate authority
  scales with how much the rider is actually leaning (0 at zero roll, full at
  a documented placeholder ~10 deg), a cheap W2 stopgap; the real lean-steer
  controller is Tuesday. `yaw_rad` stays labelled non-physical.
- **Startup kick gated off by default** (`HostConfig::startup_kick`,
  `--startup-kick` flag) -- issue #169: on the ridden plant an ungated kick
  was measured handing the board ~1.1 m/s before a player had touched
  anything, enough to leave a finite Unreal level in the first few seconds.
  Kept available for `wire-probe`/diagnostic runs.
- **Two misleading comments fixed** (issue #169):
  - `pacer.rs` claimed `next_deadline += period` avoids "a cascading pile-up
    of catch-up iterations". It does not -- issue #168 measured exactly that
    (macOS timer coalescing turns a ~2 ms sleep into ~16 ms, so the next call
    finds the deadline ~8 periods behind and burns through them back-to-back).
    Comment corrected to say what the arithmetic actually guarantees: no
    physics step is skipped/doubled, and the burst doesn't compound further.
  - `host.rs` called the loop "pure station-keeping balance" -- true of W1's
    driverless config, actively wrong now that a physically-driven ballast
    means nothing in this loop opposes net forward motion, on purpose.
- **New dev/verification-only tools**, neither part of the Unreal-facing
  wire: `send-input` (a scripted UDP input sender for verification runs --
  reuses `sim_host::wire::InputIn` directly, so the encoding can't drift from
  the real decoder) and `wire-probe --csv PATH` (one row per received packet:
  seq, sim_time_s, pos, pitch/yaw, wheel_rate, motor current).

### Turf note

`sim/models/` is Sr. Mechanical & Systems' path by CODEOWNERS. Writing
`overboard_rider.xml` there is a deliberate, time-boxed deviation the COO's
W2 dispatch explicitly assigned to Senior Controls for this launch weekend
(mirroring ADR-0010's own pattern of a recorded, time-boxed cross-role call
rather than a quiet one) -- see the `TURF-OVERRIDE:` line in the commit
message, which is what `policy_check.py`'s turf gate reads. Mechanical's
existing model (`overboard_onewheel.xml`) is untouched.

## Real, captured verification run

Built in an isolated `CARGO_TARGET_DIR` (same shared-`target/`-symlink issue
as W1's PR #167). `sim-host` run for 20 s with **no startup kick** (default,
issue #169), driven by `send-input`'s scripted schedule (settle -> lean
forward -> release -> lean back -> release -> lean+steer -> release),
captured with `wire-probe --csv` overlapping:

```
wire-probe: listening on 127.0.0.1:9601 for 16.0s
--- wire-probe report ---
run duration: 16.173 s
total ticks (valid state packets received): 4473
measured tick rate (mean): 276.57 Hz
seq range: 5527..=9999 (span 4473)
inter-packet interval (ms): mean=1.9998 p50=0.5110 p99=9.0121 max=11.6728
missed-deadline count from the host: 4848 (host reports 10000 ticks, stats file /tmp/overboard-sim-host-stats.txt)
pitch_rad: min=-0.099324 max=0.111411 final=0.003199 (-5.691 deg / 6.383 deg / 0.183 deg)
confirmation: magic (0x4f425731) + schema_version (1) parsed correctly on all 4473/4473 received packets
csv: wrote 4473 rows to /tmp/wire-probe-w2.csv
```

Host's own final line for the full 20 s run: `sim-host: stopped cleanly --
10000 ticks, 4848 missed deadlines`.

**Position/velocity over time, the actual evidence requested** (from the CSV,
`ground_speed_m_s = wheel_rate_rad_s * r_eff_m`, positive = forward, matching
the wire's own convention):

| sim_time_s | pos_x_m (fwd=neg) | wheel_rate_rad_s | ground_speed_m_s | motor_current_a | yaw_rad |
|---|---|---|---|---|---|
| 11.1 | -3.198 | 18.215 | 2.649 | 19.524 | 0.00000 |
| 12.0 | -5.982 | 21.632 | 3.145 | 7.042 | 0.00000 |
| 13.0 | -9.194 | 22.754 | 3.308 | 1.913 | 0.00000 |
| 14.0 | -12.286 | 18.892 | 2.747 | -13.188 | 0.00000 |
| 15.0 | -14.526 | 11.803 | 1.716 | -18.032 | 0.00000 |
| 16.0 | -15.676 | 3.974 | 0.578 | -20.100 | 0.00000 |
| 17.0 | -15.663 | -3.274 | -0.476 | -10.641 | 0.00000 |
| 18.0 | -15.026 | -5.226 | -0.760 | -3.764 | 0.00000 |
| 19.0 | -14.212 | -5.912 | -0.860 | -1.878 | 0.00162 |
| 20.0 | -13.331 | -6.191 | -0.900 | -1.175 | 0.00402 |

Read honestly: forward speed **accelerates** under sustained forward lean
(2.65 -> peak 3.31 m/s around t=13s, tracking `send-input`'s "lean forward"
window), **decelerates** once the lean reverses (falling to zero between
t=16-17s, `pos_x` bottoming out at its most-forward point right at that
crossing), then **reverses** to a steady ~-0.9 m/s coast -- `pos_x` visibly
turning around and increasing (moving back) from t=17s onward. `yaw_rad`
starts moving (0.0016 -> 0.004 rad) as the scripted lean+steer "turn" phase
lands near the end of the capture window (the host was running behind real
time under the same missed-deadline load W1's PR already reported, so
`send-input`'s wall-clock schedule doesn't land 1:1 on sim-time). This is the
actual mechanism working, not a return-to-origin -- there is no such term in
this loop.

**Missed-deadline rate is again real and high (~48.5%, 4848/10000)** -- same
stock-macOS, non-PREEMPT_RT-target cause W1's PR already documented, not a
regression here. `Pacer`'s comment now says honestly what its arithmetic
guarantees (see above); the aggregate tick rate over the full 20 s run still
landed at 10000/10000 physics ticks completed (500 Hz average), consistent
with W1.

## Test plan
- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] Full `pytest tests/` still **293 passed, 2 xfailed** -- the exact
      baseline from PR #167, replay-equivalence gate included (it does not
      touch anything this PR changes, but re-run to be sure nothing in
      `plant-mujoco`/`sim-backend` regressed it)
- [x] Real captured `sim-host` + `send-input` + `wire-probe --csv` run,
      output above

## Assumptions / calls made (flagging for review)
1. **Ballast joint ranges (+/-0.05 m) and actuator `kp`/`timeconst`** are
   documented, reasoned-through placeholders (shown in the model's own
   comments), not bench-tuned.
2. **`ROLL_FULL_YAW_AUTHORITY_RAD` (~10 deg)** is a documented placeholder,
   not derived from the widened wheel's exact new tip angle (no Rust binding
   to that collision-hull geometry query exists).
3. **Roll is computed via an approximate atan2, not a true Euler
   decomposition** -- exact near zero pitch, which is the loop's normal
   operating regime; explicitly flagged as a "cheap stopgap" in code.
4. **`send-input`/`wire-probe --csv`** are new dev-only binaries, not
   requested in those exact words, added because there was no other way to
   produce the position/velocity-over-time evidence asked for.
5. **Turf**: see the note above; recorded via `TURF-OVERRIDE:` per
   `policy_check.py`'s documented mechanism.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>