### PR TITLE
fix(vocabulary): the Playable Sim declaration needed a fifth line (#163)

### DIFF
--- a/docs/vocabulary/README.md
+++ b/docs/vocabulary/README.md
@@ -64,3 +64,12 @@ unreproducible, so it fit none of `Footage · Sim Replay · Hardware Replay · C
 in Shared Vocabulary § 1, mirrored here. Playable Sim also introduced the first
 required-presence check — see "What belongs here" above — because it is the only category
 where a tag alone cannot tell a viewer which part of the frame is physics.
+
+**2026-08-01, same day — the declaration grew a fifth line before the fourth one shipped.**
+PR #172 (`overboard`, `crates/sim-host`) found that `yaw_rad` never touched the MuJoCo
+physics, so the game's `pos_x`/`pos_y` had to be dead-reckoned in the host from real forward
+speed projected along the synthetic heading rather than sent as literal MuJoCo truth. That is
+a new non-physical channel, caught before any footage existed rather than after — which is the
+whole reason this is a *check* against `provenance-marks.json` and not prose someone has to
+remember. `ground-path-dead-reckoned` added to `required_patterns`; a `PLAYABLE SIM` asset
+declaring only four of five now fails the sweep by name.

--- a/docs/vocabulary/provenance-marks.json
+++ b/docs/vocabulary/provenance-marks.json
@@ -19,6 +19,17 @@
     "are looking at is physics and which is not -- so the mark is not enough; the",
     "full non-physical channel declaration has to travel with it, every time.",
     "",
+    "2026-08-01, same day: fifth required pattern (ground-path-dead-reckoned) added",
+    "per the COO's finding on PR #172 (sim-host). yaw_rad never touched the MuJoCo",
+    "physics -- the plant only ever translated along one axis -- so the game's",
+    "ground path (pos_x/pos_y on the wire) is now dead-reckoned in the host from",
+    "real forward speed projected along the synthetic heading, not read as literal",
+    "MuJoCo truth. True MuJoCo x/y stays available out-of-band (truth_pos_x_m /",
+    "truth_pos_y_m). This is exactly the failure the category exists to catch: a",
+    "viewer who accepts \"steering is invented\" could still assume the path drawn",
+    "on the ground is simulated output, and a path is exactly what a stranger",
+    "would screenshot and treat as a controls result.",
+    "",
     "Scope note: checked over OPEN issues only, same reasoning as retired-terms.json",
     "-- a past asset's declaration is the record of what was known at the time and",
     "is never rewritten to match a later, longer declaration."
@@ -34,7 +45,7 @@
       "channel_declaration": {
         "_note": [
           "Every channel invented or diverged from the hardware model, stated",
-          "wherever the asset appears. For Monday's launch these are the four",
+          "wherever the asset appears. For Monday's launch these are the five",
           "required lines. Extend this list as new non-physical channels are added",
           "-- do not silently shrink it: a shorter declaration on a later asset is",
           "itself a finding, not a simplification."
@@ -54,6 +65,11 @@
             "id": "rigid-ballast",
             "pattern": "rigid ballast|not a person",
             "note": "The rider is a rigid ballast, not a person."
+          },
+          {
+            "id": "ground-path-dead-reckoned",
+            "pattern": "dead[- ]?reckon\\w*",
+            "note": "The board's ground path is dead-reckoned from a synthetic heading, not simulated -- PR #172. Forward speed and balance come from the physics; the travel direction comes from the invented yaw channel, not tyre contact."
           },
           {
             "id": "no-hardware",


### PR DESCRIPTION
## Summary

Follow-up to #163 / PR #166. The COO's independent verification of PR #172 (`crates/sim-host`) found that `yaw_rad` never touches the MuJoCo physics — the plant only ever translates along one axis — so the game's `pos_x`/`pos_y` on the wire is now dead-reckoned in the host from real forward speed projected along the invented steering heading, not literal MuJoCo truth. That's a new non-physical channel the four-line declaration shipped in #166 didn't cover, caught **before any footage exists**, which is the whole point of a checked declaration over a prose one.

## What changed

- **Notion — Shared Vocabulary (canonical) § 1**: "For Monday, the declaration is five lines" (was four) — adds *"The board's ground path is dead-reckoned, not simulated. Forward speed and balance come from the physics; the direction the board travels is computed from the invented steering channel, not from tyre contact."* Re-fetched post-write, structure confirmed intact.
- **Notion — Session start prompts, DCP block**: five lines, citing PR #172. Re-fetched, confirmed intact.
- **`docs/vocabulary/provenance-marks.json`**: new `ground-path-dead-reckoned` entry in `required_patterns` (pattern: `dead[- ]?reckon\w*`), `_note` count corrected four → five, dated addendum to `_comment` explaining the finding.
- **`docs/vocabulary/README.md`**: status addendum.

## Re-verification (as the COO asked)

Synthetic, via `compile_marks()`/`scan_declarations()` directly:
- **absent** (no `PLAYABLE SIM` mark) → silent
- **partial**, old four-of-five declaration → exactly one finding: `on-frame mark present but declaration missing: ground-path-dead-reckoned`
- **complete**, five-of-five (COO's suggested wording) → silent

Live, via `python3 docs/vocabulary/sweep_public.py --no-timeline` against real `gh` data: now also flags **#163's own issue body** (it predates PR #172 and states only four lines). That's not a mislabeled asset — it's the governance issue demonstrating the exact gap it describes — so left as-is rather than special-cased; noted here for the record. One other finding is pre-existing and unrelated (PR #80, known renamed-history case).

`python3 .github/policy_check.py` — all hard checks pass.

## Acceptance criteria (from the COO's message)

- [x] Fifth line added to the canonical Shared Vocabulary page, mirrored to `docs/vocabulary/`
- [x] Added to `provenance-marks.json`'s `required_patterns` — the sweep now enforces five, not four
- [x] Digital Content Production session-start prompt updated
- [x] Sweep re-verified: absent, partial (four-of-five), complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)