### PR TITLE
fix(controls): roll gate was ~400x miscalibrated -- widened wheel kills roll

### DIFF
--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -94,14 +94,55 @@ const BALLAST_RANGE_M: f32 = 0.05;
 const YAW_RATE_GAIN_RAD_S: f32 = 1.5;
 
 /// Roll magnitude, radians, at which the roll-shaped yaw limiter reaches
-/// full authority (issue #161 W2 item 4 -- the cheap stopgap: `steer`'s
-/// authority is scaled by how much the rider is actually leaning, so a
-/// player has to lean to turn hard, rather than `steer` alone doing
-/// everything regardless of stance). Not derived from the widened wheel's
-/// exact tip angle -- this crate has no Rust binding to that collision-hull
-/// geometry query, same caveat as [`FALLEN_PITCH_RAD`] below -- a documented
-/// round placeholder, not a bench-tuned number.
-const ROLL_FULL_YAW_AUTHORITY_RAD: f32 = 10.0 * std::f32::consts::PI / 180.0;
+/// full authority (issue #161 W2 item 4).
+///
+/// **MEASURED, not guessed -- and the honest number is tiny.** The first cut
+/// of this constant (10 deg) was a placeholder that turned out to be ~400x
+/// too high: issue #169's follow-up measured 0.267 deg of yaw over the whole
+/// `send-input` turn phase against a 10 deg threshold, which is what a
+/// limiter that never leaves its floor looks like. Diagnosed by holding a
+/// steady balance controller and commanding `ballast_lat` directly
+/// (`sim/models/overboard_rider.xml`, full stick = 0.05 m target): the
+/// actuator DOES reach its commanded position (~0.0401 m at 0.8 stick, ~full
+/// convergence, ruling out a wiring/scaling bug) -- but the resulting
+/// steady-state roll tops out at only **~0.032 deg at full stick (1.0)**.
+/// The widened wheel geom (issue #161 W2, same PR) is the reason: a much
+/// wider flat cylinder rim sitting on the ground plane resists tipping far
+/// more than the original narrow tire did, and a 70 kg / 0.05 m lateral
+/// shift's ~24.5 N*m of roll torque is nowhere near enough to peel it.
+///
+/// Recalibrated to slightly below that measured ceiling (not the ceiling
+/// itself) so a genuinely full-stick lateral command reliably saturates
+/// `roll_authority` to 1.0 with some margin, rather than sitting just under
+/// it. This is a real physical limit of the current geometry, not a
+/// placeholder -- but see [`YAW_AUTHORITY_FLOOR`] below for why this
+/// threshold alone does NOT make yaw usable.
+const ROLL_FULL_YAW_AUTHORITY_RAD: f32 = 0.025 * std::f32::consts::PI / 180.0;
+
+/// Floor on `roll_authority`, below which the roll gate would otherwise clamp
+/// `steer` to near-zero.
+///
+/// **Read this before touching the roll gate again.** At the widened wheel's
+/// achievable roll (~0.03 deg, see [`ROLL_FULL_YAW_AUTHORITY_RAD`]'s doc
+/// comment), a PURE roll-gated limiter is not "shaped by lean" in any
+/// perceptible sense -- lean this small is not something a player can feel
+/// or control, so without a floor the gate would function as an near-binary
+/// on/off switch that happens to correlate weakly with the lateral stick,
+/// not a smooth lean-to-turn feel. That is not what issue #161 W2 asked
+/// for, and pretending otherwise in a comment is exactly the mistake #169
+/// already caught twice in this crate.
+///
+/// So: **this gate is now largely cosmetic, and steer is effectively the
+/// primary driver of yaw this weekend.** The floor guarantees full `steer`
+/// always produces a usable turn (tens of degrees over a few seconds, not
+/// tenths) regardless of how much roll the geometry can actually deliver;
+/// the roll term still nudges authority up smoothly from the floor toward
+/// 1.0 as lean increases, which is the connection to lean the design intends
+/// to keep and what the real lean-steer controller (Tuesday) inherits --
+/// it just cannot be the WHOLE story on this geometry. 0.35 is chosen so
+/// full steer alone clears a "tens of degrees" turn even at zero lean
+/// (`0.6 (steer) * 1.5 rad/s * 0.35 * a few seconds`); not bench-tuned.
+const YAW_AUTHORITY_FLOOR: f32 = 0.35;
 
 /// How long a stale input is still trusted before the host zeroes it rather
 /// than continuing to act on a value from a client that may have gone away.
