### PR TITLE
fix(controls): dead-reckon the game ground path -- yaw alone was a car spinning out

### DIFF
--- a/crates/sim-host/src/bin/wire-probe.rs
+++ b/crates/sim-host/src/bin/wire-probe.rs
@@ -19,7 +19,9 @@
 //! received packet -- seq, sim_time_s, pos_x/y, pitch/yaw/roll_rad,
 //! wheel_rate_rad_s, motor_current_a -- because "the board balances" is no
 //! longer the claim W2 needs evidence for; "speed responds to lean" is, and
-//! that needs a real trace, not a min/max/final summary.
+//! that needs a real trace, not a min/max/final summary. `pos_x`/`pos_y` are
+//! `sim-host`'s dead-reckoned game path, NOT raw MuJoCo x/y -- see
+//! `sim_host::wire::StateOut::pos`'s doc comment.
 
 use sim_host::wire::{StateOut, SCHEMA_VERSION, STATE_MAGIC};
 use std::net::UdpSocket;

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -32,7 +32,7 @@
 
 use crate::pacer::Pacer;
 use crate::wire::{self, InputIn, StateOut};
-use board_types::{Command, Faults, ImuSample, Params, RAD_S_PER_ERPM};
+use board_types::{Command, Faults, ImuSample, Params, DEFAULT_R_EFF_M, RAD_S_PER_ERPM};
 use control_core::{CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator};
 use hal::BoardObserve;
 use hal_actuate::BoardActuate;
@@ -336,6 +336,20 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     let mut prev_reset_bit = false;
     let mut yaw_rad: f32 = 0.0;
     let mut wheel_angle_rad: f32 = 0.0;
+    // Dead-reckoned game-ground path -- see the PARTIALLY SYNTHETIC POSITION
+    // block further down for why this exists and what it costs. f64: this
+    // accumulates every tick for the whole run, and f32 would visibly drift
+    // over a multi-minute session the way `wheel_angle_rad` (f32, but reset
+    // every run and never compared against a long-run reference) does not
+    // need to guard against.
+    let mut dr_pos_x_m: f64 = 0.0;
+    let mut dr_pos_y_m: f64 = 0.0;
+    // Latest TRUE MuJoCo x/y, kept for `write_stats` -- the out-of-band
+    // channel that keeps ground truth available now that `pos`'s x/y on the
+    // wire itself are dead-reckoned, not MuJoCo truth. See the PARTIALLY
+    // SYNTHETIC POSITION block below.
+    let mut truth_pos_x_m: f64 = 0.0;
+    let mut truth_pos_y_m: f64 = 0.0;
 
     let start = Instant::now();
     let mut pacer = Pacer::new(Duration::from_nanos(CYCLE_NS), start);
@@ -506,8 +520,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // (Tuesday) needs a better one.
         let roll_rad = (xmat[5] as f32).atan2(xmat[8] as f32);
         let pos_f64 = backend.truth_frame_xpos();
+        truth_pos_x_m = pos_f64[0];
+        truth_pos_y_m = pos_f64[1];
         let quat_f64 = backend.truth_frame_xquat();
