### PR TITLE
ops(routing): oracle moves to Fable 5, and gets pulled in a notch sooner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,12 +78,13 @@ finished, which has now happened three times in two days.
 Keep docs clean: prune resolved threads; keep the roadmap synced to reality.
 
 ## Model routing (project override of global)
-- **Oracle = `opus5-oracle` (Opus 5), NOT fable-oracle.** Escalate judgment here (epic scoping/sequencing, acceptance criteria, "right problem?" gate, thorny architecture/root-cause/adjudication, adversarial pre-commit review). Distill first; one call; adjudicate-not-author; read-only.
+- **Oracle = `fable-oracle` (Fable 5).** Escalate judgment here (epic scoping/sequencing, acceptance criteria, "right problem?" gate, thorny architecture/root-cause/adjudication, adversarial pre-commit review). Distill first; one call; adjudicate-not-author; read-only. `opus5-oracle` remains available and is the fallback if Fable is unreachable.
+- **Reach for the oracle a notch sooner than feels necessary.** It is the lowest-volume call in the system — one distilled question, read-only, no fan-out — so its cost is dominated by the *decisions it prevents rebuilding*, not by its tokens. The bar is still "model IQ changes the outcome", but resolve borderline cases toward escalating rather than away. Difficulty alone is still not a trigger; irreversibility is.
 - **Opus 4.8 drives; Sonnet executes** well-scoped work (`sonnet-executor`; `general-purpose`/`Explore` at `model: sonnet`). Opus reviews every hand-back.
 - **Effort is a lever:** `low`/`medium` for Sonnet + simple driver tasks, `high`/`xhigh` for oracle-grade judgment; prefer lowering effort over adding scaffolding. Opus-5 self-verifies — don't add verify passes; cap delegation and constrain scope on narrow tasks. (See global CLAUDE.md → Opus-5-era refinements, and `[[context-engineering-anthropic]]`.)
 
 ## Agent skills (Addy Osmani suite)
-Use the `agent-skills:*` suite. Judgment steps (`idea-refine`/`spec`, `plan`, `doubt-driven-development`, `code-review`, `debugging-and-error-recovery`) escalate to `opus5-oracle`; execution steps (`build`, `incremental-implementation`, `test`, `code-simplify`) delegate to Sonnet; Opus orchestrates.
+Use the `agent-skills:*` suite. Judgment steps (`idea-refine`/`spec`, `plan`, `doubt-driven-development`, `code-review`, `debugging-and-error-recovery`) escalate to `fable-oracle`; execution steps (`build`, `incremental-implementation`, `test`, `code-simplify`) delegate to Sonnet; Opus orchestrates.
 
 ## Engineering conventions
 - **Sim-in-the-loop from day one, TDD-style:** every change runs against a sim; build meaningful automated integration tests + Rust unit tests from the start. A rough visual 3D sim POC comes early (full UE5 later).


### PR DESCRIPTION
## What changed

`CLAUDE.md` → Model routing. Two edits:

1. **Oracle is now `fable-oracle` (Fable 5)**, not `opus5-oracle`. The Agent-skills line that routed judgment steps to `opus5-oracle` follows it. `opus5-oracle` stays defined as the fallback if Fable is unreachable.
2. **The escalation bar drops a notch.** Borderline cases now resolve *toward* escalating rather than away. Difficulty is still explicitly not a trigger — irreversibility is.

Nothing else moves. Sonnet still executes; Opus still drives and reviews every hand-back.

## Why

The oracle is the lowest-volume call in the org — one distilled question, read-only, no fan-out, one at a time. What it costs in tokens is dominated by what it prevents us rebuilding. That makes it the one seat where paying for the top model is straightforwardly correct, and pinning it to Opus 5 was optimising the wrong axis.

The cost question was raised and measured rather than assumed. From `ops/usage.py` (2026-08-02): **~90% of weighted spend is cache read + cache creation** — carrying context, not generating text. Oracle calls carry a distilled packet and return a verdict, so they sit at the bottom of that distribution regardless of which model answers. The meter is driven by execution volume, and that routing is unchanged.

The lowered bar is aimed at a failure mode this org has actually hit — committing to a direction nobody adjudicated, then rediscovering the problem downstream — not at a hypothetical one.

## Acceptance criteria

None move. This is a working-agreement change, not a capability change.

## Note for other roles

`CLAUDE.md` is shared across every worktree, so this takes effect for all roles on merge. If you have an oracle call in flight against `opus5-oracle`, it is still valid — the agent is not being removed.