@@ -474,12 +515,18 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             quat_f64[3] as f32,
         ];
 
-        // yaw_rad: NON-PHYSICAL game channel (issue #161), roll-shaped
-        // (issue #161 W2 item 4) -- `steer`'s authority scales with how much
-        // the rider is actually leaning (roll_authority in [0, 1]), zero at
-        // zero roll, full at ROLL_FULL_YAW_AUTHORITY_RAD or beyond. `steer`
-        // still supplies the SIGN/direction; only the magnitude is limited.
-        let roll_authority = (roll_rad.abs() / ROLL_FULL_YAW_AUTHORITY_RAD).clamp(0.0, 1.0);
+        // yaw_rad: NON-PHYSICAL game channel (issue #161). `steer` supplies
+        // the sign/direction; `roll_authority` scales its magnitude between
+        // YAW_AUTHORITY_FLOOR (steer alone, however little the player is
+        // leaning) and 1.0 (at/above ROLL_FULL_YAW_AUTHORITY_RAD's measured,
+        // physically-achievable roll). Read BOTH constants' doc comments
+        // before touching this line -- on the current (widened) wheel
+        // geometry, achievable roll is ~0.03 deg, so `steer` is effectively
+        // the primary driver of yaw this weekend, NOT roll; the floor is
+        // what makes that honest instead of a limiter that reads as "off".
+        let roll_authority = YAW_AUTHORITY_FLOOR
+            + (1.0 - YAW_AUTHORITY_FLOOR)
+                * (roll_rad.abs() / ROLL_FULL_YAW_AUTHORITY_RAD).clamp(0.0, 1.0);
         yaw_rad += steer * YAW_RATE_GAIN_RAD_S * roll_authority * DT_S as f32;
 
         let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;


### PR DESCRIPTION
## Summary

Issue #161/#169 follow-up. The COO measured the turn phase after PR #170 and
found max |yaw| of **0.267 deg** across the whole `send-input` turn window
(`lateral=0.8, steer=0.6` for 2s) -- the roll-shaped yaw limiter was reading
as dead, matching what Mike saw visually in Unreal.

## Diagnosis (per the COO's explicit two-hypothesis request -- measured, not guessed)

Held a steady balance controller and commanded `ballast_lat` directly at
increasing fractions of full stick (`0.2` through `1.0`), reading back the
actual joint position and the resulting steady-state roll:

```
lateral_stick=0.2 target_m=0.010 steady_roll_deg=0.00615
lateral_stick=0.4 target_m=0.020 steady_roll_deg=0.01239
lateral_stick=0.6 target_m=0.030 steady_roll_deg=0.01877
lateral_stick=0.8 target_m=0.040 steady_roll_deg=0.02530
lateral_stick=1.0 target_m=0.050 steady_roll_deg=0.03193
```