-        let pos = [pos_f64[0] as f32, pos_f64[1] as f32, pos_f64[2] as f32];
         let quat = [
             quat_f64[0] as f32,
             quat_f64[1] as f32,
@@ -524,10 +539,56 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // geometry, achievable roll is ~0.03 deg, so `steer` is effectively
         // the primary driver of yaw this weekend, NOT roll; the floor is
         // what makes that honest instead of a limiter that reads as "off".
+        // Updated BEFORE the position dead-reckoning below, so that
+        // reckoning always projects against this tick's freshest heading.
         let roll_authority = YAW_AUTHORITY_FLOOR
             + (1.0 - YAW_AUTHORITY_FLOOR)
                 * (roll_rad.abs() / ROLL_FULL_YAW_AUTHORITY_RAD).clamp(0.0, 1.0);
         yaw_rad += steer * YAW_RATE_GAIN_RAD_S * roll_authority * DT_S as f32;
+
+        // --- PARTIALLY SYNTHETIC POSITION (issue #161/#163) -------------
+        //
+        // MuJoCo only ever translates this plant along its own -X axis
+        // (there is no lateral/carving force anywhere in this model --
+        // `yaw_rad` never touches the physics). Sending MuJoCo's own
+        // x/y straight through, the way W1/W2's first cut did, is
+        // therefore honest about the SIM but dishonest about the GAME: on
+        // screen the board would spin to face `yaw_rad` while sliding
+        // along its original straight line underneath -- a car spinning
+        // out, not a board carving -- and that reads as a physics bug to
+        // anyone watching, on the single artifact (Monday's footage) this
+        // whole channel exists to protect.
+        //
+        // So `pos`'s x/y are DEAD-RECKONED here, in the host (never in
+        // Unreal -- the renderer computes no board state, ADR-0009 and
+        // `overboard-game`'s own README are explicit about that boundary):
+        // REAL forward ground speed (`wheel_rate_rad_s * DEFAULT_R_EFF_M`,
+        // straight off `hal`, nothing invented) is projected along the
+        // SYNTHETIC heading (`yaw_rad`) and integrated every tick. The
+        // result is a curved path that matches where the board is
+        // pointing -- exactly as partially synthetic as the heading that
+        // drives it, no more and no less.
+        //
+        // z is untouched: vertical position stays real MuJoCo truth (the
+        // wheel's own rolling motion in the sagittal plane needs no
+        // reckoning -- MuJoCo already integrates that correctly, which is
+        // the entire property this block exists to compensate for the
+        // LACK of in the lateral plane).
+        //
+        // This is a NEW non-physical channel, same status as `yaw_rad`/
+        // `steer` -- it needs its own line in the `Playable Sim` channel
+        // declaration (issue #163), flagged in this PR's body rather than
+        // added to `docs/vocabulary/` directly (Archivist's path, not
+        // this crate's). True MuJoCo x/y is NOT deleted -- see
+        // `write_stats`'s `truth_pos_x_m`/`truth_pos_y_m` lines below,
+        // which keep it available out-of-band for anything downstream
+        // that needs ground truth rather than the game path.
+        let heading_x = -yaw_rad.cos();
+        let heading_y = -yaw_rad.sin();
+        let forward_speed_m_s = wheel_rate_rad_s * DEFAULT_R_EFF_M;
+        dr_pos_x_m += (forward_speed_m_s * heading_x) as f64 * DT_S;
+        dr_pos_y_m += (forward_speed_m_s * heading_y) as f64 * DT_S;
+        let pos = [dr_pos_x_m as f32, dr_pos_y_m as f32, pos_f64[2] as f32];
 
         let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;
         if pitch_rad.abs() > FALLEN_PITCH_RAD {
@@ -554,7 +615,13 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
 
         if let Some(path) = &cfg.stats_path {
             if last_stats_write.elapsed() >= Duration::from_millis(100) {
-                write_stats(path, ticks, pacer.missed_deadlines());
+                write_stats(
+                    path,
+                    ticks,
+                    pacer.missed_deadlines(),
+                    truth_pos_x_m,
+                    truth_pos_y_m,
+                );
                 last_stats_write = Instant::now();
             }
         }
@@ -571,7 +638,13 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     }
 
     if let Some(path) = &cfg.stats_path {
-        write_stats(path, ticks, pacer.missed_deadlines());
+        write_stats(
+            path,
+            ticks,
+            pacer.missed_deadlines(),
+            truth_pos_x_m,
+            truth_pos_y_m,
+        );
     }
 
     let _ = backend.close();
@@ -582,13 +655,25 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     })
 }
 
