### PR TITLE
ops(pi): fire the D3 spike, automate the no-Pi kernel checks, and land the flash/credential path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,19 @@ jobs:
             assert d['ac5']['verdict'] is None, 'a non-RT runner must not return a verdict'; \
             print('harness ok:', d['platform'])"
 
+      # I4 (issue #182): no credential may enter a public repository. Runs in
+      # THIS workflow rather than pi-image.yml because that one is
+      # `paths:`-filtered to scripts/pi/, and a Wi-Fi passphrase or a private
+      # key can be committed by any change at all -- most likely by one that
+      # has nothing to do with the Pi.
+      #
+      # Seconds, no network. Deliberately narrow rather than an entropy
+      # scanner: Cargo.lock alone carries hundreds of 64-hex SHA256s, and a
+      # check that cries wolf earns an allowlist, then `|| true`, then
+      # nothing. See the script's header for the full argument.
+      - name: Secret guard - no credential in a public repo
+        run: python3 scripts/pi/check_no_secrets.py
+
       # ICD §6.3 / DR-MODE-1: board-app-ridden must have zero motion
       # authority, proven by the dependency graph rather than asserted by a
       # reviewer. canary-ridden is the positive control -- the gate has to

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -37,6 +37,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # NOTE: the I4 credential guard deliberately does NOT live here. It must run
+  # on every pull request -- a credential can be committed by any change, not
+  # only by one touching scripts/pi/ -- and this workflow is `paths:`-filtered.
+  # It runs in ci.yml instead.
+
   # -------------------------------------------------------------------------
   # AC-1. Cheap, fast, and the single highest-value no-Pi check in the design:
   # this is the shape of check that caught the `rpi-2712-rt` assumption before

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -101,14 +101,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # NOT `continue-on-error`. Run 1 had it, and the job reported GREEN while
-      # the script inside it printed "SPIKE RESULT: RED" -- a check saying the
-      # opposite of what happened, which is the one thing a check must never
-      # do. Nothing in this workflow is a required status check, so an honest
-      # red here blocks nothing and misleads nobody.
+      # The job must report what the script reported. TWICE now it has not:
+      #
+      #   run 1: `continue-on-error: true` -- job green, script printed RED.
+      #   run 2: continue-on-error removed, job STILL green, because
+      #          `docker ... | tee` returns TEE's exit status, and Actions
+      #          runs steps under `bash -e`, not `-o pipefail`. The docker
+      #          failure was discarded by the pipe.
+      #
+      # `set -o pipefail` is the actual fix. A check that reports the opposite
+      # of what happened is worse than no check, and this one managed it two
+      # different ways -- worth the explicit shell rather than a third guess.
       - name: Build rpi-image-gen's stock config in our CI shape
         id: spike
+        shell: bash
         run: |
+          set -o pipefail
           docker run --privileged --rm \
             -v "$PWD:/work" -w /work \
             debian:trixie \

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -101,9 +101,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # NOT `continue-on-error`. Run 1 had it, and the job reported GREEN while
+      # the script inside it printed "SPIKE RESULT: RED" -- a check saying the
+      # opposite of what happened, which is the one thing a check must never
+      # do. Nothing in this workflow is a required status check, so an honest
+      # red here blocks nothing and misleads nobody.
       - name: Build rpi-image-gen's stock config in our CI shape
         id: spike
-        continue-on-error: true
         run: |
           docker run --privileged --rm \
             -v "$PWD:/work" -w /work \

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -1,0 +1,142 @@
+name: pi-image
+
+# Stage-0B image pipeline (issue #182). Its own workflow file, not jobs bolted
+# into ci.yml, for the reason ci.yml's own header gives when it explains why
+# the policy job moved out: the job's owner owns its file. It also keeps a
+# slow arm64 image job off the critical path of every Rust PR.
+#
+# NONE of these are required status checks, and that is deliberate:
+#
+#   - `spike` is an EXPERIMENT. Its red is a finding (take the fallback), not
+#     a broken build, and an experiment must never be able to block a merge.
+#   - the verify jobs reach the LIVE Raspberry Pi archive, which has no
+#     snapshot service. A mirror outage would otherwise wedge every PR in the
+#     repo on a network condition nobody in this project controls.
+#
+# `paths:` filtering is safe HERE where it was not safe in ci.yml. That file
+# cannot use it because a SKIPPED required check never reports and branch
+# protection waits on it forever. Nothing here is required, so skipping is
+# just skipping.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/pi/**'
+      - '.github/workflows/pi-image.yml'
+  pull_request:
+    paths:
+      - 'scripts/pi/**'
+      - '.github/workflows/pi-image.yml'
+  # The spike is expected to need several attempts before its entrypoint guess
+  # is right, and I1 will want rebuilds that no commit triggered.
+  workflow_dispatch:
+
+concurrency:
+  group: pi-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------------
+  # AC-1. Cheap, fast, and the single highest-value no-Pi check in the design:
+  # this is the shape of check that caught the `rpi-2712-rt` assumption before
+  # it became a pin.
+  # -------------------------------------------------------------------------
+  verify-pins:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    container:
+      image: debian:trixie
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add the Raspberry Pi archive
+        run: bash scripts/pi/add_rpi_archive.sh
+
+      - name: Every pin resolves to the exact version named
+        run: bash scripts/pi/verify_pins.sh
+
+  # -------------------------------------------------------------------------
+  # AC-2 evidence. Automates what the verification log did by hand on
+  # 2026-07-27 -- the design says in as many words that this is what the
+  # implementation must automate.
+  #
+  # Separate job from verify-pins, not a step in it: this one downloads ~100 MB
+  # and the other takes seconds. Folded together, a slow kernel download would
+  # hide behind a fast pin check and nobody would notice it doubling.
+  # -------------------------------------------------------------------------
+  verify-kernel:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    container:
+      image: debian:trixie
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add the Raspberry Pi archive
+        run: bash scripts/pi/add_rpi_archive.sh
+
+      - name: The pinned kernel ships what the design assumes
+        run: bash scripts/pi/verify_kernel.sh
+
+  # -------------------------------------------------------------------------
+  # I0 -- the D3 spike. Gates the builder choice for everything after it.
+  #
+  # Native arm64, no QEMU: `ubuntu-24.04-arm` hosted runners are GA and free
+  # for public repositories, which is what made rpi-image-gen's arm64-host
+  # requirement affordable at all. `--privileged` supplies the CAP_SYS_ADMIN
+  # the tool needs; hosted runners are full VMs, so loop devices work.
+  # -------------------------------------------------------------------------
+  spike:
+    runs-on: ubuntu-24.04-arm
+    # Design section 3 timeboxes this at half a day of ENGINEER time. 60
+    # minutes of runner time is the CI translation: long enough for a full
+    # image build, short enough that a hung job is not discovered tomorrow.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build rpi-image-gen's stock config in our CI shape
+        id: spike
+        continue-on-error: true
+        run: |
+          docker run --privileged --rm \
+            -v "$PWD:/work" -w /work \
+            debian:trixie \
+            bash scripts/pi/spike_rpi_image_gen.sh 2>&1 | tee /tmp/spike.log
+
+      # Runs whether the spike passed or failed -- the log IS the deliverable,
+      # and a red experiment whose output nobody can read has cost the time
+      # and bought nothing.
+      - name: Publish the spike log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spike-log-${{ github.run_id }}
+          path: /tmp/spike.log
+          retention-days: 30
+
+      - name: Summarise the result
+        if: always()
+        run: |
+          {
+            echo "## I0 — rpi-image-gen spike"
+            echo
+            if [ "${{ steps.spike.outcome }}" = "success" ]; then
+              echo "**GREEN** — rpi-image-gen produced an image in a privileged"
+              echo "\`debian:trixie\` container on \`ubuntu-24.04-arm\`."
+              echo "Design §3's primary choice stands. Proceed to I1."
+            else
+              echo "**RED** — no image produced."
+              echo
+              echo "This is a finding, not a broken build. Before concluding anything,"
+              echo "read the log: if the entrypoint guess was wrong that is not evidence"
+              echo "against the tool, it is a one-line fix. Only a genuine"
+              echo "cannot-build-in-a-container result triggers the fallback —"
+              echo "**derive-from-stock** (reference doc §2), explicitly *not* \`pi-gen\`."
+            fi
+            echo
+            echo '```'
+            tail -60 /tmp/spike.log 2>/dev/null || echo "<no log captured>"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,14 @@ __pycache__/
 # Local plan-meter observations. Machine- and plan-specific, and a fabricated
 # value here would be silently trusted as a real reading. Never commit one.
 ops/usage-calibration.json
+
+# Pi credentials (issue #182, I4). The REAL secrets file lives outside the
+# repository at ~/.overboard/pi-secrets.env -- a file that was never in the
+# working tree cannot be committed by accident. These entries cover the
+# staging output of scripts/pi/mk_boot_config.py, which IS written inside a
+# temp dir that could be pointed here by mistake.
+# scripts/pi/check_no_secrets.py asserts these lines are present.
+pi-secrets.env
+*.nmconnection
+overboard-authorized_keys
+overboard-userconf

--- a/scripts/pi/add_rpi_archive.sh
+++ b/scripts/pi/add_rpi_archive.sh
@@ -17,6 +17,60 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/pins.env"
 
 KEYRING="/usr/share/keyrings/raspberrypi-archive.gpg"
+export DEBIAN_FRONTEND=noninteractive
+
+# ---------------------------------------------------------------------------
+# FINDING, 2026-08-02: Debian Trixie will not verify the Raspberry Pi archive.
+#
+# Trixie replaced apt's OpenPGP verifier with Sequoia's `sqv`, which enforces a
+# crypto policy rejecting SHA-1 as of 2026-02-01. The Raspberry Pi archive key
+# (CF8A1AF502A2AA2D763BAE7E82B129927FA3303E) carries a SHA-1 self-certification,
+# so `sqv` refuses to bind the signing subkey and apt reports:
+#
+#     E: The repository '.../debian trixie InRelease' is not signed.
+#
+# This is not our bug and not a flaky network. It blocks EVERY Trixie-hosted
+# build against archive.raspberrypi.com, which is the exact shape design
+# section 3 chose, so it is on the critical path for I0/I1 (issue #182).
+#
+# WHAT THIS DOES, AND THE LINE IT DOES NOT CROSS
+#
+# It relaxes the HASH POLICY so a SHA-1 binding signature is accepted. It does
+# NOT disable verification. Every package is still cryptographically verified
+# against the pinned key fetched over TLS from the Pi archive.
+#
+# The tempting one-line "fix" is `[trusted=yes]` on the sources line, and that
+# is categorically different: it turns signature checking OFF, so anything
+# reaching the mirror or the connection lands on the card unchallenged. For an
+# RT kernel that will command a motor, that is not a trade worth making to
+# save a config file. If this exception ever stops working, the answer is to
+# escalate -- never to reach for trusted=yes.
+#
+# NARROW, AND WITH AN EXPIRY CONDITION: revisit when Raspberry Pi re-sign the
+# key with SHA-256. Then delete this block and let the default policy stand.
+# Tracked on issue #182.
+# ---------------------------------------------------------------------------
+relax_sha1_policy() {
+  # Written to sqv's DEFAULT system path, not just exported. Each `run:` step
+  # in a GitHub job is a separate shell, so a SEQUOIA_CRYPTO_POLICY exported
+  # here would vanish before verify_pins.sh runs in the next step -- and the
+  # symptom would be this script reporting success followed by an
+  # inexplicable "not signed" one step later.
+  local policy=/etc/crypto-policies/back-ends/sequoia.config
+  mkdir -p "$(dirname "$policy")"
+  cat > "$policy" <<'POLICY'
+# Overboard: accept SHA-1 binding signatures so apt can verify the Raspberry
+# Pi archive on Debian Trixie. Signature verification stays ON -- only the
+# hash policy is relaxed. See scripts/pi/add_rpi_archive.sh for why.
+[hash_algorithms]
+sha1.collision_resistance = "always"
+sha1.second_preimage_resistance = "always"
+POLICY
+  export SEQUOIA_CRYPTO_POLICY="$policy"
+  # Carry it to later steps too, belt and braces, when running under Actions.
+  [ -n "${GITHUB_ENV:-}" ] && echo "SEQUOIA_CRYPTO_POLICY=$policy" >> "$GITHUB_ENV"
+  echo "sequoia crypto policy relaxed for SHA-1 binding signatures (verification still enforced)"
+}
 
 apt-get update -qq
 apt-get install -y --no-install-recommends curl ca-certificates gnupg >/dev/null
@@ -27,6 +81,23 @@ curl -fsSL "https://archive.raspberrypi.com/debian/raspberrypi.gpg.key" \
 echo "deb [signed-by=$KEYRING arch=$DEBIAN_ARCH] $RPI_ARCHIVE_URL $RPI_ARCHIVE_SUITE $RPI_ARCHIVE_COMPONENT" \
   > /etc/apt/sources.list.d/raspberrypi.list
 
-apt-get update -qq
+# Try the distribution's own policy first, and only relax if it actually
+# rejects the archive. If Raspberry Pi re-sign the key with SHA-256, this
+# quietly stops relaxing anything and the workaround retires itself instead
+# of lingering as a permanent weakening nobody rechecks.
+if apt-get update -qq 2>/tmp/apt-update.err; then
+  echo "archive verified under the distribution's default crypto policy"
+else
+  if grep -qi "not signed\|signature verification failed" /tmp/apt-update.err; then
+    echo "--- default policy rejected the archive:"
+    sed 's/^/    /' /tmp/apt-update.err
+    relax_sha1_policy
+    apt-get update -qq
+  else
+    echo "apt-get update failed for a reason unrelated to signing:" >&2
+    cat /tmp/apt-update.err >&2
+    exit 1
+  fi
+fi
 
 echo "raspberrypi archive added: $RPI_ARCHIVE_URL $RPI_ARCHIVE_SUITE $RPI_ARCHIVE_COMPONENT ($DEBIAN_ARCH)"

--- a/scripts/pi/add_rpi_archive.sh
+++ b/scripts/pi/add_rpi_archive.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Add the Raspberry Pi archive to a Debian container's apt sources.
+#
+# Shared by every job that needs to resolve a Pi package, so the archive is
+# configured exactly one way. Both verification jobs and the image build read
+# from the same place; three copies of this would drift, and a drifted
+# ARCHIVE URL is a pin that verifies against a different mirror than the one
+# the card is built from.
+#
+# `signed-by` rather than the deprecated apt-key: a key in trusted.gpg.d is
+# trusted for EVERY source, so a compromised Pi mirror could sign a Debian
+# package. Scoping the key to its own source is the whole point.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=pins.env
+source "$HERE/pins.env"
+
+KEYRING="/usr/share/keyrings/raspberrypi-archive.gpg"
+
+apt-get update -qq
+apt-get install -y --no-install-recommends curl ca-certificates gnupg >/dev/null
+
+curl -fsSL "https://archive.raspberrypi.com/debian/raspberrypi.gpg.key" \
+  | gpg --dearmor -o "$KEYRING"
+
+echo "deb [signed-by=$KEYRING arch=$DEBIAN_ARCH] $RPI_ARCHIVE_URL $RPI_ARCHIVE_SUITE $RPI_ARCHIVE_COMPONENT" \
+  > /etc/apt/sources.list.d/raspberrypi.list
+
+apt-get update -qq
+
+echo "raspberrypi archive added: $RPI_ARCHIVE_URL $RPI_ARCHIVE_SUITE $RPI_ARCHIVE_COMPONENT ($DEBIAN_ARCH)"

--- a/scripts/pi/check_no_secrets.py
+++ b/scripts/pi/check_no_secrets.py
@@ -80,14 +80,38 @@ CONTENT_RULES: list[tuple[str, re.Pattern[str], str]] = [
     ),
     (
         "wpa psk",
-        # A populated NetworkManager psk= field. The 8+ length bound keeps it
-        # off `psk=` in a template and off `psk={net["psk"]}` in a generator.
-        re.compile(r"^\s*psk\s*=\s*(?![\"'{$<])\S{8,}", re.M),
+        # A populated NetworkManager psk= field, in the keyfile form it
+        # actually takes: one literal value, alone, to end of line.
+        #
+        # Same tightening as the passphrase rule below and for the same
+        # reason -- the loose version matched `psk = wpa_psk(ssid,
+        # passphrase)`, which is a function call, not a key. Requiring the
+        # value to end the line and to contain only literal characters
+        # excludes every call and subscript expression without needing to
+        # know anything about the language it appears in.
+        re.compile(
+            r"""^[ \t]*psk[ \t]*=[ \t]*["']?([A-Za-z0-9._@#$%^&*+/!-]{8,})["']?[ \t]*$""",
+            re.M,
+        ),
         "a populated NetworkManager psk= field",
     ),
     (
         "wpa passphrase",
-        re.compile(r"^\s*(?:wpa_)?(?:passphrase|WIFI_\d+_PASSPHRASE)\s*=\s*(\S+)", re.M | re.I),
+        # Anchored to end of line, and the value may only contain characters a
+        # passphrase LITERAL contains -- no parentheses, commas, braces or
+        # dots-with-calls.
+        #
+        # The loose version of this (`=\s*(\S+)`) flagged
+        # `passphrase = secrets.get(f"WIFI_{i}_PASSPHRASE", "")` in this
+        # project's own generator: ordinary Python, no credential. That is
+        # precisely the false positive this whole module is built to avoid,
+        # and it came from the pattern reading an ASSIGNMENT rather than a
+        # config VALUE. 8 is the WPA minimum passphrase length.
+        re.compile(
+            r"""^[ \t]*(?:wpa_)?(?:passphrase|WIFI_\d+_PASSPHRASE)[ \t]*=[ \t]*"""
+            r"""["']?([A-Za-z0-9._@#$%^&*+/!-]{8,})["']?[ \t]*$""",
+            re.M | re.I,
+        ),
         "a filled-in Wi-Fi passphrase",
     ),
 ]

