### PR TITLE
fix(sim-host): the game heading steered the path but never turned the board

### DIFF
--- a/crates/sim-host/src/bin/send-input.rs
+++ b/crates/sim-host/src/bin/send-input.rs
@@ -44,50 +44,61 @@ const SCHEDULE: &[(f64, f64, f32, f32, f32, &str)] = &[
     (14.0, 15.0, 0.0, 0.0, 0.0, "release"),
 ];
 
-/// `--scenario s-curve`: hold a decent forward speed and weave, for watching the board CARVE
+/// `--scenario s-curve`: hold a decent forward speed and weave wide, for watching the board CARVE
 /// rather than checking one turn happens at all.
 ///
 /// [`SCHEDULE`] above is issue #161 W2's acceptance criterion and is deliberately left alone --
 /// it exercises accelerate / coast / reverse / turn once each, which is what that AC asks for and
 /// what any regression check should keep running. This one is a viewing scenario.
 ///
-/// Shape: build speed, then alternate steer around the original heading. The first and last lobes
-/// are HALF length so the weave is centred on the road rather than walking off it -- full lobes
-/// throughout would leave the board pointing 25-odd degrees off-axis at the end of every pass.
+/// Shape: build speed, then five alternating 2.6 s lobes around the original heading, entered and
+/// left on half-length lobes so the weave is centred on the road rather than walking off it.
+/// Measured result: 5 reversals, ~82 deg of heading peak-to-peak, +/-3 m of lateral excursion over
+/// ~74 m at ~5.2 m/s. The road at OB_City's spawn carries road-level surface out to roughly 8.6 m
+/// either side, so +/-3 m keeps a few feet of margin to the kerb.
 ///
-/// Sizing is measured, not guessed. `YAW_RATE_GAIN_RAD_S` is 1.5 rad/s at full steer and full
-/// authority; a live run at steer 0.6 with lateral 0.8 produced ~0.78 rad/s, i.e. `roll_authority`
-/// lands near 0.87 (well above its 0.35 floor) once the rider leans into it. At steer 0.5 that is
-/// ~0.64 rad/s, so a 0.8 s half-lobe swings ~29 deg and a 1.6 s full lobe swings ~59 deg through
-/// centre -- a weave that reads clearly on camera without leaving the carriageway.
-///
-/// The exit lobe is LONGER than the entry one (1.2 s against 0.8 s), which is not a typo. The
-/// ballast takes time to build roll, so a short lobe sees a lower `roll_authority` than the same
-/// fraction of a long one and under-turns: with entry and exit both at 0.8 s the left/right
-/// DURATIONS balanced exactly (4.0 s each) and the heading still finished +6.4 deg off, walking
-/// the board 5.8 m sideways over 50 m. Balanced time does not mean balanced yaw when the gain is
-/// state-dependent. 1.2 s over-corrected to -19.8 deg, so the null sits near 0.95 s.
-///
-/// **Do not try to tune the residual heading to zero.** This schedule is open loop and `sim-host`
-/// paces on the wall clock, missing roughly half its 500 Hz deadlines on a non-RT macOS host, so
-/// the arrival timing of these 50 Hz packets shifts run to run: two runs of the SAME schedule
-/// gave yaw extremes of (-28.2, +38.9) and (-33.7, +30.0) deg. The weave shape is repeatable; the
-/// exact end heading is not, and chasing it would be fitting noise. Expect to finish somewhere
-/// within roughly +/-15 deg of straight and drifting a few metres off the centre line.
+/// **Width comes from lobe DURATION, not from more steer.** Lateral excursion grows with the time
+/// spent holding a heading, so long gentle lobes push the board wide while keeping it pointed
+/// mostly down the road; cranking `steer` instead just aims it across the carriageway at the same
+/// offset. 2.6 s at steer 0.40 is the shape that reads as carving rather than swerving.
 ///
 /// `fore_aft` stays slightly positive (0.12) through the weave rather than zero: there is no outer
 /// velocity loop, so the board coasts rather than holding speed, and a small standing lean covers
 /// the losses without running away. Sign convention matches [`SCHEDULE`]: positive is right.