**Hypothesis (1) -- ruled out.** The `ballast_lat` actuator reaches its
commanded position cleanly (~0.0401 m at 0.8 stick vs. a 0.04 m target, full
convergence within ~1s of the actuator's 0.15s `timeconst`). Not a
wiring/scaling bug.

**Hypothesis (2) -- confirmed.** Steady-state roll tops out at only **~0.032
deg at full stick (1.0)** -- ~400x below the old 10 deg
`ROLL_FULL_YAW_AUTHORITY_RAD` threshold. Root cause is the SAME PR's widened
wheel geom (`overboard_rider.xml`, half-width 0.075 -> 0.15 m, PR #170): a
much wider flat cylinder rim sitting on the ground plane resists tipping far
more than the original tire did, and a 70 kg / 0.05 m lateral shift's ~24.5
N*m of roll torque is nowhere near enough to peel it off. Two individually
correct W2 decisions -- widen for playability, gate yaw on physically
simulated roll -- cancel when combined.

## Fix

Per the explicit instruction not to remove the roll gate:

- **`ROLL_FULL_YAW_AUTHORITY_RAD`** recalibrated from the 10 deg guess to
  **0.025 deg**, just below the measured ~0.032 deg ceiling (with margin so
  full-stick lean reliably saturates authority to 1.0).
- **New `YAW_AUTHORITY_FLOOR` (0.35)**: at achievable roll this small (not
  something a player can feel or control), the roll gate alone cannot make
  yaw usable -- so a floor guarantees full `steer` always produces a usable
  turn regardless of lean, while roll still nudges authority smoothly from
  the floor toward 1.0 as lean increases. That's the connection to lean the
  design intends to keep and what Tuesday's real lean-steer controller
  inherits; it just isn't the whole story on this geometry.
- Comments now say plainly that **the gate is largely cosmetic and `steer`
  is the effective primary driver of yaw this weekend** -- not a third
  comment asserting the inverse of actual behaviour (issue #169 already
  caught two in this crate; not making it three).

## Real, captured verification -- same measurement the COO used

`sim-host` run for 20s, **no startup kick** (default, per #169), driven by
`send-input`'s scripted schedule, captured with `wire-probe --csv`:

```
wire-probe: listening on 127.0.0.1:9601 for 17.0s
--- wire-probe report ---
run duration: 17.162 s
total ticks (valid state packets received): 4264
measured tick rate (mean): 248.46 Hz
seq range: 5736..=9999 (span 4264)
inter-packet interval (ms): mean=1.9985 p50=0.1230 p99=9.3300 max=9.8978
missed-deadline count from the host: 5498 (host reports 10000 ticks)
pitch_rad: min=-0.009575 max=0.111377 final=-0.000014 (-0.549 deg / 6.381 deg / -0.001 deg)
confirmation: magic + schema_version parsed correctly on all 4264/4264 received packets
csv: wrote 4264 rows to /tmp/wp-yaw.csv
```

**`max |yaw_deg|` across the captured window: 97.3121** (up from 0.267).
**`max |pos_y|`: 0.0055 m** -- still small, and that's expected, not a
residual bug: `pos_y` is the frame's literal physical lateral position, and
`yaw_rad` is explicitly the NON-PHYSICAL game heading channel (the simulated
wheel is a cylinder and cannot carve) -- the two were never meant to move
together, and the COO's own report listed `pos_y` as corroborating evidence
the turn was dead, not as a metric this fix targets.

Time-series (every 1s, `yaw_deg` computed from `yaw_rad`):

| sim_t | pos_x | pos_y | yaw_deg | pitch_deg |
|---|---|---|---|---|
| 11.47 | -8.373 | 0.0000 | 0.000 | -0.541 |
| 13.25 | -13.467 | 0.0000 | 0.000 | 5.230 |
| 15.25 | -15.494 | 0.0000 | 0.000 | 6.173 |
| 16.25 | -14.960 | 0.0000 | 0.000 | 2.137 |
| 17.25 | -14.118 | -0.0003 | 13.072 | 0.728 |
| 18.25 | -13.175 | 0.0007 | 64.106 | 0.278 |
| 19.25 | -12.191 | 0.0033 | 97.312 | 0.083 |

`yaw_deg` stays exactly 0.000 for the entire non-turn portion of the run
(confirming the gate isn't leaking authority when the player isn't leaning
or steering), then ramps smoothly through tens of degrees once the turn
phase (`lateral=0.8, steer=0.6`) starts -- "a turn that reads as a turn",
per the ask.

Host's own final line for the full 20 s run: `sim-host: stopped cleanly --
10000 ticks, 5498 missed deadlines` (same macOS-scheduling cause already
documented in #167/#170, not a regression here).

## Test plan
- [x] `cargo build --workspace --all-targets` clean (modest `-j 2` parallelism
      per the machine note)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] Real captured `sim-host` + `send-input` + `wire-probe --csv` run,
      output above, using the exact same measurement methodology the COO
      used for the original bug report

## Scope note
This PR touches only `crates/sim-host/src/host.rs` -- two constants and the
`roll_authority` expression. No model/XML changes, no other crate changes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>