### PR TITLE
feat(sim-host): port overrides for verification runs, to avoid colliding with a live capture

### DIFF
--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -7,6 +7,7 @@
 //!
 //! ```text
 //! sim-host [--duration-secs SECONDS] [--startup-kick]
+//!          [--state-out-addr ADDR] [--input-in-addr ADDR]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
 //! it, stops after that many seconds and exits -- used for verification runs
@@ -16,8 +17,17 @@
 //! shove the board before a player has touched anything. Pass it explicitly
 //! for a `wire-probe` diagnostic run that wants a guaranteed disturbance to
 //! show recovery from.
+//!
+//! `--state-out-addr`/`--input-in-addr` override the documented
+//! `127.0.0.1:9601`/`:9602` (still the default -- Unreal always talks to
+//! those). Exists so a verification run can avoid the standard ports
+//! entirely rather than colliding with a live capture session already
+//! bound to them -- learned the hard way (issue #161 follow-up) when a
+//! verification `sim-host` ran its full course straight into a live
+//! `UnrealEditor` capture that was already listening on 9601.
 
 use sim_host::HostConfig;
+use std::net::SocketAddr;
 use std::process::ExitCode;
 use std::time::Duration;
 
@@ -43,6 +53,30 @@ fn main() -> ExitCode {
             "--startup-kick" => {
                 cfg.startup_kick = true;
                 i += 1;
+            }
+            "--state-out-addr" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --state-out-addr needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(addr) = v.parse::<SocketAddr>() else {
+                    eprintln!("sim-host: --state-out-addr value '{v}' is not an address");
+                    return ExitCode::FAILURE;
+                };
+                cfg.state_out_addr = addr;
+                i += 2;
+            }
+            "--input-in-addr" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --input-in-addr needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(addr) = v.parse::<SocketAddr>() else {
+                    eprintln!("sim-host: --input-in-addr value '{v}' is not an address");
+                    return ExitCode::FAILURE;
+                };
+                cfg.input_in_addr = addr;
+                i += 2;
             }
             other => {
                 eprintln!("sim-host: unrecognized argument '{other}'");


### PR DESCRIPTION
## Summary

Issue #161 follow-up (CEO request via the COO: a `send-input --scenario s-curve`
for the launch capture). While verifying my own first pass at that scenario, a
`sim-host` verification run bound the standard ports and ran its full course
straight into a **live `UnrealEditor` capture session already listening on
9601** (confirmed with `lsof -nP -iUDP:9601` mid-run: `UnrealEditor ... UDP
127.0.0.1:9601`). That means a scripted test run's traffic was live on the same
socket a real City Park capture was reading from during that window.

PR #176 (`ops/capture-game.sh`, merged concurrently) independently confirms
this is exactly how the capture pipeline's readiness detection works: it binds
9601 itself and treats `EADDRINUSE` as "the game is up". So a `sim-host`
verification run on the standard ports is fundamentally incompatible with the
capture loop being active at the same time -- not a one-off mistake.

## This PR: a way to avoid it, not a scenario

`sim-host`'s own `HostConfig` already carries `state_out_addr`/`input_in_addr`
as plain, already-general fields -- only the **binary's** CLI parsing had no
way to override the hardcoded `127.0.0.1:9601`/`:9602` defaults. Adds:

```
sim-host --state-out-addr ADDR --input-in-addr ADDR
```

so a verification run can point at throwaway ports (e.g. `19601`/`19602`) and
never risk colliding with a live capture again. **Defaults unchanged** --
Unreal always talks to the documented standard ports either way; this only
matters for `sim-host`/`wire-probe`/`send-input` verification tooling
(`wire-probe --bind` and `send-input --target` already supported this).

## Scope note -- what this PR deliberately does NOT include

**No `--scenario s-curve` for `send-input`.** I built one (spool-up then
coast to fix a runaway-acceleration bug I found -- sustained lean has no
speed ceiling on this plant, since there is no outer velocity loop), but
**PR #175 landed the same feature, on the same file, while this branch was in
flight** -- with materially more rigorous tuning than a first pass here would
have matched: measured lobe timing, an entry/exit lobe asymmetry finding
(0.8s balanced-duration lobes finished 6.4 deg off and walked the board 5.8m
sideways; 0.95s entry lobe fixed it), and a real quat/yaw rendering bug fix
(`ABoardActor` reads only `pos`/`quat`, and `quat` had no yaw in it at all --
the board dead-reckoned a curved path while its nose stayed locked straight
ahead) that a scenario alone can't demonstrate correctly without.

Landing a second, conflicting `s-curve` implementation on the same file would
have been pure duplication of already-shipped, already-measured work. This PR
is scoped down to the one piece PR #175 does not already cover: making
verification tooling safe to run *alongside* an active capture session,
which is exactly the situation that produced the collision in the first
place.

(For what it's worth, my own measurement of the collision-causing run
independently found the same class of issue PR #175's commit message
describes -- a sustained yaw bias that does not cancel over a full weave
cycle -- before I saw that PR had already landed a fix. Not claiming credit;
just noting the two investigations agree.)

## Test plan
- [x] `cargo build --workspace --all-targets` clean (`-j 2` throughout per
      the machine-memory note)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (this file has no unit tests -- CLI
      parsing only; the workspace's higher test count reflects PR #175's own
      new tests, not a regression here)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>