+///
+/// # The entry lobe is 1.17 s and that number is load-bearing
+///
+/// It sets where the whole oscillation is CENTRED, and the board's lateral drift follows directly
+/// from the mean heading -- ~74 m of travel at a 7 deg mean is ~9 m off line. Measured:
+///
+/// | entry lobe | mean yaw | lateral drift |
+/// |---|---|---|
+/// | 1.30 s | +7.0 deg | -10.0 m |
+/// | 1.17 s | -1.1 deg | +2.5 m |
+/// | 1.05 s | -6.9 deg | +11.8 m |
+///
+/// A quarter of a second swings the drift by twenty metres, so do not treat this as a free knob.
+///
+/// Two things that look like fixes and are not. Balancing the left/right DURATIONS exactly does
+/// not centre it -- `roll_authority` is state-dependent, so equal time does not buy equal yaw.
+/// And pre-loading roll before the first steer input (lean applied, steer still zero) makes it
+/// WORSE, not better: it hands the entry lobe more authority than the full lobes get, pushing the
+/// mean to +13 deg and the drift to -23 m. The entry lobe over-delivers; it does not under-deliver.
+///
+/// Finally: `sim-host` paces on the wall clock and misses roughly half its 500 Hz deadlines on a
+/// non-RT macOS host, so packet arrival shifts between runs. Expect a couple of metres of run-to-run
+/// variation in the final offset. Chasing the last metre is fitting noise; a genuinely
+/// drift-free weave needs closed-loop steering, which this open-loop sender deliberately is not.
 const S_CURVE_SCHEDULE: &[(f64, f64, f32, f32, f32, &str)] = &[
     (0.0, 1.0, 0.0, 0.0, 0.0, "settle"),
     (1.0, 4.0, 0.65, 0.0, 0.0, "lean forward (build speed)"),
-    (4.0, 4.8, 0.12, 0.7, 0.5, "weave right (half lobe, enter)"),
-    (4.8, 6.4, 0.12, -0.7, -0.5, "weave left"),
-    (6.4, 8.0, 0.12, 0.7, 0.5, "weave right"),
-    (8.0, 9.6, 0.12, -0.7, -0.5, "weave left"),
-    (9.6, 11.2, 0.12, 0.7, 0.5, "weave right"),
-    (11.2, 12.15, 0.12, -0.7, -0.5, "straighten (exit lobe)"),
-    (12.15, 15.0, 0.0, 0.0, 0.0, "release (coast straight)"),
+    (4.0, 5.17, 0.12, 0.7, 0.40, "weave right (half lobe, enter)"),
+    (5.17, 7.77, 0.12, -0.7, -0.40, "weave left"),
+    (7.77, 10.37, 0.12, 0.7, 0.40, "weave right"),
+    (10.37, 12.97, 0.12, -0.7, -0.40, "weave left"),
+    (12.97, 15.57, 0.12, 0.7, 0.40, "weave right"),
+    (15.57, 16.87, 0.12, -0.7, -0.40, "straighten (exit lobe)"),
+    (16.87, 19.2, 0.0, 0.0, 0.0, "release (coast straight)"),
 ];
 
 fn total_duration_s(schedule: Schedule) -> f64 {

--- a/crates/sim-host/src/bin/send-input.rs
+++ b/crates/sim-host/src/bin/send-input.rs
@@ -15,10 +15,12 @@
 //! asks for ("drives forward, slows and reverses under lean, and turns").
 //!
 //! ```text
-//! send-input [--target ADDR]
+//! send-input [--target ADDR] [--scenario default|s-curve]
 //! ```
 
 use sim_host::wire::{InputIn, INPUT_MAGIC, INPUT_SCHEMA_VERSION};
+
+type Schedule = &'static [(f64, f64, f32, f32, f32, &'static str)];
 use std::net::UdpSocket;
 use std::time::{Duration, Instant};
 