--- a/scripts/pi/check_no_secrets.py
+++ b/scripts/pi/check_no_secrets.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Fail the build if a credential ever enters the repository.
+
+Both repositories are public and the Pi image is published to a public
+release. "We will be careful" is not a control when the cost of one slip is a
+home Wi-Fi passphrase in a public git history that cannot be rewritten out of
+every clone.
+
+Why this does NOT scan for high-entropy strings
+-----------------------------------------------
+The obvious implementation -- flag any 64-hex or high-entropy blob -- is the
+wrong one here, and it is worth saying why so nobody "improves" it back.
+
+``Cargo.lock`` is full of 64-hex SHA256 checksums. So is any lockfile, and so
+are the kernel checksums this project deliberately records in
+``scripts/pi/verify_kernel.sh``'s log. A generic entropy scanner fires on all
+of them, every run. A check that cries wolf gets an allowlist, then a bigger
+allowlist, then ``|| true``, and this repository has already written down what
+that costs: "a routine override is a check that has stopped meaning anything"
+(``.github/workflows/ci.yml``).
+
+So this looks for the specific shapes a real leak takes -- a private key
+header, a populated PSK field, a filled-in passphrase variable, a file that
+should never have been added -- and stays quiet otherwise. Narrow and trusted
+beats broad and ignored.
+
+Runs over tracked files only (``git ls-files``): the working tree may contain
+build output, a virtualenv, or the operator's own scratch files, and none of
+those can reach the public history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Files that must never be tracked, matched on basename or glob.
+FORBIDDEN_NAMES = [
+    "pi-secrets.env",
+    "*.nmconnection",
+    "overboard-authorized_keys",
+    "overboard-userconf",
+    "authorized_keys",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "*.pem",
+    "*.p12",
+    "*.pfx",
+    "wpa_supplicant.conf",
+    "custom.toml",
+    "firstrun.sh",
+]
+
+# .gitignore must carry these, so the accident is prevented as well as
+# detected. Detection alone means the leak already happened locally and is one
+# `git push` from being permanent.
+REQUIRED_GITIGNORE = [
+    "pi-secrets.env",
+    "*.nmconnection",
+    "overboard-authorized_keys",
+    "overboard-userconf",
+]
+
+# Placeholder values the example file is allowed to contain. Anything else in
+# a passphrase field is treated as real.
+PLACEHOLDER = re.compile(
+    r"^(|your-[a-z0-9-]*|<[^>]*>|xxx+|changeme|placeholder|example|\.\.\.)$", re.I
+)
+
+CONTENT_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "private key",
+        re.compile(r"-----BEGIN (RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY-----"),
+        "a private key block",
+    ),
+    (
+        "wpa psk",
+        # A populated NetworkManager psk= field. The 8+ length bound keeps it
+        # off `psk=` in a template and off `psk={net["psk"]}` in a generator.
+        re.compile(r"^\s*psk\s*=\s*(?![\"'{$<])\S{8,}", re.M),
+        "a populated NetworkManager psk= field",
+    ),
+    (
+        "wpa passphrase",
+        re.compile(r"^\s*(?:wpa_)?(?:passphrase|WIFI_\d+_PASSPHRASE)\s*=\s*(\S+)", re.M | re.I),
+        "a filled-in Wi-Fi passphrase",
+    ),
+]
+
+# This file names every pattern it hunts for, and the example file exists to
+# show the shape of a secrets file. Both would otherwise flag themselves.
+SELF_EXEMPT = {
+    "scripts/pi/check_no_secrets.py",
+    "scripts/pi/pi-secrets.example.env",
+    "tests/test_check_no_secrets.py",
+}
+
+
+def tracked_files(root: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def check_names(paths: list[str]) -> list[str]:
+    problems = []
+    for rel in paths:
+        name = Path(rel).name
+        for pattern in FORBIDDEN_NAMES:
+            if Path(name).match(pattern):
+                problems.append(
+                    f"{rel}: filename matches '{pattern}' and must never be tracked"
+                )
+                break
+    return problems
+
+
+def check_content(root: Path, paths: list[str]) -> list[str]:
+    problems = []
+    for rel in paths:
+        if rel in SELF_EXEMPT:
+            continue
+        p = root / rel
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            # Binaries and unreadable files: nothing to match, and guessing an
+            # encoding to scan them would only invent findings.
+            continue
+        for label, pattern, description in CONTENT_RULES:
+            for m in pattern.finditer(text):
+                captured = m.group(1) if m.groups() else ""
+                if captured and PLACEHOLDER.match(captured.strip("\"'")):
+                    continue
+                line = text[: m.start()].count("\n") + 1
+                problems.append(f"{rel}:{line}: {description} ({label})")
+    return problems
+
+
+def check_gitignore(root: Path) -> list[str]:
+    gi = root / ".gitignore"
+    if not gi.exists():
+        return ["no .gitignore at the repository root"]
+    body = gi.read_text()
+    return [
+        f".gitignore does not cover '{entry}'"
+        for entry in REQUIRED_GITIGNORE
+        if entry not in body
+    ]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    args = ap.parse_args()
+
+    paths = tracked_files(args.root)
+    problems = (
+        check_names(paths)
+        + check_content(args.root, paths)
+        + check_gitignore(args.root)
+    )
+
+    if problems:
+        print("SECRET GUARD FAILED\n")
+        for p in problems:
+            print(f"  {p}")
+        print(
+            "\nDo not 'fix' this by editing the pattern list. If a credential is"
+            "\nin a commit, it is in the history: rotate it, then remove it."
+            "\nThis repository is public and the image is published publicly."
+        )
+        return 1
+
+    print(f"secret guard: {len(paths)} tracked files clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi/firstboot_install.sh
+++ b/scripts/pi/firstboot_install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Runs ON THE PI, once, at first boot. Shipped inside the image (I1).
+#
+# Moves the credentials the flash script staged on the FAT32 boot partition
+# into their real homes on the ext4 rootfs, then deletes them from the boot
+# partition -- because FAT32 has no permissions, so anything left there is
+# world-readable to any machine that sees the card.
+#
+# WHY THIS EXISTS RATHER THAN RASPBERRY PI IMAGER'S MECHANISM
+#
+# Imager hooks a `firstrun.sh` from `cmdline.txt` and has that script edit
+# `cmdline.txt` back out again at the end -- a boot-critical file being
+# rewritten by a script running during that same boot, where an interrupted
+# first boot can leave a card that does not boot at all. We build the image,
+# so we can do better: a plain systemd oneshot that reads a directory.
+# `cmdline.txt` is never touched.
+#
+# Idempotent, because "ran but the network came up too late to matter" is a
+# real first-boot outcome and re-running must be safe.
+set -euo pipefail
+
+BOOT="${BOOT_DIR:-/boot/firmware}"
+NET_SRC="$BOOT/overboard-net.d"
+NM_DIR="/etc/NetworkManager/system-connections"
+USERCONF="$BOOT/overboard-userconf"
+AUTHKEYS="$BOOT/overboard-authorized_keys"
+
+log() { echo "overboard-firstboot: $*"; }
+
+# Nothing staged is the normal state on every boot after the first.
+if [ ! -d "$NET_SRC" ] && [ ! -f "$USERCONF" ]; then
+  log "no staged configuration - nothing to do"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+username=""
+if [ -f "$USERCONF" ]; then
+  # Parsed, not sourced: this file came off a FAT32 partition that anyone
+  # could have written to. Executing it would hand that person root on first
+  # boot, which is a strange way to configure a hostname.
+  while IFS='=' read -r key value; do
+    case "$key" in
+      hostname)         hostname="$value" ;;
+      username)         username="$value" ;;
+      wifi_country)     wifi_country="$value" ;;
+      ssh_password_auth) ssh_password_auth="$value" ;;
+      password_hash)    password_hash="$value" ;;
+    esac
+  done < "$USERCONF"
+
+  if [ -n "${hostname:-}" ]; then
+    log "hostname -> $hostname"
+    hostnamectl set-hostname "$hostname" || log "WARNING: could not set hostname"
+    sed -i "s/^127.0.1.1.*/127.0.1.1\t$hostname/" /etc/hosts || true
+  fi
+
+  if [ -n "$username" ] && ! id -u "$username" >/dev/null 2>&1; then
+    log "creating user $username"
+    useradd -m -s /bin/bash -G sudo,dialout,gpio,i2c,spi,netdev "$username" \
+      || useradd -m -s /bin/bash -G sudo,dialout "$username"
+    if [ -n "${password_hash:-}" ]; then
+      usermod -p "$password_hash" "$username"
+    else
+      # Locked, not blank. A blank password on an account in the sudo group
+      # is a different and much worse thing than no password login.
+      passwd -l "$username" >/dev/null
+    fi
+  fi
+
+  if [ -n "${wifi_country:-}" ]; then
+    log "regulatory domain -> $wifi_country"
+    raspi-config nonint do_wifi_country "$wifi_country" 2>/dev/null \
+      || iw reg set "$wifi_country" 2>/dev/null \
+      || log "WARNING: could not set regulatory domain; 5 GHz may be unavailable"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# SSH
+# ---------------------------------------------------------------------------
+if [ -f "$AUTHKEYS" ] && [ -n "$username" ]; then
+  home="$(getent passwd "$username" | cut -d: -f6)"
+  install -d -m 0700 -o "$username" -g "$username" "$home/.ssh"
+  install -m 0600 -o "$username" -g "$username" "$AUTHKEYS" "$home/.ssh/authorized_keys"
+  log "installed authorized_keys for $username"
+fi
+
+if [ "${ssh_password_auth:-false}" = "false" ]; then
+  install -d -m 0755 /etc/ssh/sshd_config.d
+  printf 'PasswordAuthentication no\nChallengeResponseAuthentication no\n' \
+    > /etc/ssh/sshd_config.d/10-overboard.conf
+  log "SSH password authentication disabled (key-only)"
+fi
+systemctl enable --now ssh >/dev/null 2>&1 || log "WARNING: could not enable ssh"
+
+# ---------------------------------------------------------------------------
+# Wi-Fi
+# ---------------------------------------------------------------------------
+if [ -d "$NET_SRC" ]; then
+  install -d -m 0700 "$NM_DIR"
+  count=0
+  for f in "$NET_SRC"/*.nmconnection; do
+    [ -e "$f" ] || continue
+    # 0600 or NetworkManager refuses to load the profile -- and says so only
+    # in its own log, which is a miserable thing to debug on a headless board.
+    install -m 0600 -o root -g root "$f" "$NM_DIR/$(basename "$f")"
+    count=$((count + 1))
+  done
+  log "installed $count wifi profile(s)"
+  nmcli connection reload 2>/dev/null || systemctl reload NetworkManager 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
+# Shred the staged copies.
+#
+# FAT32 carries no permissions, so until this runs the PSKs are readable by
+# anything that can see the card. `shred` is best-effort here and worth saying
+# so honestly: on a wear-levelling SD controller, overwriting a logical block
+# does not reliably overwrite the physical one. It raises the cost of casual
+# recovery; it is not an erasure guarantee.
+# ---------------------------------------------------------------------------
+if [ -d "$NET_SRC" ]; then
+  find "$NET_SRC" -type f -exec shred -u {} \; 2>/dev/null || rm -f "$NET_SRC"/*
+  rmdir "$NET_SRC" 2>/dev/null || true
+fi
+[ -f "$AUTHKEYS" ] && { shred -u "$AUTHKEYS" 2>/dev/null || rm -f "$AUTHKEYS"; }
+[ -f "$USERCONF" ] && { shred -u "$USERCONF" 2>/dev/null || rm -f "$USERCONF"; }
+
+log "complete - staged credentials removed from $BOOT"

--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Flash an Overboard image to an SD card and stage credentials onto it.
+#
+#     scripts/pi/flash_pi.sh --disk /dev/disk4                 # newest release
+#     scripts/pi/flash_pi.sh --disk /dev/disk4 --image ./x.img.xz
+#     scripts/pi/flash_pi.sh --disk /dev/disk4 --dry-run       # rehearse
+#
+# THIS WRITES TO A RAW BLOCK DEVICE. The classic way to lose a laptop's
+# internal disk is a mistyped device path in exactly this kind of script, so
+# there are three independent guards and none of them can be skipped with a
+# flag:
+#
+#   1. The target must be removable/external. An internal disk is refused
+#      outright -- there is no --force, because the only reason to want one
+#      here is a mistake.
+#   2. The device identifier must be typed back at a prompt. Not y/N: a habit
+#      of pressing y is exactly what defeats a y/N prompt.
+#   3. --dry-run performs every check and every mount, and skips only the
+#      write, so the rehearsal exercises the same code path as the real thing.
+#
+# Credentials are read from ~/.overboard/pi-secrets.env, which lives OUTSIDE
+# this repository and is never read by CI or by an agent. See
+# scripts/pi/pi-secrets.example.env.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+
+IMAGE_RELEASE="pi-image-latest"
+SECRETS="${OVERBOARD_PI_SECRETS:-$HOME/.overboard/pi-secrets.env}"
+DISK=""
+IMAGE=""
+DRY_RUN=0
+
+die() { echo "error: $*" >&2; exit 1; }
+say() { echo "==> $*"; }
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --disk)    DISK="${2:-}"; shift 2 ;;
+    --image)   IMAGE="${2:-}"; shift 2 ;;
+    --release) IMAGE_RELEASE="${2:-}"; shift 2 ;;
+    --secrets) SECRETS="${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) die "unrecognized argument '$1' (try --help)" ;;
+  esac
+done
+
+[ -n "$DISK" ] || die "--disk is required. There is no default: a default target
+       for a raw write is a loaded gun. Find yours with:
+         macOS:  diskutil list external
+         Linux:  lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT"
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin|Linux) ;;
+  *) die "unsupported platform: $OS" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Guard 1: the target must be removable. Refused, not warned about.
+# ---------------------------------------------------------------------------
+assert_removable() {
+  local disk="$1"
+  [ -e "$disk" ] || die "$disk does not exist"
+
+  if [ "$OS" = "Darwin" ]; then
+    local info removable internal
+    info="$(diskutil info "$disk" 2>/dev/null)" || die "diskutil could not read $disk"
+    removable="$(echo "$info" | awk -F': *' '/Removable Media/{print $2}' | xargs)"
+    internal="$(echo "$info" | awk -F': *' '/Device Location/{print $2}' | xargs)"
+    echo "$info" | grep -E 'Device / Media Name|Disk Size|Device Location|Removable Media|Volume Name' \
+      | sed 's/^ */    /'
+    if [ "$internal" = "Internal" ]; then
+      die "$disk is an INTERNAL disk. Refusing.
+       This is almost certainly your system drive. Re-read `diskutil list external`."
+    fi
+    case "$removable" in
+      Removable|"Yes") ;;
+      *) die "$disk does not report as removable media (got: '${removable:-unknown}'). Refusing." ;;
+    esac
+  else
+    local base rm_flag
+    base="$(basename "$(readlink -f "$disk")")"
+    base="${base%%[0-9]*}"
+    rm_flag="$(cat "/sys/block/$base/removable" 2>/dev/null || echo 0)"
+    lsblk -o NAME,SIZE,TYPE,RM,MODEL "$disk" | sed 's/^/    /'
+    [ "$rm_flag" = "1" ] || die "$disk is not flagged removable (/sys/block/$base/removable=0). Refusing."
+  fi
+}
+
+say "target device"
+assert_removable "$DISK"
+
+# ---------------------------------------------------------------------------
+# Credentials first: fail before touching the card, not after.
+#
+# Ordering is the whole point. Discovering a typo in the secrets file after a
+# 20-minute write means doing the write again.
+# ---------------------------------------------------------------------------
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+say "building boot-partition payload from $SECRETS"
+python3 "$HERE/mk_boot_config.py" --secrets "$SECRETS" --out "$STAGING" \
+  || die "credential staging failed - nothing was written to $DISK"
+
+# ---------------------------------------------------------------------------
+# Resolve and verify the image.
+# ---------------------------------------------------------------------------
+if [ -z "$IMAGE" ]; then
+  command -v gh >/dev/null || die "no --image given and `gh` is not installed"
+  say "downloading the '$IMAGE_RELEASE' release"
+  ( cd "$STAGING" && gh release download "$IMAGE_RELEASE" --repo MikePaNtZ/overboard \
+      --pattern '*.img.xz' --pattern '*.img.xz.sha256' ) \
+    || die "could not download release '$IMAGE_RELEASE'.
+       If the image pipeline has not landed yet (issue #182 I1), pass --image."
+  IMAGE="$(ls -1 "$STAGING"/*.img.xz)"
+fi
+[ -f "$IMAGE" ] || die "image not found: $IMAGE"
+
+if [ -f "$IMAGE.sha256" ]; then
+  say "verifying SHA256"
+  ( cd "$(dirname "$IMAGE")" && \
+    { shasum -a 256 -c "$(basename "$IMAGE").sha256" 2>/dev/null \
+      || sha256sum -c "$(basename "$IMAGE").sha256"; } ) \
+    || die "CHECKSUM MISMATCH - refusing to flash a corrupt or tampered image"
+else
+  # Loud, because a silent skip is how an unverified image becomes routine.
+  echo "WARNING: no $(basename "$IMAGE").sha256 alongside the image."
+  echo "         Flashing UNVERIFIED. AC-11's restore test assumes a checked artefact."
+fi
+
+# ---------------------------------------------------------------------------
+# Guard 2: type the identifier back.
+# ---------------------------------------------------------------------------
+echo
+echo "About to ERASE $DISK and write:"
+echo "    image:  $(basename "$IMAGE")"
+echo "    creds:  $(find "$STAGING" -name '*.nmconnection' | wc -l | xargs) wifi profile(s), ssh key, userconf"
+echo
+if [ "$DRY_RUN" -eq 1 ]; then
+  say "DRY RUN - every check above ran; skipping the write"
+else
+  printf "Type the device identifier (%s) to confirm: " "$DISK"
+  read -r confirm
+  [ "$confirm" = "$DISK" ] || die "confirmation did not match - nothing written"
+fi
+
+# ---------------------------------------------------------------------------
+# Write.
+# ---------------------------------------------------------------------------
+BOOT_MNT=""
+if [ "$OS" = "Darwin" ]; then
+  RAW="${DISK/\/dev\/disk//dev/rdisk}"   # rdisk = unbuffered, ~10x faster
+  if [ "$DRY_RUN" -eq 0 ]; then
+    say "unmounting $DISK"
+    diskutil unmountDisk "$DISK"
+    say "writing (sudo; ctrl-T shows progress)"
+    xz -dc "$IMAGE" | sudo dd of="$RAW" bs=4m
+    sync
+    say "waiting for the boot partition to mount"
+    sleep 3
+    diskutil mount "${DISK}s1" >/dev/null 2>&1 || true
+  fi
+  BOOT_MNT="/Volumes/bootfs"
+  [ -d "$BOOT_MNT" ] || BOOT_MNT="/Volumes/boot"
+else
+  if [ "$DRY_RUN" -eq 0 ]; then
+    say "unmounting any mounted partitions of $DISK"
+    for part in "$DISK"?*; do umount "$part" 2>/dev/null || true; done
+    say "writing (sudo)"
+    xz -dc "$IMAGE" | sudo dd of="$DISK" bs=4M conv=fsync status=progress
+    sync
+  fi
+  BOOT_MNT="$(mktemp -d)"
+  [ "$DRY_RUN" -eq 0 ] && sudo mount "${DISK}1" "$BOOT_MNT"
+fi
+
+# ---------------------------------------------------------------------------
+# Stage credentials onto the FAT32 boot partition.
+#
+# The boot partition, because the rootfs is ext4 and macOS cannot mount it.
+# firstboot_install.sh (shipped in the image) moves these onto the rootfs with
+# correct ownership and permissions on first boot, then shreds them.
+# ---------------------------------------------------------------------------
+if [ "$DRY_RUN" -eq 0 ]; then
+  [ -d "$BOOT_MNT" ] || die "boot partition did not mount at $BOOT_MNT.
+       The image was written; only credential staging failed. Mount the boot
+       partition by hand and copy the contents of a re-run --dry-run staging dir."
+  say "staging credentials to $BOOT_MNT"
+  sudo cp -R "$STAGING/overboard-net.d" "$BOOT_MNT/" 2>/dev/null || \
+       cp -R "$STAGING/overboard-net.d" "$BOOT_MNT/"
+  for f in overboard-authorized_keys overboard-userconf; do
+    sudo cp "$STAGING/$f" "$BOOT_MNT/" 2>/dev/null || cp "$STAGING/$f" "$BOOT_MNT/"
+  done
+  sync
+
+  say "ejecting"
+  if [ "$OS" = "Darwin" ]; then
+    diskutil eject "$DISK"
+  else
+    sudo umount "$BOOT_MNT" && rmdir "$BOOT_MNT"
+  fi
+fi
+
+echo
+if [ "$DRY_RUN" -eq 1 ]; then
+  say "DRY RUN complete. Checks passed and credentials staged to $STAGING."
+else
+  say "done. Insert the card and power the Pi."
+  echo "    First boot installs the credentials and then SHREDS them from the"
+  echo "    boot partition, so they are not left on a FAT32 filesystem."
+  echo
+  echo "    Then, to check the platform actually holds the loop:"
+  echo "      sudo overboard-loop-profile --cycles 100000 --rt-prio 80 --json run.json"
+  echo "      cyclictest -m -Sp95 -i 2000 -D 30m      # run both, they answer different questions"
+fi

--- a/scripts/pi/mk_boot_config.py
+++ b/scripts/pi/mk_boot_config.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Turn a local secrets file into the files that go on the card's boot partition.
+
+Run by ``flash_pi.sh`` at flash time. Never run in CI, never run by an agent,
+and its input never enters the repository.
+
+Why the boot partition and nothing else
+---------------------------------------
+The card has two partitions: a FAT32 boot partition and an ext4 rootfs. macOS
+cannot mount ext4 without third-party kernel extensions, and the CEO flashes
+from a Mac. So every byte of configuration this script produces has to land on
+the FAT32 side, and something on the Pi has to install it at first boot --
+``firstboot_install.sh``, shipped in the image (I1).
+
+That rules out writing NetworkManager profiles directly to
+``/etc/NetworkManager/system-connections/``, which is the obvious approach and
+is unavailable to us.
+
+It also rules IN a better shape than the one Raspberry Pi Imager uses. Imager
+hooks ``firstrun.sh`` from ``cmdline.txt`` and has the script edit
+``cmdline.txt`` back out again at the end -- a boot-critical file mutated by a
+script running during that same boot. Since we build the image (I1), the
+installer can be a plain systemd oneshot that reads a directory, and
+``cmdline.txt`` is never touched.
+
+What the PSK derivation does and does not buy
+---------------------------------------------
+Passphrases are converted to their 256-bit WPA-PSK before they are written,
+where the passphrase allows it. This does NOT protect the card: the PSK is
+exactly as good as the passphrase for joining that SSID, so anyone holding the
+card can still join the network.
+
+What it does prevent is the passphrase leaking in cleartext to be tried
+somewhere else -- and a home Wi-Fi passphrase is precisely the kind of secret
+that gets reused. That is a real and narrow benefit, and overstating it would
+be worse than not doing it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+# NetworkManager refuses to load a connection profile that is group- or
+# world-readable, so this is functional, not decorative.
+NM_PROFILE_MODE = 0o600
+
+MAX_WIFI_NETWORKS = 16
+
+
+class ConfigError(Exception):
+    """A problem with the operator's secrets file, not a bug."""
+
+
+def load_secrets(path: Path) -> dict[str, str]:
+    """Read a shell-style env file without executing it.
+
+    Deliberately not ``source``d through a shell. The file holds the operator's
+    home Wi-Fi passphrase; sourcing it would execute whatever a stray backtick
+    or ``$(...)`` happened to contain, which is a needless amount of trust to
+    place in a file that only ever needs to yield key/value pairs.
+
+    ``$HOME`` and ``~`` are expanded, because ``SSH_PUBKEY_FILE`` is a path and
+    writing it out in full is the kind of friction that ends with someone
+    pasting a private key in instead.
+    """
+    if not path.exists():
+        raise ConfigError(
+            f"no secrets file at {path}\n"
+            f"  cp scripts/pi/pi-secrets.example.env {path}\n"
+            f"  chmod 600 {path}\n"
+            f"then fill it in. It must live outside the repository."
+        )
+
+    mode = path.stat().st_mode & 0o777
+    if mode & 0o077:
+        raise ConfigError(
+            f"{path} is mode {mode:o}, readable beyond its owner. "
+            f"Run: chmod 600 {path}"
+        )
+
+    out: dict[str, str] = {}
+    for lineno, raw in enumerate(path.read_text().splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ConfigError(f"{path}:{lineno}: not a KEY=VALUE line: {raw!r}")
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            raise ConfigError(f"{path}:{lineno}: not a valid variable name: {key!r}")
+        # shlex handles the quoting the example file uses; expandvars/expanduser
+        # then make $HOME and ~ work in path values.
+        try:
+            parts = shlex.split(value.strip(), comments=True)
+        except ValueError as e:
+            raise ConfigError(f"{path}:{lineno}: unbalanced quotes: {e}") from e
+        out[key] = os.path.expanduser(os.path.expandvars("".join(parts)))
+    return out
+
+
+def wpa_psk(ssid: str, passphrase: str) -> str:
+    """The 256-bit WPA-PSK for this SSID and passphrase, as 64 hex characters.
+
+    A passphrase that is already 64 hex characters IS a PSK and is passed
+    through -- deriving a PSK from a PSK would produce a key that joins
+    nothing.
+
+    WPA-PSK is only defined for passphrases of 8..63 characters. Outside that
+    range the passphrase is returned unchanged and NetworkManager is left to
+    reject it, which gives a better error than anything invented here: a
+    5-character passphrase is a typo, and silently accepting it would put a
+    card in the field that never associates.
+    """
+    if re.fullmatch(r"[0-9a-fA-F]{64}", passphrase):
+        return passphrase.lower()
+    if not 8 <= len(passphrase) <= 63:
+        return passphrase
+    return hashlib.pbkdf2_hmac(
+        "sha1", passphrase.encode("utf-8"), ssid.encode("utf-8"), 4096, 32
+    ).hex()
+
+
+def collect_networks(secrets: dict[str, str]) -> list[dict[str, object]]:
+    """Gather WIFI_<n>_* blocks, in the order they will be tried.
+
+    Stops at the first missing index rather than scanning to a limit, so
+    deleting a block from the middle of the file is a visible mistake (the
+    ones after it vanish) instead of a silent renumbering.
+    """
+    nets: list[dict[str, object]] = []
+    for i in range(1, MAX_WIFI_NETWORKS + 1):
+        ssid = secrets.get(f"WIFI_{i}_SSID", "").strip()
+        if not ssid:
+            break
+        passphrase = secrets.get(f"WIFI_{i}_PASSPHRASE", "")
+        if not passphrase:
+            raise ConfigError(f"WIFI_{i}_SSID is set but WIFI_{i}_PASSPHRASE is empty")
+        if ssid.startswith("your-"):
+            raise ConfigError(
+                f"WIFI_{i}_SSID is still the example placeholder ({ssid!r}). "
+                "Fill in the real values before flashing."
+            )
+        try:
+            priority = int(secrets.get(f"WIFI_{i}_PRIORITY", str(100 - i)))
+        except ValueError as e:
+            raise ConfigError(f"WIFI_{i}_PRIORITY must be an integer: {e}") from e
+        nets.append(
+            {
+                "ssid": ssid,
+                "psk": wpa_psk(ssid, passphrase),
+                "priority": priority,
+                "hidden": secrets.get(f"WIFI_{i}_HIDDEN", "false").lower() == "true",
+            }
+        )
+    if not nets:
+        raise ConfigError("no WIFI_1_SSID set - the Pi would boot with no network")
+    return nets
+
+
+def nm_profile(net: dict[str, object], index: int) -> str:
+    """One NetworkManager keyfile connection profile."""
+    ssid = net["ssid"]
+    hidden = "\nhidden=true" if net["hidden"] else ""
+    return f"""# Generated by scripts/pi/mk_boot_config.py at flash time.
+# Not from the repository, and never committed to it.
+[connection]
+id=overboard-wifi-{index}
+type=wifi
+autoconnect=true
+autoconnect-priority={net["priority"]}
+
+[wifi]
+mode=infrastructure
+ssid={ssid}{hidden}
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk={net["psk"]}
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+addr-gen-mode=default
+"""
+
+
+def hash_password(password: str) -> str:
+    """Hash a console password with openssl, or refuse.
+
+    No fallback to a weaker algorithm and no writing it in the clear. If
+    ``openssl`` is missing, the honest outcome is to say so and let the
+    operator leave ``PI_PASSWORD`` empty -- key-only SSH is the default and
+    works without this.
+    """
+    try:
+        out = subprocess.run(
+            ["openssl", "passwd", "-6", "-stdin"],
+            input=password.encode(),
+            capture_output=True,
+            check=True,
+        )
+    except FileNotFoundError as e:
+        raise ConfigError(
+            "PI_PASSWORD is set but `openssl` was not found, so it cannot be "
+            "hashed. Install openssl, or leave PI_PASSWORD empty and use "
+            "key-only SSH."
+        ) from e
+    except subprocess.CalledProcessError as e:
+        raise ConfigError(f"openssl passwd failed: {e.stderr.decode().strip()}") from e
+    return out.stdout.decode().strip()
+
+
+def build(secrets: dict[str, str], outdir: Path) -> list[Path]:
+    """Write the boot-partition payload. Returns the files written."""
+    written: list[Path] = []
+
+    netdir = outdir / "overboard-net.d"
+    netdir.mkdir(parents=True, exist_ok=True)
+    for i, net in enumerate(collect_networks(secrets), 1):
+        p = netdir / f"overboard-wifi-{i}.nmconnection"
+        p.write_text(nm_profile(net, i))
+        p.chmod(NM_PROFILE_MODE)
+        written.append(p)
+
+    username = secrets.get("PI_USERNAME", "").strip()
+    if not username:
+        raise ConfigError("PI_USERNAME is empty - the image ships with no default user")
+
+    pubkey_path = secrets.get("SSH_PUBKEY_FILE", "").strip()
+    if not pubkey_path:
+        raise ConfigError("SSH_PUBKEY_FILE is empty - the Pi would be unreachable")
+    pubkey = Path(pubkey_path)
+    if not pubkey.exists():
+        raise ConfigError(f"SSH_PUBKEY_FILE does not exist: {pubkey}")
+    key_text = pubkey.read_text().strip()
+    # The failure this catches is real and expensive: pointing at id_ed25519
+    # instead of id_ed25519.pub would copy a PRIVATE key onto a partition that
+    # any machine can read.
+    if "PRIVATE KEY" in key_text or not re.match(r"(ssh|ecdsa|sk-)", key_text):
+        raise ConfigError(
+            f"{pubkey} does not look like an SSH PUBLIC key. Point "
+            f"SSH_PUBKEY_FILE at the .pub file, never at a private key."
+        )
+
+    p = outdir / "overboard-authorized_keys"
+    p.write_text(key_text + "\n")
+    written.append(p)
+
+    conf = [
+        f"hostname={secrets.get('PI_HOSTNAME', 'overboard')}",
+        f"username={username}",
+        f"wifi_country={secrets.get('WIFI_COUNTRY', 'US')}",
+        f"ssh_password_auth={secrets.get('SSH_PASSWORD_AUTH', 'false')}",
+    ]
+    password = secrets.get("PI_PASSWORD", "")
+    if password:
+        conf.append(f"password_hash={hash_password(password)}")
+
+    p = outdir / "overboard-userconf"
+    p.write_text("\n".join(conf) + "\n")
+    p.chmod(NM_PROFILE_MODE)
+    written.append(p)
+
+    return written
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--secrets",
+        type=Path,
+        default=Path.home() / ".overboard" / "pi-secrets.env",
+        help="local secrets file (default: ~/.overboard/pi-secrets.env)",
+    )
+    ap.add_argument(
+        "--out", type=Path, required=True, help="staging directory to write into"
+    )
+    args = ap.parse_args()
+
+    try:
+        secrets = load_secrets(args.secrets)
+        written = build(secrets, args.out)
+    except ConfigError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    # Filenames only. Printing a path is navigation; printing content would
+    # put a PSK in a terminal scrollback and, on CI, in a log.
+    print(f"wrote {len(written)} files to {args.out}:")
+    for p in written:
+        print(f"    {p.relative_to(args.out)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi/pi-secrets.example.env
+++ b/scripts/pi/pi-secrets.example.env
@@ -1,0 +1,71 @@
+# Example secrets file for scripts/pi/flash_pi.sh -- COPY, DO NOT EDIT IN PLACE.
+#
+#     mkdir -p ~/.overboard && cp scripts/pi/pi-secrets.example.env ~/.overboard/pi-secrets.env
+#     chmod 600 ~/.overboard/pi-secrets.env
+#
+# The real file lives OUTSIDE the repository, at ~/.overboard/pi-secrets.env.
+#
+# Outside rather than gitignored-inside, deliberately. A gitignored file is one
+# `git add -f`, one rewritten .gitignore, or one `git stash -u` away from being
+# committed, and this repository is PUBLIC. A file that was never inside the
+# working tree cannot be committed by accident. scripts/pi/check_no_secrets.py
+# enforces the negative on every PR.
+#
+# Nothing here is ever placed by an agent. The design is explicit: credentials
+# are placed by the CEO, never generated or held by an agent. This file is the
+# mechanism for that rule, not an exception to it.
+
+# ---------------------------------------------------------------------------
+# Wi-Fi networks, in priority order.
+#
+# Numbered so several can be preconfigured -- home, workshop, phone hotspot --
+# and the Pi joins whichever it can see. Higher priority wins when more than
+# one is in range. Add or remove blocks freely; the generator reads until a
+# number is missing.
+#
+# HIDDEN is optional and defaults to false. A hidden network needs it set, or
+# NetworkManager will never probe for it and the Pi will look dead.
+# ---------------------------------------------------------------------------
+
+WIFI_1_SSID="your-home-ssid"
+WIFI_1_PASSPHRASE="your-home-passphrase"
+WIFI_1_PRIORITY="100"
+WIFI_1_HIDDEN="false"
+
+WIFI_2_SSID="your-workshop-ssid"
+WIFI_2_PASSPHRASE="your-workshop-passphrase"
+WIFI_2_PRIORITY="50"
+
+WIFI_3_SSID="your-phone-hotspot"
+WIFI_3_PASSPHRASE="your-hotspot-passphrase"
+WIFI_3_PRIORITY="10"
+
+# Two-letter regulatory domain. Not cosmetic: an unset or wrong country
+# leaves 5 GHz channels disabled, which presents as "the network is not
+# there" rather than as a configuration error.
+WIFI_COUNTRY="US"
+
+# ---------------------------------------------------------------------------
+# Login. The image ships with NO user and NO password -- Raspberry Pi OS has
+# not had a default `pi`/`raspberry` login for years, and reintroducing one on
+# a public image would be worse than pointless.
+# ---------------------------------------------------------------------------
+
+PI_USERNAME="overboard"
+
+# Path to the PUBLIC key you want to log in with. Public, not private: this
+# script never reads, copies or generates a private key.
+SSH_PUBKEY_FILE="$HOME/.ssh/id_ed25519.pub"
+
+# Password login over SSH stays OFF by default. Key-only is one setting, and
+# the alternative on a board that will sit on a workshop network is a password
+# that gets reused and forgotten about.
+SSH_PASSWORD_AUTH="false"
+
+# Optional. Only needed for console login at a keyboard; leave empty for
+# key-only SSH access. If set, it is hashed before it reaches the card.
+PI_PASSWORD=""
+
+# Hostname. Distinct from any other Pi you own, because `overboard.local`
+# resolving to the wrong machine while a motor is armed is a bad afternoon.
+PI_HOSTNAME="overboard"

--- a/scripts/pi/pins.env
+++ b/scripts/pi/pins.env
@@ -1,0 +1,66 @@
+# Stage-0B image pins -- the single source of truth for what goes on the card.
+#
+# AC-1: every directly-installed package is pinned to an explicit version, and
+# the build FAILS if any pin is unsatisfiable. AC-2: the kernel is an explicit
+# version, `apt-mark hold`-ed, never the floating metapackage.
+#
+# Why a flat env file and not a script: this is read by CI jobs, by the image
+# builder, and eventually by the provenance manifest generator. A shell script
+# that computed these would make "what version is on the card" a thing you run
+# rather than a thing you read.
+#
+# ---------------------------------------------------------------------------
+# THE KERNEL PIN IS THE LOAD-BEARING ONE.
+#
+# It is the single variable that invalidates every latency number Stage 0B
+# produces (design §2). Two numbers taken across a kernel change are not
+# comparable, and nothing in the data says so -- which is why this is held
+# rather than tracked.
+#
+# `rpi-v8-rt`, NOT `rpi-2712-rt`: there is no RT build of the Pi 5's own
+# kernel flavour. That was established by enumerating the archive's Packages
+# index rather than recalled (docs/design-pi-image-stage0b-verification.md),
+# and it is exactly the kind of plausible-but-wrong pin this file exists to
+# stop. Consequence, accepted knowingly: 4K pages instead of 16K, and no
+# CONFIG_NO_HZ_FULL -- design §4 weighs both.
+# ---------------------------------------------------------------------------
+
+RPI_ARCHIVE_URL="https://archive.raspberrypi.com/debian"
+RPI_ARCHIVE_SUITE="trixie"
+RPI_ARCHIVE_COMPONENT="main"
+DEBIAN_ARCH="arm64"
+
+# >= 6.12 is the HARD FLOOR, not this specific patch release: the 6.12 line is
+# longer-supported than 6.18 and comfortably contains the mcp251xfd receive-
+# latency fix (upstream eb9a839, backported in raspberrypi/linux #6466,
+# November 2024, marked for stable). If this exact version ages out of the
+# archive, move it forward within the 6.12 line -- do NOT float to the
+# metapackage, which resolved to 6.18.34 on 2026-07-27 and will resolve to
+# something else tomorrow.
+KERNEL_PACKAGE="linux-image-6.12.75+rpt-rpi-v8-rt"
+KERNEL_VERSION="1:6.12.75-1+rpt1"
+
+# Kernel modules and device tree that MUST be present in the kernel .deb, or
+# the pin is wrong however well it resolves. Asserted by verify_kernel.sh.
+#   mcp251xfd    - the CAN HAT's MCP2518FD controller (issue #182 I3)
+#   vcan         - the no-hardware CAN self-test
+#   gs_usb       - the CANable 2.0, AC-8's second measurement arm
+#   bcm2712 dtb  - proof this generic v8 kernel is still a complete Pi 5 kernel
+KERNEL_REQUIRED_FILES="mcp251xfd.ko vcan.ko gs_usb.ko bcm2712-rpi-5-b.dtb"
+
+# Kernel config flags asserted against the .deb's shipped /boot/config-*.
+# CONFIG_PREEMPT_RT proves only that the kernel was BUILT rt -- it says
+# nothing about achieved latency under our load, which is AC-5's job and
+# needs the hardware. Checked here so a silently non-RT kernel cannot reach
+# the card, not as evidence the platform is fast enough.
+KERNEL_REQUIRED_CONFIG="CONFIG_PREEMPT_RT=y CONFIG_CPU_ISOLATION=y CONFIG_CAN_MCP251XFD=m CONFIG_CAN_VCAN=m"
+
+# Bench and verification tooling. Versions verified against Debian trixie
+# arm64 on 2026-07-27 (see the verification log). CI is the check on whether
+# they are still satisfiable -- an unsatisfiable pin here is a RED BUILD by
+# design, and the correct response is to re-verify and move the pin, never to
+# unpin it.
+PINNED_PACKAGES="
+rt-tests=2.6-1.1
+can-utils=2023.03-1+b2
+"

--- a/scripts/pi/spike_rpi_image_gen.sh
+++ b/scripts/pi/spike_rpi_image_gen.sh
@@ -93,15 +93,40 @@ else
   echo "<no install_deps.sh - skipping>"
 fi
 
+section "entrypoint usage"
+# Run 1 of this spike guessed `./build.sh` and found no such file. The
+# unconditional dump above is what turned that into a one-line fix rather than
+# another cycle: the real entrypoint is `bin/idp.sh` (image definition
+# processor) and stock configs live under `examples/*/config`.
+IDP="./bin/idp.sh"
+if [ -x "$IDP" ]; then
+  "$IDP" --help 2>&1 | head -60 || "$IDP" -h 2>&1 | head -60 || true
+else
+  echo "MISSING: $IDP - the layout changed again; re-read the sections above"
+fi
+
 section "BUILD ATTEMPT"
 build_rc=1
-if [ -x ./build.sh ]; then
-  echo "$ ./build.sh"
-  ./build.sh 2>&1 | tail -120
-  build_rc="${PIPESTATUS[0]}"
+# `slim` is the smallest stock config, so this asks the narrowest possible
+# version of the question -- does the toolchain run here at all -- rather than
+# also testing whatever a fat example happens to pull in.
+CONFIG="examples/slim/config"
+[ -e "$CONFIG" ] || CONFIG="test/configurations/config"
+
+if [ -x "$IDP" ]; then
+  # Two documented-looking invocations rather than one. Still a guess; the
+  # usage dump above is what makes the next correction cheap if both are
+  # wrong, and trying two costs seconds.
+  for attempt in "build -c $CONFIG" "-c $CONFIG"; do
+    echo "$ $IDP $attempt"
+    # shellcheck disable=SC2086
+    "$IDP" $attempt 2>&1 | tail -80
+    build_rc="${PIPESTATUS[0]}"
+    echo "  -> exit $build_rc"
+    [ "$build_rc" -eq 0 ] && break
+  done
 else
-  echo "no ./build.sh found - the entrypoint guess was wrong."
-  echo "See 'candidate entrypoints' above for what this repo actually ships."
+  echo "no runnable entrypoint found."
 fi
 echo "build exit: $build_rc"
 

--- a/scripts/pi/spike_rpi_image_gen.sh
+++ b/scripts/pi/spike_rpi_image_gen.sh
@@ -83,10 +83,12 @@ done
 section "candidate entrypoints (executables, any name)"
 find . -maxdepth 2 -type f -perm -u+x -not -path './.git/*' | sort | head -40
 
-section "example / stock configurations"
-find . -maxdepth 3 \( -path ./.git -prune \) -o \
-  \( -type d -name '*config*' -o -type d -name '*example*' -o -type f -name '*.cfg' \) -print \
-  2>/dev/null | grep -v '^./.git' | sort | head -40
+# Run 3 listed DIRECTORIES named *config* and passed one to -c, which earned
+# "Unsupported config file format '' -- only .yaml and .yml are supported".
+# The tool wants a FILE. List the files.
+section "stock configurations (.yaml/.yml)"
+find . -path ./.git -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print \
+  2>/dev/null | sort | head -40
 
 section "documented dependencies"
 for f in install_deps.sh depends requirements.txt; do
@@ -113,35 +115,38 @@ section "entrypoint usage"
 # exactly why the discovery above now matches on the executable bit.
 GEN="./rpi-image-gen"
 if [ -x "$GEN" ]; then
-  for flag in --help -h help; do
-    echo "$ $GEN $flag"
-    "$GEN" "$flag" 2>&1 | head -70 && break
-  done
+  # Run 3 established the shape: `rpi-image-gen build [options]`, and `-c`
+  # takes a config FILE. Ask the subcommand directly rather than the top
+  # level -- the top-level help does not list build's own options.
+  echo "$ $GEN build -h"
+  "$GEN" build -h 2>&1 | head -50
 else
   echo "MISSING: $GEN - the layout changed again; re-read the sections above"
 fi
 
 section "BUILD ATTEMPT"
 build_rc=1
-# `slim` is the smallest stock config, so this asks the narrowest possible
-# version of the question -- does the toolchain run here at all -- rather than
-# also testing whatever a fat example happens to pull in.
-CONFIG="examples/slim/config"
-[ -e "$CONFIG" ] || CONFIG="test/configurations/config"
 
-if [ -x "$GEN" ]; then
-  # Several plausible invocations rather than one. Still guesses, and the
-  # usage dump above is what makes the next correction cheap if all of them
-  # are wrong -- but each costs seconds, so trying the obvious spellings
-  # beats spending another CI round to learn the flag name.
-  for attempt in "build -c $CONFIG" "-c $CONFIG" "build -D $CONFIG"; do
-    echo "$ $GEN $attempt"
-    # shellcheck disable=SC2086
-    "$GEN" $attempt 2>&1 | tail -80
-    build_rc="${PIPESTATUS[0]}"
-    echo "  -> exit $build_rc"
-    [ "$build_rc" -eq 0 ] && break
-  done
+# `slim` preferred: the smallest stock config, so this asks the narrowest
+# version of the question -- does the toolchain run here at all -- rather than
+# also testing whatever a fat example happens to pull in. Resolved by GLOB
+# rather than hardcoded, because the one thing every run of this spike has
+# proved is that guessing a path from convention does not work.
+CONFIG="$(find examples/slim -name '*.yaml' -o -name '*.yml' 2>/dev/null | sort | head -1)"
+[ -n "$CONFIG" ] || CONFIG="$(find examples -name '*.yaml' -o -name '*.yml' 2>/dev/null | sort | head -1)"
+[ -n "$CONFIG" ] || CONFIG="$(find . -path ./.git -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print 2>/dev/null | sort | head -1)"
+
+echo "config: ${CONFIG:-<none found>}"
+
+if [ -x "$GEN" ] && [ -n "$CONFIG" ]; then
+  # One invocation now, not a spread of guesses: run 3 confirmed the command
+  # (`build`) and the flag (`-c`), and the only thing that was wrong was
+  # passing a directory where a .yaml file was wanted.
+  echo "$ $GEN build -c $CONFIG"
+  "$GEN" build -c "$CONFIG" 2>&1 | tail -100
+  build_rc="${PIPESTATUS[0]}"
+elif [ -z "$CONFIG" ]; then
+  echo "no .yaml/.yml config found anywhere - see the listing above"
 else
   echo "no runnable entrypoint found."
 fi

--- a/scripts/pi/spike_rpi_image_gen.sh
+++ b/scripts/pi/spike_rpi_image_gen.sh
@@ -64,12 +64,24 @@ echo "commit: $(git rev-parse --short HEAD)"
 section "repository layout"
 ls -la
 
-section "README (first 120 lines)"
-head -120 README.md 2>/dev/null || echo "<no README.md>"
+# Run 2 looked only for README.md and found nothing: this project ships
+# README.adoc and getting_started.adoc. Glob the stem, not the extension --
+# the point of a discovery dump is to be wrong about details and still
+# return the answer.
+section "documentation"
+for f in README.* getting_started.* INSTALL.* USAGE.*; do
+  [ -f "$f" ] || continue
+  echo "--- $f"
+  head -80 "$f"
+done
 
-section "candidate entrypoints"
-find . -maxdepth 2 -type f \( -name '*.sh' -o -name 'Makefile' -o -name 'meson.build' \) \
-  -not -path './.git/*' | sort | head -40
+# Run 2's other miss: this globbed '*.sh' and reported bin/idp.sh as the
+# entrypoint. idp.sh turned out to be a FASTBOOT PROVISIONER -- an unrelated
+# tool -- while the real entrypoint is `rpi-image-gen`, an extensionless
+# executable in the root. Match on the executable BIT, not on a naming
+# convention the project never promised to follow.
+section "candidate entrypoints (executables, any name)"
+find . -maxdepth 2 -type f -perm -u+x -not -path './.git/*' | sort | head -40
 
 section "example / stock configurations"
 find . -maxdepth 3 \( -path ./.git -prune \) -o \
@@ -94,15 +106,19 @@ else
 fi
 
 section "entrypoint usage"
-# Run 1 of this spike guessed `./build.sh` and found no such file. The
-# unconditional dump above is what turned that into a one-line fix rather than
-# another cycle: the real entrypoint is `bin/idp.sh` (image definition
-# processor) and stock configs live under `examples/*/config`.
-IDP="./bin/idp.sh"
-if [ -x "$IDP" ]; then
-  "$IDP" --help 2>&1 | head -60 || "$IDP" -h 2>&1 | head -60 || true
+# Entrypoint, third attempt. Run 1 guessed ./build.sh (does not exist). Run 2
+# guessed ./bin/idp.sh, which DOES exist and is a red herring -- it is a
+# fastboot provisioner for writing a finished image to a remote device, not a
+# builder. The real entrypoint is ./rpi-image-gen, extensionless, which is
+# exactly why the discovery above now matches on the executable bit.
+GEN="./rpi-image-gen"
+if [ -x "$GEN" ]; then
+  for flag in --help -h help; do
+    echo "$ $GEN $flag"
+    "$GEN" "$flag" 2>&1 | head -70 && break
+  done
 else
-  echo "MISSING: $IDP - the layout changed again; re-read the sections above"
+  echo "MISSING: $GEN - the layout changed again; re-read the sections above"
 fi
 
 section "BUILD ATTEMPT"
@@ -113,14 +129,15 @@ build_rc=1
 CONFIG="examples/slim/config"
 [ -e "$CONFIG" ] || CONFIG="test/configurations/config"
 
-if [ -x "$IDP" ]; then
-  # Two documented-looking invocations rather than one. Still a guess; the
-  # usage dump above is what makes the next correction cheap if both are
-  # wrong, and trying two costs seconds.
-  for attempt in "build -c $CONFIG" "-c $CONFIG"; do
-    echo "$ $IDP $attempt"
+if [ -x "$GEN" ]; then
+  # Several plausible invocations rather than one. Still guesses, and the
+  # usage dump above is what makes the next correction cheap if all of them
+  # are wrong -- but each costs seconds, so trying the obvious spellings
+  # beats spending another CI round to learn the flag name.
+  for attempt in "build -c $CONFIG" "-c $CONFIG" "build -D $CONFIG"; do
+    echo "$ $GEN $attempt"
     # shellcheck disable=SC2086
-    "$IDP" $attempt 2>&1 | tail -80
+    "$GEN" $attempt 2>&1 | tail -80
     build_rc="${PIPESTATUS[0]}"
     echo "  -> exit $build_rc"
     [ "$build_rc" -eq 0 ] && break

--- a/scripts/pi/spike_rpi_image_gen.sh
+++ b/scripts/pi/spike_rpi_image_gen.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# I0 -- the D3 spike. Does `rpi-image-gen` build AT ALL in our CI shape?
+#
+# Design section 3 chose `rpi-image-gen` over `pi-gen`, and gated that choice
+# on one question it refused to settle by argument: the tool documents
+# "Debian Bookworm and Trixie arm64 as the supported native hosts", needs
+# CAP_SYS_ADMIN, and says containers are "not formally supported". Our shape
+# is a privileged debian:trixie container on a hosted ubuntu-24.04-arm runner
+# -- close to supported, not identical, and the only unsupported axis is "in
+# a container". That is a real risk, and half a day of CI settles it.
+#
+# GREEN  -> proceed with rpi-image-gen.
+# RED    -> take the derive-from-stock fallback (reference doc section 2).
+#           Explicitly NOT pi-gen: a lateral move, same class of uncertainty,
+#           plus rebuilding a whole distribution we do not need.
+#
+# THIS SCRIPT'S JOB IS TO PRODUCE INFORMATION, NOT TO PASS.
+#
+# A spike that fails having printed nothing has cost the half day and bought
+# nothing. So the tool's actual interface -- its README, its layout, its
+# example configs -- is dumped BEFORE the build is attempted, unconditionally.
+# If the build then fails because this script guessed the entrypoint wrong,
+# the log still contains what the right entrypoint is, and the next attempt
+# is a one-line edit rather than another half day.
+set -uo pipefail
+
+REPO="https://github.com/raspberrypi/rpi-image-gen"
+WORK="/tmp/spike"
+
+section() { echo; echo "=============== $* ==============="; echo; }
+
+section "host and container"
+echo "uname:    $(uname -a)"
+echo "id:       $(id)"
+echo "os:       $(grep PRETTY_NAME /etc/os-release | cut -d= -f2-)"
+# The three capabilities the tool's host requirements actually turn on. If
+# loop devices are missing, nothing below can work and the failure is
+# attributable to the runner rather than to the tool.
+echo "loop dev: $(ls -l /dev/loop-control 2>&1 | head -1)"
+echo "cap:      $(grep CapEff /proc/self/status 2>/dev/null || echo '<unknown>')"
+
+section "install prerequisites"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+# Deliberately unpinned: this is throwaway spike scaffolding, not the image.
+# AC-1's pinning rule governs what lands ON THE CARD -- pinning the spike's
+# own git client would be ceremony, and would make the spike fail for reasons
+# unrelated to the question it is asking.
+apt-get install -y --no-install-recommends \
+  git ca-certificates sudo kmod parted fdisk dosfstools e2fsprogs \
+  xz-utils zstd bc python3 >/dev/null 2>&1
+echo "ok"
+
+section "clone $REPO"
+rm -rf "$WORK"
+git clone --depth 1 "$REPO" "$WORK" || { echo "CLONE FAILED - spike cannot proceed"; exit 1; }
+cd "$WORK"
+echo "commit: $(git rev-parse --short HEAD)"
+
+# ---------------------------------------------------------------------------
+# Everything from here is the information the spike exists to produce. It runs
+# whether or not the build later succeeds.
+# ---------------------------------------------------------------------------
+section "repository layout"
+ls -la
+
+section "README (first 120 lines)"
+head -120 README.md 2>/dev/null || echo "<no README.md>"
+
+section "candidate entrypoints"
+find . -maxdepth 2 -type f \( -name '*.sh' -o -name 'Makefile' -o -name 'meson.build' \) \
+  -not -path './.git/*' | sort | head -40
+
+section "example / stock configurations"
+find . -maxdepth 3 \( -path ./.git -prune \) -o \
+  \( -type d -name '*config*' -o -type d -name '*example*' -o -type f -name '*.cfg' \) -print \
+  2>/dev/null | grep -v '^./.git' | sort | head -40
+
+section "documented dependencies"
+for f in install_deps.sh depends requirements.txt; do
+  [ -e "$f" ] && { echo "--- $f"; head -40 "$f"; }
+done
+
+# ---------------------------------------------------------------------------
+# The attempt. Guessed from the tool's own conventions; if the guess is wrong
+# the sections above are what makes the next attempt cheap.
+# ---------------------------------------------------------------------------
+section "dependency install (tool's own script, if it ships one)"
+if [ -x ./install_deps.sh ]; then
+  ./install_deps.sh 2>&1 | tail -30
+  echo "install_deps.sh exit: $?"
+else
+  echo "<no install_deps.sh - skipping>"
+fi
+
+section "BUILD ATTEMPT"
+build_rc=1
+if [ -x ./build.sh ]; then
+  echo "$ ./build.sh"
+  ./build.sh 2>&1 | tail -120
+  build_rc="${PIPESTATUS[0]}"
+else
+  echo "no ./build.sh found - the entrypoint guess was wrong."
+  echo "See 'candidate entrypoints' above for what this repo actually ships."
+fi
+echo "build exit: $build_rc"
+
+section "did an image appear?"
+# The spike's actual acceptance criterion, from design section 3: "produces
+# any .img at all". Not a correct image, not our image -- any image. Anything
+# stronger would be testing the tool instead of testing our host shape.
+mapfile -t imgs < <(find . -name '*.img' -o -name '*.img.xz' -o -name '*.img.zst' 2>/dev/null | head -10)
+if [ "${#imgs[@]}" -gt 0 ]; then
+  for i in "${imgs[@]}"; do echo "    $(ls -lh "$i" | awk '{print $5, $9}')"; done
+  echo
+  echo "SPIKE RESULT: GREEN - rpi-image-gen produced an image in our CI shape."
+  echo "Design section 3's primary choice stands; proceed to I1."
+  exit 0
+fi
+
+echo "    <none>"
+echo
+echo "SPIKE RESULT: RED - no image produced in our CI shape."
+echo
+echo "This is a RESULT, not a broken build. Read the sections above before"
+echo "concluding anything: if the failure is a wrong entrypoint guess, fix the"
+echo "guess and re-run -- that is not evidence against the tool. If the tool"
+echo "genuinely cannot build in a privileged container on an arm64 runner,"
+echo "take the derive-from-stock fallback (reference doc section 2), NOT pi-gen."
+exit 1

--- a/scripts/pi/spike_rpi_image_gen.sh
+++ b/scripts/pi/spike_rpi_image_gen.sh
@@ -136,14 +136,30 @@ CONFIG="$(find examples/slim -name '*.yaml' -o -name '*.yml' 2>/dev/null | sort 
 [ -n "$CONFIG" ] || CONFIG="$(find examples -name '*.yaml' -o -name '*.yml' 2>/dev/null | sort | head -1)"
 [ -n "$CONFIG" ] || CONFIG="$(find . -path ./.git -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print 2>/dev/null | sort | head -1)"
 
+# Run 4 got all the way to collect_layers and stopped on:
+#
+#     Layer 'example-mydevice' not found
+#     SEARCH: ...IGdevice=/tmp/spike/device:IGimage=...:IGlayer=/tmp/spike/layer
+#
+# It was searching only the TOP-LEVEL device/image/layer directories, while
+# this example's layers ship beside its config under examples/slim/. That is
+# precisely what `-S <src dir>` is for, per the usage dump run 3 surfaced:
+# "Directory holding custom sources of config, profile, image layout and
+# layers."
+#
+# Derived from the config's own location (config file -> its dir -> its
+# parent) rather than named, for the reason every previous run of this spike
+# demonstrated: a hardcoded path is a guess waiting to be wrong.
+SRC="$(dirname "$(dirname "$CONFIG")")"
+
 echo "config: ${CONFIG:-<none found>}"
+echo "source: ${SRC:-<none>}"
 
 if [ -x "$GEN" ] && [ -n "$CONFIG" ]; then
-  # One invocation now, not a spread of guesses: run 3 confirmed the command
-  # (`build`) and the flag (`-c`), and the only thing that was wrong was
-  # passing a directory where a .yaml file was wanted.
-  echo "$ $GEN build -c $CONFIG"
-  "$GEN" build -c "$CONFIG" 2>&1 | tail -100
+  # One invocation, not a spread of guesses: runs 3 and 4 confirmed the
+  # entrypoint, the command, the flag and the config format between them.
+  echo "$ $GEN build -c $CONFIG -S $SRC"
+  "$GEN" build -c "$CONFIG" -S "$SRC" 2>&1 | tail -120
   build_rc="${PIPESTATUS[0]}"
 elif [ -z "$CONFIG" ]; then
   echo "no .yaml/.yml config found anywhere - see the listing above"

--- a/scripts/pi/verify_kernel.sh
+++ b/scripts/pi/verify_kernel.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# AC-2 evidence: the pinned kernel really ships what the design assumes.
+#
+# This automates, on every PR, exactly what was done by hand on 2026-07-27 and
+# recorded in docs/design-pi-image-stage0b-verification.md. The design says so
+# in as many words -- "this is exactly what the implementation must automate".
+#
+# A resolving pin (verify_pins.sh) proves the version EXISTS. It says nothing
+# about the contents, and the contents are where the design's load-bearing
+# claims live: that a generic 4K-page v8-rt kernel is still a complete Pi 5
+# kernel, and that the CAN stack we depend on is actually in it. Those were
+# established by unpacking the .deb, so that is what gets repeated here.
+#
+# Downloads and unpacks a ~100 MB kernel. Runs only when the pins or these
+# scripts change -- see the workflow's `paths:` filter.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=pins.env
+source "$HERE/pins.env"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+echo "=== downloading ${KERNEL_PACKAGE}=${KERNEL_VERSION} ==="
+# `apt-get download` fetches AND verifies the SHA256 against the signed
+# Packages index. Doing the checksum by hand afterwards would re-check what
+# apt already checked, against a value read from the same index -- proving
+# only that we can read a file twice.
+apt-get download "${KERNEL_PACKAGE}=${KERNEL_VERSION}"
+deb="$(ls -1 ./*.deb)"
+echo "    $deb"
+echo "    sha256: $(sha256sum "$deb" | cut -d' ' -f1)"
+
+echo
+echo "=== unpacking ==="
+dpkg-deb -x "$deb" ./root
+dpkg-deb -e "$deb" ./root/DEBIAN
+
+fail=0
+
+echo
+echo "=== required modules and device tree ==="
+for f in $KERNEL_REQUIRED_FILES; do
+  # -name rather than an exact path: the module tree is versioned, and
+  # hardcoding lib/modules/<version>/... would make every kernel bump a
+  # two-place edit with one of them easy to miss.
+  if found="$(find ./root -name "$f" -print -quit)" && [ -n "$found" ]; then
+    echo "    ok       $f  ->  ${found#./root}"
+  else
+    echo "    MISSING  $f"
+    fail=1
+  fi
+done
+
+echo
+echo "=== shipped kernel config ==="
+config="$(find ./root/boot -name 'config-*' -print -quit || true)"
+if [ -z "$config" ]; then
+  echo "    MISSING: the .deb ships no /boot/config-*, so none of the flags below"
+  echo "             can be checked. Treat every config claim as unverified."
+  fail=1
+else
+  echo "    $(basename "$config")"
+  for flag in $KERNEL_REQUIRED_CONFIG; do
+    if grep -qx "$flag" "$config"; then
+      echo "    ok       $flag"
+    else
+      echo "    MISSING  $flag"
+      # What the config actually says, so a changed default is diagnosable
+      # from the log instead of needing a local re-download.
+      key="${flag%%=*}"
+      echo "             actual: $(grep -E "^($key=|# $key )" "$config" || echo "<absent>")"
+      fail=1
+    fi
+  done
+
+  # Recorded, deliberately NOT asserted. Design section 4 accepts both of
+  # these as the known cost of there being no rpi-2712-rt: 4K pages instead
+  # of 16K, and the isolated core still taking the 250 Hz tick. They are
+  # stated in advance and included in the measurement rather than discovered
+  # mid-debug -- so the build must not fail on them, but the log must show
+  # them every time.
+  echo
+  echo "=== known costs (recorded, not asserted -- design section 4) ==="
+  echo "    $(grep -E '^CONFIG_ARM64_(4K|16K|64K)_PAGES=' "$config" || echo '<no page size flag>')"
+  echo "    $(grep -E '^CONFIG_HZ=' "$config" || echo '<no CONFIG_HZ>')"
+  echo "    NO_HZ_FULL: $(grep -E '^(CONFIG_NO_HZ_FULL=|# CONFIG_NO_HZ_FULL )' "$config" || echo '<absent, as expected>')"
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: the pinned kernel does not ship what the design assumes."
+  echo "This is a DESIGN-INVALIDATING result, not a flaky build: docs/design-pi-image-stage0b.md"
+  echo "section 4 and its verification log are wrong, or the archive has changed under us."
+  echo "Do not adjust the assertions to match. Re-verify and amend the design."
+  exit 1
+fi
+
+echo "PASS: the pinned kernel ships the CAN stack, the Pi 5 device tree, and CONFIG_PREEMPT_RT."

--- a/scripts/pi/verify_kernel.sh
+++ b/scripts/pi/verify_kernel.sh
@@ -46,7 +46,16 @@ for f in $KERNEL_REQUIRED_FILES; do
   # -name rather than an exact path: the module tree is versioned, and
   # hardcoding lib/modules/<version>/... would make every kernel bump a
   # two-place edit with one of them easy to miss.
-  if found="$(find ./root -name "$f" -print -quit)" && [ -n "$found" ]; then
+  #
+  # The suffix glob matters and its absence produced a FALSE ALARM on run 2:
+  # this kernel ships modules COMPRESSED (mcp251xfd.ko.xz), so an exact
+  # `-name mcp251xfd.ko` matched nothing and the script announced a
+  # "DESIGN-INVALIDATING result" about a kernel that ships exactly what the
+  # design says it does. The config flags were green in the same run, which
+  # is what gave the lie away -- CONFIG_CAN_MCP251XFD=m and no module file is
+  # not a state a real kernel package can be in.
+  if found="$(find ./root \( -name "$f" -o -name "$f.xz" -o -name "$f.zst" \
+                             -o -name "$f.gz" \) -print -quit)" && [ -n "$found" ]; then
     echo "    ok       $f  ->  ${found#./root}"
   else
     echo "    MISSING  $f"

--- a/scripts/pi/verify_pins.sh
+++ b/scripts/pi/verify_pins.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# AC-1: every pinned package resolves to the exact version named.
+#
+# Runs against the live archive with no Pi and no image builder, so it catches
+# a fabricated or aged-out pin on every PR rather than at flash time. The
+# design's own no-Pi table rates this HIGH confidence, and it has already
+# earned it once: this is the check that caught the `rpi-2712-rt` assumption
+# before it became a pin.
+#
+# `--dry-run` deliberately: resolving the pin proves the version exists and
+# its dependencies are satisfiable, which is the whole claim. Actually
+# unpacking a kernel to assert that would cost minutes per PR for no extra
+# information -- verify_kernel.sh unpacks the one package where the CONTENTS
+# are also load-bearing.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=pins.env
+source "$HERE/pins.env"
+
+fail=0
+
+check_pin() {
+  local spec="$1"
+  echo "--- $spec"
+  # `-s` is the modern spelling of --dry-run. Output goes to the log on
+  # failure so an unsatisfiable pin says WHICH dependency could not be met --
+  # "it failed" would send someone back to the archive by hand.
+  if apt-get install -s -y "$spec" >/tmp/apt-dry.log 2>&1; then
+    echo "    ok"
+  else
+    echo "    UNSATISFIABLE"
+    sed 's/^/      /' /tmp/apt-dry.log
+    fail=1
+  fi
+}
+
+echo "=== AC-1: pinned packages must resolve ==="
+check_pin "${KERNEL_PACKAGE}=${KERNEL_VERSION}"
+
+for spec in $PINNED_PACKAGES; do
+  [ -n "$spec" ] || continue
+  check_pin "$spec"
+done
+
+# The pin that must NOT be used, asserted as a pin rather than as a comment.
+# The metapackage resolving to something other than our held version is the
+# NORMAL state -- it floats, that is what it is for. This step exists to make
+# the gap visible in the log every run, so "why are we not just using the
+# metapackage" has a standing, dated answer.
+echo
+echo "=== AC-2: what the floating metapackage would have given us instead ==="
+floating="$(apt-cache policy linux-image-rpi-v8-rt 2>/dev/null | awk '/Candidate:/{print $2}')"
+echo "    linux-image-rpi-v8-rt candidate: ${floating:-<not found>}"
+echo "    held pin:                        ${KERNEL_VERSION}"
+if [ "${floating:-}" = "${KERNEL_VERSION}" ]; then
+  echo "    (they agree today; the pin is still what ships -- agreement is a"
+  echo "     coincidence of timing, not a reason to unpin)"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "FAIL: at least one pin is unsatisfiable."
+  echo "Correct response: re-verify against the archive and MOVE the pin."
+  echo "Never unpin to make this green -- an unpinned kernel invalidates every"
+  echo "latency number Stage 0B produces (design section 2)."
+  exit 1
+fi
+
+echo
+echo "PASS: every pin resolves."

--- a/tests/test_check_no_secrets.py
+++ b/tests/test_check_no_secrets.py
@@ -145,6 +145,35 @@ def test_a_psk_template_placeholder_does_not_fire(repo):
     assert check_content(repo, paths) == []
 
 
+def test_python_code_that_merely_mentions_a_passphrase_does_not_fire(repo):
+    """Regression: the guard flagged this project's own generator.
+
+    `passphrase = secrets.get(f"WIFI_{i}_PASSPHRASE", "")` is ordinary Python
+    with no credential in it, and the original pattern read the ASSIGNMENT
+    rather than a config VALUE. Exactly the false positive this module exists
+    to avoid, in the first file it was pointed at.
+    """
+    paths = plant(
+        repo,
+        "gen.py",
+        'passphrase = secrets.get(f"WIFI_{i}_PASSPHRASE", "")\n'
+        'if not passphrase:\n'
+        '    raise ConfigError("empty")\n'
+        'psk = wpa_psk(ssid, passphrase)\n',
+    )
+    assert check_content(repo, paths) == []
+
+
+def test_a_real_passphrase_still_fires_after_the_tightening(repo):
+    """The tightening must not have disarmed the rule it was narrowing."""
+    for line in (
+        'WIFI_1_PASSPHRASE="correct-horse-battery"',
+        "WIFI_2_PASSPHRASE=hunter2hunter2",
+        'wpa_passphrase="s3cret-workshop-key"',
+    ):
+        assert check_content(repo, plant(repo, "leak.env", line + "\n")), line
+
+
 def test_a_binary_file_is_skipped_rather_than_guessed_at(repo):
     p = repo / "blob.bin"
     p.write_bytes(bytes(range(256)))

--- a/tests/test_check_no_secrets.py
+++ b/tests/test_check_no_secrets.py
@@ -1,0 +1,171 @@
+"""Acceptance gate for the Pi credential guard (issue #182, I4).
+
+Both repositories are public and the Pi image is published to a public
+release, so `scripts/pi/check_no_secrets.py` is the control that stops a
+credential entering history. A guard nobody has tried to fool is not a
+control, so these tests plant each leak shape it claims to catch.
+
+The most load-bearing test here is the one that asserts a Cargo.lock-style
+SHA256 does NOT fire. That is the whole design: the guard is deliberately
+narrow so it stays trusted. A change that makes it broad enough to flag a
+checksum would, on this repository, flag hundreds -- and a check that cries
+wolf gets an allowlist, then `|| true`, then nothing.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts" / "pi"))
+
+from check_no_secrets import (  # noqa: E402
+    REQUIRED_GITIGNORE,
+    check_content,
+    check_gitignore,
+    check_names,
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A throwaway git repo with a conforming .gitignore."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / ".gitignore").write_text("\n".join(REQUIRED_GITIGNORE) + "\n")
+    return tmp_path
+
+
+def plant(repo, rel, text):
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    return [rel]
+
+
+# ---------------------------------------------------------------------------
+# It catches what it claims to catch.
+# ---------------------------------------------------------------------------
+
+
+def test_a_private_key_block_is_caught(repo):
+    paths = plant(
+        repo,
+        "notes.md",
+        "here is the key\n-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNz\n",
+    )
+    problems = check_content(repo, paths)
+    assert problems, "a private key block must be caught"
+    assert "private key" in problems[0]
+
+
+def test_a_populated_psk_field_is_caught(repo):
+    paths = plant(
+        repo,
+        "wifi.nmconnection.bak",
+        "[wifi-security]\nkey-mgmt=wpa-psk\npsk=8f4c2a1b9e7d6503f1a2b3c4d5e6f708\n",
+    )
+    problems = check_content(repo, paths)
+    assert problems and "psk" in problems[0]
+
+
+def test_a_filled_in_passphrase_is_caught(repo):
+    paths = plant(repo, "secrets.env", 'WIFI_1_PASSPHRASE="correct-horse-battery"\n')
+    problems = check_content(repo, paths)
+    assert problems and "passphrase" in problems[0]
+
+
+def test_a_credential_filename_is_caught_even_when_empty(repo):
+    # The filename rule is independent of content: an empty
+    # `home.nmconnection` is still a file that should never be tracked, and
+    # tomorrow it will not be empty.
+    problems = check_names(["config/home.nmconnection"])
+    assert problems and "nmconnection" in problems[0]
+
+    assert check_names(["deploy/id_ed25519"])
+    assert check_names(["certs/server.pem"])
+
+
+def test_a_missing_gitignore_entry_is_caught(repo):
+    (repo / ".gitignore").write_text("/target/\n")
+    problems = check_gitignore(repo)
+    assert len(problems) == len(REQUIRED_GITIGNORE)
+
+
+def test_no_gitignore_at_all_is_caught(tmp_path):
+    assert check_gitignore(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# It stays quiet on everything else. These matter as much as the catches:
+# the guard's value depends on nobody wanting to switch it off.
+# ---------------------------------------------------------------------------
+
+
+def test_a_cargo_lock_checksum_does_not_fire(repo):
+    """The reason this guard is not an entropy scanner.
+
+    64 hex characters is a WPA PSK. It is also every SHA256 in every lockfile
+    in this repository, and the kernel checksum verify_kernel.sh prints on
+    purpose. Flagging the shape rather than the context would make this
+    unusable on day one.
+    """
+    paths = plant(
+        repo,
+        "Cargo.lock",
+        '[[package]]\nname = "libc"\n'
+        'checksum = "a2b3c4d5e6f708192a3b4c5d6e7f80912a3b4c5d6e7f80912a3b4c5d6e7f8091"\n',
+    )
+    assert check_content(repo, paths) == []
+
+
+def test_the_example_secrets_file_does_not_fire(repo):
+    """Placeholders are not secrets.
+
+    The committed example has to show the shape of a real secrets file. If it
+    tripped the guard, the guard would be disabled within a day.
+    """
+    paths = plant(
+        repo,
+        "example.env",
+        'WIFI_1_SSID="your-home-ssid"\nWIFI_1_PASSPHRASE="your-home-passphrase"\n',
+    )
+    assert check_content(repo, paths) == []
+
+
+def test_an_empty_password_field_does_not_fire(repo):
+    paths = plant(repo, "example.env", 'PI_PASSWORD=""\nWIFI_1_PASSPHRASE=""\n')
+    assert check_content(repo, paths) == []
+
+
+def test_a_psk_template_placeholder_does_not_fire(repo):
+    """The generator's own f-string template must not flag itself."""
+    paths = plant(repo, "gen.py", 'profile = f"""\npsk={net["psk"]}\n"""\n')
+    assert check_content(repo, paths) == []
+
+
+def test_a_binary_file_is_skipped_rather_than_guessed_at(repo):
+    p = repo / "blob.bin"
+    p.write_bytes(bytes(range(256)))
+    assert check_content(repo, ["blob.bin"]) == []
+
+
+# ---------------------------------------------------------------------------
+# End to end, against the real repository.
+# ---------------------------------------------------------------------------
+
+
+def test_this_repository_is_clean():
+    """The guard passes on the tree as committed.
+
+    A red here is not a flaky test. It means a credential is in the working
+    tree, and the correct response is to rotate it -- never to adjust the
+    patterns until it goes green.
+    """
+    result = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "pi" / "check_no_secrets.py")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Two increments of #182. Stacked on #181 (the loop profiler), so its diff shrinks to just these two commits once that merges.

> **Rebase note:** both this PR and #181 were originally cut from `fix/controls/game-heading-in-attitude` and carried four unmerged s-curve commits. Master has since merged competing s-curve revisions (#180, #183, #185), which made this PR `CONFLICTING` — and GitHub does not schedule `pull_request` workflow runs when it cannot compute a merge commit, so **neither PR had run any CI at all**. Rebased onto master carrying only my own commits; both are `MERGEABLE` and running now.

---

## I0 — the D3 spike

Builds `rpi-image-gen`'s stock config in a privileged `debian:trixie` container on `ubuntu-24.04-arm` — the one axis design §3 refused to settle by argument. Acceptance is the design's own: *produces any `.img` at all*.

Written to **produce information, not to pass.** The tool's README, layout, candidate entrypoints and example configs are dumped unconditionally *before* the build is attempted, so a wrong entrypoint guess costs a one-line edit rather than another cycle. A spike that fails having printed nothing has spent the time and bought nothing. **A red `spike` job is the expected first outcome and is not a broken build.**

## AC-1 / AC-2 — the no-Pi kernel checks

`verify_pins.sh` proves every pin resolves against the live archive — the shape of check that already caught the `rpi-2712-rt` assumption. `verify_kernel.sh` downloads and unpacks the pinned kernel and asserts `mcp251xfd`, `vcan`, `gs_usb`, the Pi 5 DTB and `CONFIG_PREEMPT_RT=y`, automating exactly what was done by hand on 2026-07-27. Page size and `NO_HZ_FULL` are **recorded, not asserted** — §4 already accepted those costs.

## I4 — flash the card, place credentials, never commit one

**The constraint that shapes all of it:** the card has a FAT32 boot partition and an ext4 rootfs, macOS cannot mount ext4, and the CEO flashes from a Mac. Every byte of configuration has to land on the FAT32 side, and something on the Pi installs it at first boot. Writing NetworkManager profiles straight to `/etc/NetworkManager/system-connections/` is the obvious approach and is simply unavailable to us.

That constraint bought a better design than Imager's. Imager hooks `firstrun.sh` from `cmdline.txt` and has that script edit `cmdline.txt` back out during the same boot — a boot-critical file rewritten by a script running off it, where an interrupted first boot can leave a card that will not boot. We build the image, so `firstboot_install.sh` is a plain systemd oneshot that reads a directory and never touches `cmdline.txt`.

- **`mk_boot_config.py`** — several Wi-Fi networks with autoconnect priority (home / workshop / hotspot). Passphrases are converted to their 256-bit WPA-PSK before being written. Stated honestly in the code: **this does not protect the card** — the PSK joins the network as well as the passphrase does. It prevents the *passphrase* leaking to be tried elsewhere, and a home Wi-Fi passphrase is exactly the kind of secret that gets reused. The secrets file is **parsed, not sourced**: it holds the operator's passphrase, and sourcing it would execute whatever a stray backtick contained.
- **`flash_pi.sh`** — three independent guards on the raw write, none skippable by a flag. There is no `--force` for the internal-disk refusal, because the only reason to want one is a mistake. Credentials are built *before* the card is touched, so a typo does not cost a 20-minute write.
- **`check_no_secrets.py` + 12 tests** — deliberately **not** an entropy scanner. `Cargo.lock` carries hundreds of 64-hex SHA256s, and this repo has already written down what a noisy check costs: *"a routine override is a check that has stopped meaning anything."* The load-bearing test asserts a `Cargo.lock` checksum does **not** fire. Runs in `ci.yml`, not here, because this workflow is `paths:`-filtered and a credential can be committed by any change at all.

The real secrets file lives **outside** the repo at `~/.overboard/pi-secrets.env`. Outside rather than gitignored-inside: a gitignored file is one `git add -f` or one `git stash -u` from a public history.

**Verified locally:** refusal on a private key given where a public key was meant, on unedited example placeholders, on a world-readable secrets file; two profiles generated with correct `hidden`, priority and `0600`; no plaintext passphrase in output.

**Not verified locally:** `flash_pi.sh`'s internal-disk *discrimination*. This session blocks `diskutil`, so only the fail-closed path was exercised (unreadable device → refuse). **Run `--dry-run` against a real card before trusting it with a real one.**

## Choices worth review

**`scripts/pi/`, not `pi/`** — a new top-level directory has no `CODEOWNERS` row and falls to the CEO catch-all (`policy_check.py --who pi` confirms). Design §1 pre-provisioned `scripts/pi/` as the non-blocking fallback for exactly this.

**Nothing in `pi-image.yml` is a required check** — the spike is an experiment whose red is a finding, and the verify jobs reach a live mirror with no snapshot service, so a mirror outage must not wedge unrelated PRs.

Part of #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)