### PR TITLE
feat(controls): wire v2 -- carry the ACTUAL ballast joint position for a visible rider

### DIFF
--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -57,6 +57,8 @@ extern "C" {
     fn plant_mujoco_get_body_xpos(data: *mut c_void, body_id: c_int, out: *mut f64);
     fn plant_mujoco_get_body_xquat(data: *mut c_void, body_id: c_int, out: *mut f64);
     fn plant_mujoco_actuator_id(model: *mut c_void, name: *const c_char) -> c_int;
+    fn plant_mujoco_joint_id(model: *mut c_void, name: *const c_char) -> c_int;
+    fn plant_mujoco_joint_qposadr(model: *mut c_void, joint_id: c_int) -> c_int;
 }
 
 /// The linked libmujoco's own `mj_versionString()`.
@@ -347,6 +349,28 @@ impl Plant {
         } else {
             Some(id as usize)
         }
+    }
+
+    /// `mjModel::jnt_qposadr` for the joint named `name`, or `None` if the
+    /// model has no such joint -- the index into `Plant::qpos()`'s vector
+    /// where that joint's own generalized coordinate(s) start. Exists for
+    /// issue #161 wire v2: the state-out wire needs the ballast joints'
+    /// ACTUAL position, and there is no sensor declared for them (no model
+    /// change this pass). Correct for any 1-DOF joint (e.g. the `slide`
+    /// joints `overboard_rider.xml`'s ballast uses); a multi-DOF joint (a
+    /// `free` or `ball` joint) would need more than one address, which this
+    /// method does not attempt to return.
+    pub fn joint_qposadr(&self, name: &str) -> Option<usize> {
+        let name_c = CString::new(name).expect("joint name must not contain a NUL byte");
+        // SAFETY: `self.model` is non-null and owned for the life of `self`;
+        // `name_c` is a valid NUL-terminated string kept alive for the call.
+        let id = unsafe { plant_mujoco_joint_id(self.model, name_c.as_ptr()) };
+        if id < 0 {
+            return None;
+        }
+        // SAFETY: `id` was just resolved against this same model.
+        let adr = unsafe { plant_mujoco_joint_qposadr(self.model, id) };
+        Some(adr as usize)
     }
 
     /// `mjData::xmat[body_id]`, row-major, exactly `data.xmat[body].reshape(3,

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -183,3 +183,16 @@ void plant_mujoco_get_body_xquat(void* data, int body_id, double* out) {
 int plant_mujoco_actuator_id(void* model, const char* name) {
   return mj_name2id((const mjModel*)model, mjOBJ_ACTUATOR, name);
 }
+
+// Joint lookup by NAME, and its qpos address -- issue #161 wire v2: the
+// state-out wire needs the ballast joints' ACTUAL (not commanded) position,
+// and there is no sensor declared for them (no model change this pass), so
+// this reads mjModel::jnt_qposadr directly. Same by-name-not-offset
+// reasoning as plant_mujoco_sensor_id.
+int plant_mujoco_joint_id(void* model, const char* name) {
+  return mj_name2id((const mjModel*)model, mjOBJ_JOINT, name);
+}
+
+int plant_mujoco_joint_qposadr(void* model, int joint_id) {
+  return ((mjModel*)model)->jnt_qposadr[joint_id];
+}

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -131,6 +131,13 @@ pub struct SimBackend {
     /// reset to zero on every `open()`.
     ballast_fa_target_m: f32,
     ballast_lateral_target_m: f32,
+    /// `mjModel::jnt_qposadr` for the `ballast_fa`/`ballast_lat` joints, if
+    /// the open model declares them -- `None` for the driverless onewheel
+    /// model. Resolved once in `open()`; used by
+    /// [`SimBackend::truth_ballast_positions`], the ACTUAL (not commanded)
+    /// joint position issue #161 wire v2 puts on the state-out wire.
+    ballast_fa_qposadr: Option<usize>,
+    ballast_lateral_qposadr: Option<usize>,
     cycle: u64,
     open: bool,
     armed: bool,
@@ -274,6 +281,35 @@ impl SimBackend {
             .expect("truth_frame_xquat: backend is not open");
         plant.body_xquat(self.frame_body)
     }
+
+    /// Ground-truth ballast joint positions, metres, signed -- the ACTUAL
+    /// `ballast_fa`/`ballast_lat` `qpos`, not the commanded target
+    /// (issue #161 wire v2: "send the real joint position ... the ballast
+    /// is rate-limited so it lags the command, and that lag is honest").
+    /// `(0.0, 0.0)` on a model that declares neither joint (e.g. the
+    /// driverless onewheel model) -- same tolerance
+    /// [`SimBackend::set_ballast_targets`] has, not a panic: a caller on the
+    /// driverless plant gets an honest "no ballast" reading, not an error
+    /// for a channel that was never claimed to exist there.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_ballast_positions(&self) -> (f32, f32) {
+        let plant = self
+            .plant
+            .as_ref()
+            .expect("truth_ballast_positions: backend is not open");
+        let qpos = plant.qpos();
+        let fore_aft = self
+            .ballast_fa_qposadr
+            .map(|adr| qpos[adr] as f32)
+            .unwrap_or(0.0);
+        let lateral = self
+            .ballast_lateral_qposadr
+            .map(|adr| qpos[adr] as f32)
+            .unwrap_or(0.0);
+        (fore_aft, lateral)
+    }
 }
 
 impl BoardObserve for SimBackend {
@@ -337,6 +373,11 @@ impl BoardObserve for SimBackend {
         // issue #161 W2) does not depend on ctrl-array position.
         self.ballast_fa_actuator = plant.actuator_id("ballast_fa");
         self.ballast_lateral_actuator = plant.actuator_id("ballast_lat");
+        // Same joint names the actuators above drive; resolved separately
+        // because a qpos address is a property of the JOINT, not the
+        // actuator that happens to drive it (issue #161 wire v2).
+        self.ballast_fa_qposadr = plant.joint_qposadr("ballast_fa");
+        self.ballast_lateral_qposadr = plant.joint_qposadr("ballast_lat");
 
         self.plant = Some(plant);
         self.cycle = 0;

--- a/crates/sim-host/src/bin/send-input.rs
+++ b/crates/sim-host/src/bin/send-input.rs
@@ -18,7 +18,7 @@
 //! send-input [--target ADDR]
 //! ```
 
-use sim_host::wire::{InputIn, INPUT_MAGIC, SCHEMA_VERSION};
+use sim_host::wire::{InputIn, INPUT_MAGIC, INPUT_SCHEMA_VERSION};
 use std::net::UdpSocket;
 use std::time::{Duration, Instant};
 
@@ -98,7 +98,7 @@ fn main() {
         }
         let pkt = InputIn {
             magic: INPUT_MAGIC,
-            schema_version: SCHEMA_VERSION,
+            schema_version: INPUT_SCHEMA_VERSION,
             flags: 0,
             seq,
             weight_shift_fore_aft: fore_aft,

--- a/crates/sim-host/src/bin/wire-probe.rs
+++ b/crates/sim-host/src/bin/wire-probe.rs
@@ -23,7 +23,7 @@
 //! `sim-host`'s dead-reckoned game path, NOT raw MuJoCo x/y -- see
 //! `sim_host::wire::StateOut::pos`'s doc comment.
 
-use sim_host::wire::{StateOut, SCHEMA_VERSION, STATE_MAGIC};
+use sim_host::wire::{StateOut, STATE_MAGIC, STATE_SCHEMA_VERSION};
 use std::net::UdpSocket;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -87,6 +87,10 @@ struct CsvRow {
     yaw_rad: f32,
     wheel_rate_rad_s: f32,
     motor_current_a: f32,
+    /// v2: ACTUAL ballast joint position, metres -- see
+    /// `sim_host::wire::StateOut::rider_fore_aft_m`'s doc comment.
+    rider_fore_aft_m: f32,
+    rider_lateral_m: f32,
 }
 
 fn percentile(sorted_ms: &[f64], p: f64) -> f64 {
@@ -150,6 +154,10 @@ fn main() {
     let mut pitch_min = f32::INFINITY;
     let mut pitch_max = f32::NEG_INFINITY;
     let mut pitch_final: f32 = f32::NAN;
+    let mut rider_fore_aft_min = f32::INFINITY;
+    let mut rider_fore_aft_max = f32::NEG_INFINITY;
+    let mut rider_lateral_min = f32::INFINITY;
+    let mut rider_lateral_max = f32::NEG_INFINITY;
     let mut first_seq: Option<u64> = None;
     let mut last_seq: Option<u64> = None;
     // Buffered in memory and written once at the end, not appended live:
@@ -167,6 +175,12 @@ fn main() {
                     pitch_min = pitch_min.min(pitch);
                     pitch_max = pitch_max.max(pitch);
                     pitch_final = pitch;
+                    let (rider_fore_aft, rider_lateral) =
+                        (state.rider_fore_aft_m, state.rider_lateral_m);
+                    rider_fore_aft_min = rider_fore_aft_min.min(rider_fore_aft);
+                    rider_fore_aft_max = rider_fore_aft_max.max(rider_fore_aft);
+                    rider_lateral_min = rider_lateral_min.min(rider_lateral);
+                    rider_lateral_max = rider_lateral_max.max(rider_lateral);
                     let seq = state.seq;
                     first_seq.get_or_insert(seq);
                     last_seq = Some(seq);
@@ -181,6 +195,8 @@ fn main() {
                             yaw_rad: state.yaw_rad,
                             wheel_rate_rad_s: state.wheel_rate_rad_s,
                             motor_current_a: state.motor_current_a,
+                            rider_fore_aft_m: rider_fore_aft,
+                            rider_lateral_m: rider_lateral,
                         });
                     }
                 }
@@ -263,12 +279,20 @@ fn main() {
         pitch_max.to_degrees(),
         pitch_final.to_degrees()
     );
+    println!(
+        "rider_fore_aft_m: min={rider_fore_aft_min:.6} max={rider_fore_aft_max:.6} \
+         (v2 -- ACTUAL ballast_fa joint position, not the commanded target)"
+    );
+    println!(
+        "rider_lateral_m: min={rider_lateral_min:.6} max={rider_lateral_max:.6} \
+         (v2 -- ACTUAL ballast_lat joint position, not the commanded target)"
+    );
 
     if total_received == 0 {
         println!("confirmation: NO PACKETS RECEIVED -- nothing to confirm");
     } else if invalid_count == 0 {
         println!(
-            "confirmation: magic ({STATE_MAGIC:#010x}) + schema_version ({SCHEMA_VERSION}) \
+            "confirmation: magic ({STATE_MAGIC:#010x}) + schema_version ({STATE_SCHEMA_VERSION}) \
              parsed correctly on all {valid_count}/{total_received} received packets"
         );
     } else {
@@ -280,11 +304,11 @@ fn main() {
 
     if let Some(path) = &args.csv {
         let mut out = String::from(
-            "seq,sim_time_s,pos_x_m,pos_y_m,pitch_rad,yaw_rad,wheel_rate_rad_s,motor_current_a\n",
+            "seq,sim_time_s,pos_x_m,pos_y_m,pitch_rad,yaw_rad,wheel_rate_rad_s,motor_current_a,rider_fore_aft_m,rider_lateral_m\n",
         );
         for r in &csv_rows {
             out.push_str(&format!(
-                "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6}\n",
+                "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6}\n",
                 r.seq,
                 r.sim_time_s,
                 r.pos_x_m,
@@ -292,7 +316,9 @@ fn main() {
                 r.pitch_rad,
                 r.yaw_rad,
                 r.wheel_rate_rad_s,
-                r.motor_current_a
+                r.motor_current_a,
+                r.rider_fore_aft_m,
+                r.rider_lateral_m
             ));
         }
         match std::fs::write(path, out) {

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -590,6 +590,19 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         dr_pos_y_m += (forward_speed_m_s * heading_y) as f64 * DT_S;
         let pos = [dr_pos_x_m as f32, dr_pos_y_m as f32, pos_f64[2] as f32];
 
+        // Wire v2 (issue #161 follow-up): the ACTUAL ballast joint
+        // positions -- CEO feedback was "there is no rider, and the turn
+        // is not discernible", and a renderer cannot pose a rider from data
+        // it does not have. NOT the commanded target (`weight_shift_*` *
+        // BALLAST_RANGE_M`) -- the actuator is rate-limited
+        // (`overboard_rider.xml`'s `timeconst`), so it lags a step change,
+        // and sending the real joint value means that lag is visible
+        // honestly rather than hidden behind an instantaneous command. Small
+        // by construction (measured ~0.04 m at 0.8 stick) -- this host does
+        // NOT amplify it for legibility; that is the renderer's job, as its
+        // own declared non-physical channel, not this crate's to fake.
+        let (rider_fore_aft_m, rider_lateral_m) = backend.truth_ballast_positions();
+
         let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;
         if pitch_rad.abs() > FALLEN_PITCH_RAD {
             flags |= wire::STATE_FLAG_FALLEN;
@@ -597,7 +610,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
 
         let state = StateOut {
             magic: wire::STATE_MAGIC,
-            schema_version: wire::SCHEMA_VERSION,
+            schema_version: wire::STATE_SCHEMA_VERSION,
             flags,
             seq: ticks,
             sim_time_s: obs.t_recv_ns as f64 * 1e-9,
@@ -608,6 +621,8 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             pitch_rad,
             yaw_rad,
             motor_current_a: obs.motor_current_a,
+            rider_fore_aft_m,
+            rider_lateral_m,
         };
         out_socket.send_to(&state.to_bytes(), cfg.state_out_addr)?;
 

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -23,8 +23,16 @@ use std::net::SocketAddr;
 pub const STATE_MAGIC: u32 = 0x4F42_5731;
 /// `magic` for [`InputIn`] -- ASCII "OBI1".
 pub const INPUT_MAGIC: u32 = 0x4F42_4931;
-/// The only schema version either struct has spoken so far.
-pub const SCHEMA_VERSION: u16 = 1;
+/// [`StateOut`]'s schema version -- bumped to 2 for the rider-position
+/// fields (issue #161 follow-up). `sim-host` always sends 2; the renderer is
+/// being told to accept 1 (treating it as "no rider data, rider neutral")
+/// and 2, so a one-sided deploy in either direction cannot produce a dead
+/// window. This crate has no v1 sender left to keep around, so
+/// [`StateOut::from_bytes`] only accepts 2 -- see that method's doc comment.
+pub const STATE_SCHEMA_VERSION: u16 = 2;
+/// [`InputIn`]'s schema version. Unchanged by the v2 state-out bump --
+/// `InputIn` is explicitly untouched (issue #161 wire v2 follow-up).
+pub const INPUT_SCHEMA_VERSION: u16 = 1;
 
 /// `StateOut::flags` bit 0.
 pub const STATE_FLAG_ARMED: u16 = 1 << 0;
@@ -43,7 +51,11 @@ pub const STATE_OUT_ADDR: &str = "127.0.0.1:9601";
 /// Host BINDS/LISTENS for input here.
 pub const INPUT_IN_ADDR: &str = "127.0.0.1:9602";
 
-/// One tick of board state, host -> Unreal (issue #161 wire v1).
+/// One tick of board state, host -> Unreal (issue #161 wire, v2 as of the
+/// rider-position follow-up). v1's fields are unchanged, in the same order;
+/// v2 appends `rider_fore_aft_m`/`rider_lateral_m` at the end -- ADR-0010's
+/// own "Consequences" section calls this out as the designed-for case
+/// ("Adding a field is a version bump, which is cheap by construction").
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StateOut {
@@ -87,11 +99,25 @@ pub struct StateOut {
     /// side has a heading to render with in W1.
     pub yaw_rad: f32,
     pub motor_current_a: f32,
+    /// **v2.** ACTUAL `ballast_fa` joint position, metres, signed -- NOT the
+    /// commanded target. The ballast is rate-limited (`overboard_rider.xml`'s
+    /// `timeconst`), so it lags a step change in `weight_shift_fore_aft`;
+    /// sending the real joint position means that lag is visible to the
+    /// renderer, honestly, rather than hidden behind an instantaneous
+    /// commanded value. Small by construction -- +/-0.05 m range, ~0.04 m
+    /// achieved at 0.8 stick (measured, issue #161 follow-up) -- and this
+    /// crate does NOT amplify it for legibility; a renderer that wants a
+    /// more visible pose does that itself, as its own declared non-physical
+    /// channel, not one faked at the source.
+    pub rider_fore_aft_m: f32,
+    /// **v2.** ACTUAL `ballast_lat` joint position, metres, signed. Same
+    /// status as `rider_fore_aft_m` in every respect but axis.
+    pub rider_lateral_m: f32,
 }
 
 impl StateOut {
     /// The exact on-wire byte count -- also asserted at compile time below.
-    pub const WIRE_SIZE: usize = 72;
+    pub const WIRE_SIZE: usize = 80;
 
     #[allow(clippy::too_many_arguments)]
     pub fn to_bytes(&self) -> [u8; Self::WIRE_SIZE] {
@@ -120,13 +146,18 @@ impl StateOut {
         put!(self.pitch_rad);
         put!(self.yaw_rad);
         put!(self.motor_current_a);
+        put!(self.rider_fore_aft_m);
+        put!(self.rider_lateral_m);
         debug_assert_eq!(off, Self::WIRE_SIZE);
         buf
     }
 
     /// Parses a received datagram. Fails loudly (returns [`WireError`])
     /// rather than misreading a mismatched magic/version as a float --
-    /// per issue #161's explicit instruction.
+    /// per issue #161's explicit instruction. Accepts ONLY
+    /// [`STATE_SCHEMA_VERSION`] (2): this crate has no v1 sender to stay
+    /// compatible with (`sim-host` always sends 2 -- see that constant's doc
+    /// comment) -- v1 tolerance is the renderer's job, in a different repo.
     pub fn from_bytes(buf: &[u8]) -> Result<Self, WireError> {
         if buf.len() != Self::WIRE_SIZE {
             return Err(WireError::WrongSize {
@@ -151,9 +182,9 @@ impl StateOut {
                 got: magic,
             });
         }
-        if schema_version != SCHEMA_VERSION {
+        if schema_version != STATE_SCHEMA_VERSION {
             return Err(WireError::BadVersion {
-                expected: SCHEMA_VERSION,
+                expected: STATE_SCHEMA_VERSION,
                 got: schema_version,
             });
         }
@@ -167,6 +198,8 @@ impl StateOut {
         let pitch_rad = take!(f32);
         let yaw_rad = take!(f32);
         let motor_current_a = take!(f32);
+        let rider_fore_aft_m = take!(f32);
+        let rider_lateral_m = take!(f32);
         debug_assert_eq!(off, Self::WIRE_SIZE);
         Ok(StateOut {
             magic,
@@ -181,6 +214,8 @@ impl StateOut {
             pitch_rad,
             yaw_rad,
             motor_current_a,
+            rider_fore_aft_m,
+            rider_lateral_m,
         })
     }
 }
@@ -253,9 +288,9 @@ impl InputIn {
                 got: magic,
             });
         }
-        if schema_version != SCHEMA_VERSION {
+        if schema_version != INPUT_SCHEMA_VERSION {
             return Err(WireError::BadVersion {
-                expected: SCHEMA_VERSION,
+                expected: INPUT_SCHEMA_VERSION,
                 got: schema_version,
             });
         }
@@ -325,8 +360,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn state_out_is_exactly_72_bytes() {
-        assert_eq!(core::mem::size_of::<StateOut>(), 72);
+    fn state_out_is_exactly_80_bytes() {
+        assert_eq!(core::mem::size_of::<StateOut>(), 80);
     }
 
     #[test]
@@ -337,7 +372,7 @@ mod tests {
     fn sample_state() -> StateOut {
         StateOut {
             magic: STATE_MAGIC,
-            schema_version: SCHEMA_VERSION,
+            schema_version: STATE_SCHEMA_VERSION,
             flags: STATE_FLAG_ARMED | STATE_FLAG_VALID,
             seq: 42,
             sim_time_s: 1.5,
@@ -348,6 +383,8 @@ mod tests {
             pitch_rad: -0.05,
             yaw_rad: 0.3,
             motor_current_a: 4.5,
+            rider_fore_aft_m: 0.021,
+            rider_lateral_m: -0.013,
         }
     }
 
@@ -393,10 +430,29 @@ mod tests {
         );
     }
 
+    /// This crate always sends v2 (issue #161 follow-up); a genuine
+    /// 72-byte v1 packet -- correct magic, `schema_version = 1`, the OLD
+    /// (pre-rider-fields) size -- must still be refused, by size, before
+    /// `schema_version` is even inspected. v1/v2 coexistence tolerance is
+    /// the renderer's job, in a different repo, not `StateOut::from_bytes`'s.
+    #[test]
+    fn state_out_rejects_a_genuine_v1_sized_packet() {
+        let mut v1_bytes = [0u8; 72];
+        v1_bytes[0..4].copy_from_slice(&STATE_MAGIC.to_le_bytes());
+        v1_bytes[4..6].copy_from_slice(&1u16.to_le_bytes()); // schema_version = 1
+        assert_eq!(
+            StateOut::from_bytes(&v1_bytes),
+            Err(WireError::WrongSize {
+                expected: StateOut::WIRE_SIZE,
+                got: 72,
+            })
+        );
+    }
+
     fn sample_input() -> InputIn {
         InputIn {
             magic: INPUT_MAGIC,
-            schema_version: SCHEMA_VERSION,
+            schema_version: INPUT_SCHEMA_VERSION,
             flags: INPUT_FLAG_ARM,
             seq: 7,
             weight_shift_fore_aft: 0.5,


### PR DESCRIPTION
## Summary

Issue #161 follow-up. CEO feedback after seeing the current build run: **"there
is no rider, and the turn is not discernible."** The COO verified the turn's
physics is correct (yaw reaches ~96.5 deg, path direction converges exactly on
the heading -- PR #172) but *correct in the data* is not the same as *legible
on screen* without a visible rider -- a tall object is what makes lean and
rotation readable, and the wire carried no rider state at all for the
renderer to pose one from.

## The bump

`StateOut` -> `schema_version = 2`. Per ADR-0010's own "Consequences"
section ("Adding a field is a version bump, which is cheap by construction --
the schema is designed to be outgrown, not to be complete"), this appends
exactly two `f32` at the end, changing nothing before them (`WIRE_SIZE`
72 -> 80):

| field | type | notes |
|---|---|---|
| ...all existing v1 fields, unchanged, same order... | | |
| `rider_fore_aft_m` | f32 | **ACTUAL** `ballast_fa` joint position, metres, signed |
| `rider_lateral_m` | f32 | **ACTUAL** `ballast_lat` joint position, metres, signed |

**Real position, not the commanded target.** The ballast is rate-limited
(`overboard_rider.xml`'s `timeconst`), so it lags a step change in
`weight_shift_*` -- sending the real joint value means the renderer sees that
lag honestly, rather than an instantaneous value hidden behind the command.

**`InputIn` is untouched** -- still `schema_version = 1`. The previously
shared `SCHEMA_VERSION` constant is now two independent constants
(`STATE_SCHEMA_VERSION = 2`, `INPUT_SCHEMA_VERSION = 1`) so the two can move
on their own schedules.

## Rollout

`sim-host` always sends v2. `StateOut::from_bytes` accepts **only** 2 --
this crate has no v1 sender left to stay compatible with, and v1/v2
coexistence tolerance is the renderer's job in `overboard-game` (a different
repo), not this crate's. A new test (`state_out_rejects_a_genuine_v1_sized_packet`)
pins that a real 72-byte v1 packet is refused by size, before `schema_version`
is even inspected.

## Plumbing -- no model or controller change

The ballast joints already exist and already move (measured in PR #171:
`ballast_lat` reaching 0.0401 m at 0.8 stick). Reading their ACTUAL position
needed a new lookup, since no sensor is declared for them (no model change
this pass):

- **`crates/plant-mujoco`**: `joint_id()`/`joint_qposadr()`, mirroring the
  existing sensor/body/actuator name-lookup pattern. Reads
  `mjModel::jnt_qposadr` directly.
- **`crates/sim-backend`**: `SimBackend::truth_ballast_positions()`, reading
  the real `qpos` through the new lookup. Returns `(0.0, 0.0)` on a model
  that declares neither joint -- same tolerance `set_ballast_targets`
  already has, not a panic.
- **`crates/sim-host`**: wires the real position into `StateOut` every tick.

## Honesty note (not exaggerated on the wire)

Displacement is small -- consistent with the ~0.04 m ceiling PR #171
measured at 0.8 stick. **This PR does not amplify it.** That is a real
physical result of the current ballast range; if the renderer wants a more
legible pose, amplifying it visually is the renderer's own declared
non-physical channel, not something faked at the source here. The fifth
`Playable Sim` declaration line this needs was flagged on issue #163 and has
already shipped (#173, Archivist) -- confirms the comment-based handoff (used
instead of writing `docs/vocabulary/` directly, which is Archivist's path)
worked as intended.

## Real, captured verification -- `wire-probe`, now reporting `rider_*`

`sim-host` run for 20s, driven by `send-input`'s scripted schedule, captured
with `wire-probe --csv` (now carrying `rider_fore_aft_m`/`rider_lateral_m`):

```
wire-probe: listening on 127.0.0.1:9601 for 17.0s
--- wire-probe report ---
run duration: 17.178 s
total ticks (valid state packets received): 4764
measured tick rate (mean): 277.33 Hz
seq range: 5236..=9999 (span 4764)
inter-packet interval (ms): mean=1.9994 p50=0.0874 p99=15.3198 max=36.7167
missed-deadline count from the host: 7118 (host reports 10000 ticks)
pitch_rad: min=-0.042051 max=0.076621 final=0.000151 (-2.409 deg / 4.390 deg / 0.009 deg)
rider_fore_aft_m: min=-0.020686 max=0.002296 (v2 -- ACTUAL ballast_fa joint position, not the commanded target)
rider_lateral_m: min=-0.000426 max=0.028821 (v2 -- ACTUAL ballast_lat joint position, not the commanded target)
confirmation: magic (0x4f425731) + schema_version (2) parsed correctly on all 4764/4764 received packets
csv: wrote 4764 rows to /tmp/wp-rider.csv
```

**Real, nonzero motion tracking the scripted schedule** -- not zeros:

| sim_t | rider_fore_aft_m | rider_lateral_m |
|---|---|---|
| 10.47 | 0.00230 | -0.00000 |
| 12.25 | -0.01524 | -0.00000 |
| 14.25 | -0.01823 | -0.00000 |
| 15.25 | -0.02051 | 0.00000 |
| 16.25 | -0.00191 | 0.00000 |
| 17.25 | -0.00056 | 0.00014 |
| 18.25 | -0.00019 | 0.02604 |
| 19.25 | -0.00006 | 0.02687 |

`rider_fore_aft_m` responds during the lean-back phase (peaking near
-0.0205 m), then decays back toward zero on release, exactly the rate-limited
lag the field exists to expose honestly. `rider_lateral_m` climbs during the
turn phase (lateral lean), consistent with PR #171's own measured ceiling for
the window this capture happened to land on (a shorter window than the full
settling time, so it has not yet reached that ceiling here -- also honest).

Host's own final line for the full 20 s run: `sim-host: stopped cleanly --
10000 ticks, 7118 missed deadlines` (same macOS-scheduling cause already
documented in prior PRs, not a regression here).

## Test plan
- [x] `cargo build --workspace --all-targets` clean (`-j 2` throughout per
      the machine-memory note)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (`sim-host` 15 -> 16 tests: new
      `state_out_rejects_a_genuine_v1_sized_packet`)
- [x] Full `pytest tests/` still **293 passed, 2 xfailed**
- [x] Real captured `sim-host` + `send-input` + `wire-probe --csv` run,
      output above

## Scope note
Two fields, the `plant-mujoco` joint lookup needed to read them
(`joint_id`/`joint_qposadr`), the size assertion, the tests, and doc
comments. No model change (`overboard_rider.xml` untouched), no controller
change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>