@@ -42,12 +44,58 @@ const SCHEDULE: &[(f64, f64, f32, f32, f32, &str)] = &[
     (14.0, 15.0, 0.0, 0.0, 0.0, "release"),
 ];
 
-fn total_duration_s() -> f64 {
-    SCHEDULE.iter().map(|s| s.1).fold(0.0, f64::max)
+/// `--scenario s-curve`: hold a decent forward speed and weave, for watching the board CARVE
+/// rather than checking one turn happens at all.
+///
+/// [`SCHEDULE`] above is issue #161 W2's acceptance criterion and is deliberately left alone --
+/// it exercises accelerate / coast / reverse / turn once each, which is what that AC asks for and
+/// what any regression check should keep running. This one is a viewing scenario.
+///
+/// Shape: build speed, then alternate steer around the original heading. The first and last lobes
+/// are HALF length so the weave is centred on the road rather than walking off it -- full lobes
+/// throughout would leave the board pointing 25-odd degrees off-axis at the end of every pass.
+///
+/// Sizing is measured, not guessed. `YAW_RATE_GAIN_RAD_S` is 1.5 rad/s at full steer and full
+/// authority; a live run at steer 0.6 with lateral 0.8 produced ~0.78 rad/s, i.e. `roll_authority`
+/// lands near 0.87 (well above its 0.35 floor) once the rider leans into it. At steer 0.5 that is
+/// ~0.64 rad/s, so a 0.8 s half-lobe swings ~29 deg and a 1.6 s full lobe swings ~59 deg through
+/// centre -- a weave that reads clearly on camera without leaving the carriageway.
+///
+/// The exit lobe is LONGER than the entry one (1.2 s against 0.8 s), which is not a typo. The
+/// ballast takes time to build roll, so a short lobe sees a lower `roll_authority` than the same
+/// fraction of a long one and under-turns: with entry and exit both at 0.8 s the left/right
+/// DURATIONS balanced exactly (4.0 s each) and the heading still finished +6.4 deg off, walking
+/// the board 5.8 m sideways over 50 m. Balanced time does not mean balanced yaw when the gain is
+/// state-dependent. 1.2 s over-corrected to -19.8 deg, so the null sits near 0.95 s.
+///
+/// **Do not try to tune the residual heading to zero.** This schedule is open loop and `sim-host`
+/// paces on the wall clock, missing roughly half its 500 Hz deadlines on a non-RT macOS host, so
+/// the arrival timing of these 50 Hz packets shifts run to run: two runs of the SAME schedule
+/// gave yaw extremes of (-28.2, +38.9) and (-33.7, +30.0) deg. The weave shape is repeatable; the
+/// exact end heading is not, and chasing it would be fitting noise. Expect to finish somewhere
+/// within roughly +/-15 deg of straight and drifting a few metres off the centre line.
+///
+/// `fore_aft` stays slightly positive (0.12) through the weave rather than zero: there is no outer
+/// velocity loop, so the board coasts rather than holding speed, and a small standing lean covers
+/// the losses without running away. Sign convention matches [`SCHEDULE`]: positive is right.
+const S_CURVE_SCHEDULE: &[(f64, f64, f32, f32, f32, &str)] = &[
+    (0.0, 1.0, 0.0, 0.0, 0.0, "settle"),
+    (1.0, 4.0, 0.65, 0.0, 0.0, "lean forward (build speed)"),
+    (4.0, 4.8, 0.12, 0.7, 0.5, "weave right (half lobe, enter)"),
+    (4.8, 6.4, 0.12, -0.7, -0.5, "weave left"),
+    (6.4, 8.0, 0.12, 0.7, 0.5, "weave right"),
+    (8.0, 9.6, 0.12, -0.7, -0.5, "weave left"),
+    (9.6, 11.2, 0.12, 0.7, 0.5, "weave right"),
+    (11.2, 12.15, 0.12, -0.7, -0.5, "straighten (exit lobe)"),
+    (12.15, 15.0, 0.0, 0.0, 0.0, "release (coast straight)"),
+];
+
+fn total_duration_s(schedule: Schedule) -> f64 {
+    schedule.iter().map(|s| s.1).fold(0.0, f64::max)
 }
 
-fn value_at(t: f64) -> (f32, f32, f32, &'static str) {
-    for &(t0, t1, fa, lat, steer, label) in SCHEDULE {
+fn value_at(schedule: Schedule, t: f64) -> (f32, f32, f32, &'static str) {
+    for &(t0, t1, fa, lat, steer, label) in schedule {
         if t0 <= t && t < t1 {
             return (fa, lat, steer, label);
         }
@@ -57,6 +105,8 @@ fn value_at(t: f64) -> (f32, f32, f32, &'static str) {
 
 fn main() {
     let mut target = sim_host::wire::INPUT_IN_ADDR.to_string();
+    let mut schedule: Schedule = SCHEDULE;
+    let mut schedule_name = "default";
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mut i = 0;
     while i < args.len() {
@@ -68,6 +118,27 @@ fn main() {
                 });
                 i += 2;
             }
+            "--scenario" => {
+                let v = args.get(i + 1).cloned().unwrap_or_else(|| {
+                    eprintln!("send-input: --scenario needs a value");
+                    std::process::exit(1);
+                });
+                match v.as_str() {
+                    "default" => {
+                        schedule = SCHEDULE;
+                        schedule_name = "default";
+                    }
+                    "s-curve" => {
+                        schedule = S_CURVE_SCHEDULE;
+                        schedule_name = "s-curve";
+                    }
+                    other => {
+                        eprintln!("send-input: unknown scenario '{other}' (want: default, s-curve)");
+                        std::process::exit(1);
+                    }
+                }
+                i += 2;
+            }
             other => {
                 eprintln!("send-input: unrecognized argument '{other}'");
                 std::process::exit(1);
@@ -76,8 +147,8 @@ fn main() {
     }
 
     let socket = UdpSocket::bind("127.0.0.1:0").expect("send-input: bind failed");
-    let duration = total_duration_s();
-    eprintln!("send-input: sending to {target} for {duration:.1}s per the fixed schedule");
+    let duration = total_duration_s(schedule);
+    eprintln!("send-input: sending to {target} for {duration:.1}s per the '{schedule_name}' schedule");
 
     let start = Instant::now();
     let period = Duration::from_millis(20);
@@ -89,7 +160,7 @@ fn main() {
         if t > duration {
             break;
         }
-        let (fore_aft, lateral, steer, label) = value_at(t);
+        let (fore_aft, lateral, steer, label) = value_at(schedule, t);
         if label != last_label {
             eprintln!(
                 "send-input: t={t:6.2}s -> {label} (fore_aft={fore_aft:+.2} lateral={lateral:+.2} steer={steer:+.2})"

--- a/crates/sim-host/src/bin/send-input.rs
+++ b/crates/sim-host/src/bin/send-input.rs
@@ -144,7 +144,9 @@ fn main() {
                         schedule_name = "s-curve";
                     }
                     other => {
-                        eprintln!("send-input: unknown scenario '{other}' (want: default, s-curve)");
+                        eprintln!(
+                            "send-input: unknown scenario '{other}' (want: default, s-curve)"
+                        );
                         std::process::exit(1);
                     }
                 }
@@ -159,7 +161,9 @@ fn main() {
 
     let socket = UdpSocket::bind("127.0.0.1:0").expect("send-input: bind failed");
     let duration = total_duration_s(schedule);
-    eprintln!("send-input: sending to {target} for {duration:.1}s per the '{schedule_name}' schedule");
+    eprintln!(
+        "send-input: sending to {target} for {duration:.1}s per the '{schedule_name}' schedule"
+    );
 
     let start = Instant::now();
     let period = Duration::from_millis(20);

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -756,7 +756,10 @@ mod tests {
 
     #[test]
     fn quat_mul_identity_is_identity() {
-        let q = [0.7071068, 0.0, 0.7071068, 0.0];
+        // 90 deg about +Y. Spelled with the constant rather than 0.7071068, which clippy
+        // (correctly) flags as an approximation of it.
+        const H: f32 = std::f32::consts::FRAC_1_SQRT_2;
+        let q = [H, 0.0, H, 0.0];
         let i = [1.0, 0.0, 0.0, 0.0];
         for (a, b) in quat_mul(i, q).iter().zip(q.iter()) {
             assert!((a - b).abs() < 1e-6, "identity * q != q");

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -271,6 +271,22 @@ impl From<InputIn> for LatestInput {
 /// Spawns the control loop on its own dedicated thread (issue #161: "not on
 /// the main thread") and returns the join handle. The caller decides what to
 /// do with the calling thread -- `src/bin/sim-host.rs` just joins it.
+/// Hamilton product of two `[w, x, y, z]` quaternions.
+///
+/// Order is `a` then `b` read right-to-left: the result applies `b`'s rotation first, then `a`'s.
+/// Used to compose the synthetic heading (`a`) onto MuJoCo's truth attitude (`b`) -- see the call
+/// site for why that order, and not the other one, is the correct composition.
+fn quat_mul(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
+    let [aw, ax, ay, az] = a;
+    let [bw, bx, by, bz] = b;
+    [
+        aw * bw - ax * bx - ay * by - az * bz,
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+    ]
+}
+
 pub fn spawn(cfg: HostConfig) -> std::thread::JoinHandle<Result<RunSummary, HostError>> {
     std::thread::Builder::new()
         .name("sim-host-control".into())
@@ -523,7 +539,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         truth_pos_x_m = pos_f64[0];
         truth_pos_y_m = pos_f64[1];
         let quat_f64 = backend.truth_frame_xquat();
-        let quat = [
+        // MuJoCo's own attitude: pitch and roll, and NO yaw -- this plant has no yaw degree of
+        // freedom at all. The heading is bolted on below, after `yaw_rad` is updated.
+        let quat_truth = [
             quat_f64[0] as f32,
             quat_f64[1] as f32,
             quat_f64[2] as f32,
@@ -602,6 +620,32 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // NOT amplify it for legibility; that is the renderer's job, as its
         // own declared non-physical channel, not this crate's to fake.
         let (rider_fore_aft_m, rider_lateral_m) = backend.truth_ballast_positions();
+
+        // --- SYNTHETIC HEADING, APPLIED TO ATTITUDE TOO (issue #161/#163) ------------
+        //
+        // The dead reckoning above curves the PATH along `yaw_rad`. Sending MuJoCo's raw
+        // quaternion alongside it -- which is what the first cut of this block did -- makes the
+        // board travel that curve without ever turning to face it: it crabs sideways, nose fixed,
+        // which reads as a physics bug just as loudly as the failure the comment above describes.
+        // The two are the same mismatch with opposite signs, and fixing only one of them swaps
+        // which half is wrong.
+        //
+        // So the same synthetic heading that steers the path also rotates the body. Composed
+        // HERE, in MuJoCo's frame and before the wire, so `MuJoCoToUnreal`'s handedness flip
+        // applies to it exactly as it does to the truth attitude -- the renderer keeps computing
+        // nothing (ADR-0009), and there is one heading in the system rather than two that can
+        // disagree.
+        //
+        // Yaw is about +Z, applied on the LEFT: world-frame heading first, then the board's own
+        // pitch/roll within it. Right-multiplying would apply the heading in the board's tilted
+        // local frame, so a leaning board would yaw about its own tilted axis and drift out of
+        // the ground plane. The sign is fixed by the dead reckoning it must agree with: rotating
+        // about +Z by `yaw_rad` maps (-1, 0) to (-cos, -sin), which IS (heading_x, heading_y).
+        //
+        // `quat_truth` is not discarded -- write_stats still logs the unmodified MuJoCo attitude
+        // alongside truth_pos_x_m/truth_pos_y_m, so ground truth stays available out-of-band.
+        let (yaw_sin_half, yaw_cos_half) = (yaw_rad * 0.5).sin_cos();
+        let quat = quat_mul([yaw_cos_half, 0.0, 0.0, yaw_sin_half], quat_truth);
 
         let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;
         if pitch_rad.abs() > FALLEN_PITCH_RAD {
@@ -691,4 +735,89 @@ fn write_stats(
         "ticks={ticks}\nmissed_deadlines={missed_deadlines}\ntruth_pos_x_m={truth_pos_x_m}\ntruth_pos_y_m={truth_pos_y_m}\n"
     );
     let _ = std::fs::write(&tmp, contents).and_then(|_| std::fs::rename(&tmp, path));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rotate `v` by quaternion `q` (`q v q*`).
+    fn rotate(q: [f32; 4], v: [f32; 3]) -> [f32; 3] {
+        let qv = [0.0, v[0], v[1], v[2]];
+        let qc = [q[0], -q[1], -q[2], -q[3]];
+        let r = quat_mul(quat_mul(q, qv), qc);
+        [r[1], r[2], r[3]]
+    }
+
+    fn yaw_quat(yaw_rad: f32) -> [f32; 4] {
+        let (s, c) = (yaw_rad * 0.5).sin_cos();
+        [c, 0.0, 0.0, s]
+    }
+
+    #[test]
+    fn quat_mul_identity_is_identity() {
+        let q = [0.7071068, 0.0, 0.7071068, 0.0];
+        let i = [1.0, 0.0, 0.0, 0.0];
+        for (a, b) in quat_mul(i, q).iter().zip(q.iter()) {
+            assert!((a - b).abs() < 1e-6, "identity * q != q");
+        }
+        for (a, b) in quat_mul(q, i).iter().zip(q.iter()) {
+            assert!((a - b).abs() < 1e-6, "q * identity != q");
+        }
+    }
+
+    /// THE invariant this whole fix exists for: the attitude on the wire must point the board
+    /// along the heading the position dead reckoning is steering it down. Before the fix, `quat`
+    /// was MuJoCo's raw attitude, which has no yaw at all -- so the board crabbed along a curved
+    /// path with its nose fixed. `yaw_rad` was transmitted and used by nobody.
+    ///
+    /// The board's nose is its LOCAL -X (see `overboard_onewheel.xml`: "FORWARD IS -X"), and the
+    /// dead reckoning drives it along `(-cos yaw, -sin yaw)`. Those must be the same direction.
+    #[test]
+    fn synthetic_heading_rotates_the_body_it_steers() {
+        let level = [1.0f32, 0.0, 0.0, 0.0];
+        for &yaw in &[0.0f32, 0.3, -0.7, 1.9, -2.8, 3.0] {
+            let quat = quat_mul(yaw_quat(yaw), level);
+            let nose = rotate(quat, [-1.0, 0.0, 0.0]);
+
+            // Exactly the two lines the position integrator uses.
+            let heading_x = -yaw.cos();
+            let heading_y = -yaw.sin();
+
+            assert!(
+                (nose[0] - heading_x).abs() < 1e-5 && (nose[1] - heading_y).abs() < 1e-5,
+                "yaw={yaw}: nose points ({}, {}) but the path is steered along ({heading_x}, {heading_y})",
+                nose[0],
+                nose[1]
+            );
+        }
+    }
+
+    /// The heading must be composed on the LEFT (world frame), not the right (body frame).
+    ///
+    /// With the board rolled, right-multiplying yaws it about its own tilted axis, which lifts the
+    /// nose out of the ground plane and makes the rendered heading disagree with the flat path the
+    /// dead reckoning integrates. Left-multiplying keeps the two consistent: whatever the board's
+    /// attitude, its nose still projects onto the heading the position is following.
+    #[test]
+    fn heading_is_applied_in_the_world_frame_not_the_body_frame() {
+        let roll = 0.35f32; // rolled board, as during a carve
+        let (s, c) = (roll * 0.5).sin_cos();
+        let rolled = [c, s, 0.0, 0.0]; // rotation about local X
+        let yaw = 0.9f32;
+
+        let correct = rotate(quat_mul(yaw_quat(yaw), rolled), [-1.0, 0.0, 0.0]);
+        let wrong = rotate(quat_mul(rolled, yaw_quat(yaw)), [-1.0, 0.0, 0.0]);
+
+        let (hx, hy) = (-yaw.cos(), -yaw.sin());
+        assert!(
+            (correct[0] - hx).abs() < 1e-5 && (correct[1] - hy).abs() < 1e-5,
+            "left-composed heading should match the dead-reckoned one"
+        );
+        // Guard against someone "simplifying" the order later: on a rolled board the two differ.
+        assert!(
+            (wrong[0] - hx).abs() > 1e-3 || (wrong[1] - hy).abs() > 1e-3,
+            "body-frame composition must NOT agree here, or this test proves nothing"
+        );
+    }
 }


### PR DESCRIPTION
## What changed

`yaw_rad` was dead-reckoned into `pos` and then sent alongside MuJoCo's **raw** attitude, which has no yaw in it — this plant has no yaw degree of freedom at all, as the surrounding comment says outright (*"`yaw_rad` never touches the physics"*). So the board travelled a curved path with its nose locked straight ahead: it crabbed. `yaw_rad` went out on the wire and was used by nobody for orientation.

The comment above the dead reckoning already describes the exact mirror image of this bug — *"a car spinning out, not a board carving"*. That failure was fixed by curving the path; the board was never made to spin to face it. Same mismatch, opposite sign.

The synthetic heading now rotates the body as well as steering the path. Composed in MuJoCo's frame **before** the wire, so `MuJoCoToUnreal`'s handedness flip applies to it exactly as it does to the truth attitude — the renderer still computes nothing (ADR-0009), and there is one heading in the system rather than two that can disagree.

Composed on the **left** (world frame). On a rolled board — the carve this exists for — right-multiplying would yaw it about its own tilted axis and lift the nose out of the ground plane the flat dead reckoning integrates in.

## Verification

Decoded off the live wire during a `send-input` run:

| | max abs(yaw_rad − quat_yaw) over 17 s |
|---|---|
| before | **1.679 rad** (96°) |
| after | **0.0032 rad** (0.19°) |

The residue is real pitch/roll bleeding into the Z-Y-X yaw extraction, not drift.

Three tests, one of which is the invariant whose absence let this ship: the transmitted attitude's nose direction must equal the heading the position integrator uses. A second pins the composition order by asserting the body-frame version does **not** agree on a rolled board.

## Also here

`send-input --scenario s-curve`: a sustained wide weave for watching the board carve. The existing schedule is untouched and stays the default — it is issue #161 W2's acceptance criterion.

Measured: 5 reversals, 82° heading peak-to-peak, ±3 m lateral over 74 m at 5.2 m/s.

The entry half-lobe sets where the oscillation is centred and is savagely sensitive — 1.30 s drifts 10 m one way, 1.05 s drifts 11.8 m the other. Recorded in the doc comment, along with two things that look like fixes and are not: balancing left/right durations does not centre it (`roll_authority` is state-dependent), and pre-loading roll makes it **worse** (23 m drift), because the entry lobe over-delivers rather than under-delivers.

## How this was found

From the game side — the board visibly slid sideways under a right-hand carve instead of turning. A parallel change in `overboard-game` had already started adding camera yaw lag to make turns "more discernible"; that was treating this symptom.

Companion PR in `overboard-game` fixes the chase camera, which was sitting on the nose. Neither change alone makes a carve read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)