-/// Best-effort, atomic (write-then-rename) write of the host's own counters,
-/// for `wire-probe` to pick up. Never allowed to interrupt the control loop
-/// -- a failure here is silently swallowed ON PURPOSE (unlike a missed
-/// deadline or a malformed input packet, which issue #161 requires surfacing
-/// loudly): this file is internal tooling, not the wire.
-fn write_stats(path: &std::path::Path, ticks: u64, missed_deadlines: u64) {
+/// Best-effort, atomic (write-then-rename) write of the host's own counters
+/// AND true MuJoCo ground position, for `wire-probe` (or anyone else) to
+/// pick up. Never allowed to interrupt the control loop -- a failure here is
+/// silently swallowed ON PURPOSE (unlike a missed deadline or a malformed
+/// input packet, which issue #161 requires surfacing loudly): this file is
+/// internal tooling, not the wire. `truth_pos_x_m`/`truth_pos_y_m` exist
+/// because `pos`'s x/y on the wire are now dead-reckoned, not MuJoCo truth
+/// (see the PARTIALLY SYNTHETIC POSITION block in `run`) -- ground truth
+/// must stay reachable for anything downstream that needs it.
+fn write_stats(
+    path: &std::path::Path,
+    ticks: u64,
+    missed_deadlines: u64,
+    truth_pos_x_m: f64,
+    truth_pos_y_m: f64,
+) {
     let tmp = path.with_extension("tmp");
-    let contents = format!("ticks={ticks}\nmissed_deadlines={missed_deadlines}\n");
+    let contents = format!(
+        "ticks={ticks}\nmissed_deadlines={missed_deadlines}\ntruth_pos_x_m={truth_pos_x_m}\ntruth_pos_y_m={truth_pos_y_m}\n"
+    );
     let _ = std::fs::write(&tmp, contents).and_then(|_| std::fs::rename(&tmp, path));
 }

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -52,9 +52,27 @@ pub struct StateOut {
     pub flags: u16,
     pub seq: u64,
     pub sim_time_s: f64,
-    /// Board body position, raw MuJoCo world frame, metres, Z-up
-    /// right-handed. **Not** converted to Unreal's frame -- that conversion
+    /// Board body position, metres, Z-up right-handed, in `sim-host`'s own
+    /// world frame. **Not** converted to Unreal's frame -- that conversion
     /// is deliberately the game side's job, not this host's (issue #161).
+    ///
+    /// **`x`/`y` are PARTIALLY SYNTHETIC as of issue #161/#169's follow-up,
+    /// NOT raw MuJoCo truth** -- `crate::host` dead-reckons them from real
+    /// forward ground speed projected along the synthetic `yaw_rad` heading,
+    /// because MuJoCo itself never turns this plant (there is no lateral
+    /// force in the model; `yaw_rad` is a rendering-only overlay). Sending
+    /// literal MuJoCo x/y here would make the board spin in place while
+    /// sliding along its original straight line on screen -- a car spinning
+    /// out, not a board carving. See `crate::host::run`'s "PARTIALLY
+    /// SYNTHETIC POSITION" comment for the full reasoning; true MuJoCo x/y
+    /// stays reachable out-of-band via `crate::host::write_stats`'s
+    /// `truth_pos_x_m`/`truth_pos_y_m`. This deviates from this field's
+    /// original description in ADR-0010's wire table (which predates the
+    /// widened-wheel roll-authority finding that made it necessary); per
+    /// that ADR's own "Consequences" section, the code and this comment are
+    /// authoritative over the table when they disagree.
+    ///
+    /// `z` is untouched: vertical position is real MuJoCo truth throughout.
     pub pos: [f32; 3],
     /// Board body orientation, raw MuJoCo, **w, x, y, z**.
     pub quat: [f32; 4],


### PR DESCRIPTION
## Summary

Issue #161/#169 follow-up to PR #171. PR #171 fixed the turn's *magnitude*
(max |yaw| 0.267 deg -> 98 deg). The COO's independent verification of that
fix caught a second-order problem the yaw measurement alone hides:
**`max |pos_y|` never exceeded ~4-6 mm across the same run.**

MuJoCo only ever translates this plant along its own -X axis -- there is no
lateral force anywhere in the model, and `yaw_rad` never touches the
physics. Sending MuJoCo's literal x/y straight through (as PRs #167/#170/#171
all did) meant the board would spin to face `yaw_rad` on screen while
sliding along its original straight line underneath: **a car spinning out,
not a board carving.** Nobody has seen this yet -- Mike's live Unreal pass
only exercised forward/reverse/coast, before the turn worked at all -- but it
would have read as an instant, obvious physics bug on the first turn anyone
watched, on the single artifact (Monday's footage) this whole channel exists
to protect.

## Fix -- in the host, not Unreal

`ADR-0009` and `overboard-game`'s own README are explicit that the renderer
computes no board state; solving this by having Unreal integrate a path
would breach the boundary this whole architecture exists to protect. So
`sim-host` now dead-reckons `pos_x`/`pos_y` itself, every tick:

1. **Real** forward ground speed: `wheel_rate_rad_s * DEFAULT_R_EFF_M`,
   straight off `hal` -- nothing invented.
2. Projected along the **synthetic** `yaw_rad` heading:
   `heading = (-cos(yaw_rad), -sin(yaw_rad))` (matches this model's
   "forward = -X" convention at `yaw_rad = 0`).
3. Integrated into an `f64` accumulator every tick (sim-time `DT_S`, not
   wall-clock, same as `wheel_angle_rad`/`yaw_rad` already do).

`pos_z` is untouched -- real MuJoCo vertical truth throughout, no reckoning
needed there (MuJoCo already integrates the sagittal-plane rolling motion
correctly; this block exists to compensate for the *lack* of any lateral
integration, not to replace something that already worked).

**Does not touch the wire schema** -- `pos` is still three `f32`s, same
byte layout, same `WIRE_SIZE`, same size assertion. What changes is what
gets written into two of the three floats, which the COO was explicit is a
different thing from a schema change.

## The honesty consequence -- said explicitly, not left implicit

- **`wire.rs`'s `StateOut::pos` doc comment** now says plainly that `x`/`y`
  are partially synthetic as of this commit, not raw MuJoCo truth, why, and
  that this deviates from `ADR-0010`'s original wire-table wording for this
  field -- per that ADR's own "Consequences" section ("the code and this ADR
  disagree... the code is right and this ADR is stale"), the code and this
  comment are authoritative over the table now.
- **True MuJoCo x/y is NOT deleted.** `write_stats` -- the existing
  internal-tooling channel (`/tmp/overboard-sim-host-stats.txt`, already
  documented as "not the wire") -- now also carries `truth_pos_x_m`/
  `truth_pos_y_m` on every write, so nothing downstream loses access to
  ground truth.
- **This is a NEW non-physical channel and needs a fifth `Playable Sim`
  declaration line** (issue #163, a launch blocker, currently lists four):
  *"the board's ground path is dead-reckoned from a synthetic heading, not
  simulated."* Flagged here and via a comment on #163 rather than written
  directly to `docs/vocabulary/provenance-marks.json` -- that path is the
  Archivist's by CODEOWNERS, and (unlike `sim/models/` in PR #170) I have no
  explicit direction to write there myself this time.

## Real, captured verification -- same measurement the COO used

`sim-host` run for 20s, no startup kick, driven by `send-input`'s scripted
schedule, captured with `wire-probe --csv`:

```
wire-probe: listening on 127.0.0.1:9601 for 17.0s
--- wire-probe report ---
run duration: 17.085 s
total ticks (valid state packets received): 4224
measured tick rate (mean): 247.23 Hz
seq range: 5776..=9999 (span 4224)
inter-packet interval (ms): mean=1.9998 p50=0.1875 p99=9.2297 max=28.4829
missed-deadline count from the host: 5190 (host reports 10000 ticks)
pitch_rad: min=-0.077058 max=0.111437 final=0.003818 (-4.415 deg / 6.385 deg / 0.219 deg)
confirmation: magic + schema_version parsed correctly on all 4224/4224 received packets
csv: wrote 4224 rows to /tmp/wp-pos.csv
```

**`max |pos_y|`: 0.758663 m** (up from ~4-6 mm). **`max |yaw_deg|`: 74.72**
in this run's capture window (consistent with PR #171's fix; the exact
number varies run to run with where the capture window lands relative to
`send-input`'s schedule).

Path shape during the turn phase, at fine resolution -- `pos_y` visibly
tracking `yaw_deg` as the heading rotates, `pos_x`'s rate of change slowing
as speed gets redirected sideways:

| sim_t | pos_x | pos_y | yaw_deg |
|---|---|---|---|
| 18.50 | -14.636 | 0.0007 | 1.692 |
| 18.70 | -14.468 | 0.0200 | 10.641 |
| 18.90 | -14.298 | 0.0616 | 18.128 |
| 19.10 | -14.137 | 0.1307 | 28.338 |
| 19.30 | -13.987 | 0.2307 | 38.755 |
| 19.50 | -13.858 | 0.3552 | 48.965 |
| 19.70 | -13.750 | 0.5052 | 59.373 |
| 19.90 | -13.671 | 0.6702 | 69.564 |

`pos_y` stays exactly `0.0000` for the entire non-turn portion of the run
(confirming no leakage), then curves smoothly once the turn phase starts --
a real curved path, not a spin in place.

Host's own final line for the full 20 s run: `sim-host: stopped cleanly --
10000 ticks, 5190 missed deadlines` (same macOS-scheduling cause already
documented in #167/#170/#171, not a regression here).

## Test plan
- [x] `cargo build --workspace --all-targets` clean (`-j 2` throughout per
      the machine-memory note)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] Real captured `sim-host` + `send-input` + `wire-probe --csv` run,
      output above, same measurement methodology the COO used

## Scope note
Only `crates/sim-host/src/host.rs` (dead-reckoning + `write_stats`
plumbing) and doc comments in `wire.rs`/`wire-probe.rs`. No model or
controller-law change -- this is a position-integration fix, not a physics
or controller change.

## Follow-up needed (not this PR)
- A fifth `Playable Sim` channel declaration line for the dead-reckoned
  path, in `docs/vocabulary/provenance-marks.json` (Archivist's path) --
  flagging via a comment on #163.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>