### PR TITLE
feat(sim-host): make falls testable on demand, verify FALLEN trips

### DIFF
--- a/crates/sim-host/src/bin/send-input.rs
+++ b/crates/sim-host/src/bin/send-input.rs
@@ -15,10 +15,10 @@
 //! asks for ("drives forward, slows and reverses under lean, and turns").
 //!
 //! ```text
-//! send-input [--target ADDR] [--scenario default|s-curve]
+//! send-input [--target ADDR] [--scenario default|s-curve] [--kick-at SECONDS]
 //! ```
 
-use sim_host::wire::{InputIn, INPUT_MAGIC, INPUT_SCHEMA_VERSION};
+use sim_host::wire::{InputIn, INPUT_FLAG_KICK, INPUT_MAGIC, INPUT_SCHEMA_VERSION};
 
 type Schedule = &'static [(f64, f64, f32, f32, f32, &'static str)];
 use std::net::UdpSocket;
@@ -290,6 +290,7 @@ fn main() {
     let mut target = sim_host::wire::INPUT_IN_ADDR.to_string();
     let mut schedule: Schedule = SCHEDULE;
     let mut schedule_name = "default";
+    let mut kick_at: Option<f64> = None;
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mut i = 0;
     while i < args.len() {
@@ -299,6 +300,22 @@ fn main() {
                     eprintln!("send-input: --target needs a value");
                     std::process::exit(1);
                 });
+                i += 2;
+            }
+            // Issue #161 follow-up, item 5: "make falls testable" --
+            // triggers `wire::INPUT_FLAG_KICK` (a rising edge; sim-host
+            // debounces retriggers itself) at the given schedule time, on
+            // top of whatever the running schedule is already sending.
+            // Verification tool only -- not part of the AC schedule.
+            "--kick-at" => {
+                let v = args.get(i + 1).cloned().unwrap_or_else(|| {
+                    eprintln!("send-input: --kick-at needs a value");
+                    std::process::exit(1);
+                });
+                kick_at = Some(v.parse::<f64>().unwrap_or_else(|_| {
+                    eprintln!("send-input: --kick-at value '{v}' is not a number");
+                    std::process::exit(1);
+                }));
                 i += 2;
             }
             "--scenario" => {
@@ -332,7 +349,12 @@ fn main() {
     }
 
     let socket = UdpSocket::bind("127.0.0.1:0").expect("send-input: bind failed");
-    let duration = total_duration_s(schedule);
+    // If --kick-at lands after the schedule would otherwise end, extend the
+    // run so there is time left afterward to watch the outcome rather than
+    // the process exiting mid-fall.
+    let duration = kick_at.map_or(total_duration_s(schedule), |ka| {
+        total_duration_s(schedule).max(ka + 3.0)
+    });
     eprintln!(
         "send-input: sending to {target} for {duration:.1}s per the '{schedule_name}' schedule"
     );
@@ -341,6 +363,7 @@ fn main() {
     let period = Duration::from_millis(20);
     let mut seq: u64 = 0;
     let mut last_label = "";
+    let mut kick_logged = false;
 
     loop {
         let t = start.elapsed().as_secs_f64();
@@ -354,10 +377,19 @@ fn main() {
             );
             last_label = label;
         }
+        // One-shot rising edge: held for a couple of packets (40 ms) so a
+        // single dropped UDP datagram cannot silently swallow the whole
+        // kick, but not held so long it would look like a second press.
+        let in_kick_window = kick_at.is_some_and(|ka| (ka..ka + 0.04).contains(&t));
+        if in_kick_window && !kick_logged {
+            eprintln!("send-input: t={t:6.2}s -> KICK");
+            kick_logged = true;
+        }
+        let flags = if in_kick_window { INPUT_FLAG_KICK } else { 0 };
         let pkt = InputIn {
             magic: INPUT_MAGIC,
             schema_version: INPUT_SCHEMA_VERSION,
-            flags: 0,
+            flags,
             seq,
             weight_shift_fore_aft: fore_aft,
             weight_shift_lateral: lateral,

--- a/crates/sim-host/src/bin/wire-probe.rs
+++ b/crates/sim-host/src/bin/wire-probe.rs
@@ -23,7 +23,7 @@
 //! `sim-host`'s dead-reckoned game path, NOT raw MuJoCo x/y -- see
 //! `sim_host::wire::StateOut::pos`'s doc comment.
 
-use sim_host::wire::{StateOut, STATE_MAGIC, STATE_SCHEMA_VERSION};
+use sim_host::wire::{StateOut, STATE_FLAG_FALLEN, STATE_MAGIC, STATE_SCHEMA_VERSION};
 use std::net::UdpSocket;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -91,6 +91,11 @@ struct CsvRow {
     /// `sim_host::wire::StateOut::rider_fore_aft_m`'s doc comment.
     rider_fore_aft_m: f32,
     rider_lateral_m: f32,
+    /// Raw `StateOut::flags`, decoded off the wire (not recomputed from
+    /// `pitch_rad`) -- issue #161 follow-up, item 5: verifying `FALLEN`
+    /// actually trips means checking what actually went out over the wire,
+    /// not re-deriving the same threshold this column is supposed to check.
+    fallen: bool,
 }
 
 fn percentile(sorted_ms: &[f64], p: f64) -> f64 {
@@ -197,6 +202,7 @@ fn main() {
                             motor_current_a: state.motor_current_a,
                             rider_fore_aft_m: rider_fore_aft,
                             rider_lateral_m: rider_lateral,
+                            fallen: state.flags & STATE_FLAG_FALLEN != 0,
                         });
                     }
                 }
@@ -304,11 +310,11 @@ fn main() {
 
     if let Some(path) = &args.csv {
         let mut out = String::from(
-            "seq,sim_time_s,pos_x_m,pos_y_m,pitch_rad,yaw_rad,wheel_rate_rad_s,motor_current_a,rider_fore_aft_m,rider_lateral_m\n",
+            "seq,sim_time_s,pos_x_m,pos_y_m,pitch_rad,yaw_rad,wheel_rate_rad_s,motor_current_a,rider_fore_aft_m,rider_lateral_m,fallen\n",
         );
         for r in &csv_rows {
             out.push_str(&format!(
-                "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6}\n",
+                "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{}\n",
                 r.seq,
                 r.sim_time_s,
                 r.pos_x_m,
@@ -318,7 +324,8 @@ fn main() {
                 r.wheel_rate_rad_s,
                 r.motor_current_a,
                 r.rider_fore_aft_m,
-                r.rider_lateral_m
+                r.rider_lateral_m,
+                r.fallen
             ));
         }
         match std::fs::write(path, out) {

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -325,6 +325,36 @@ const STARTUP_KICK_T0_S: f64 = 1.0;
 const STARTUP_KICK_DURATION_S: f64 = 0.05;
 const STARTUP_KICK_FORCE_N: [f64; 3] = [-(20.0 / STARTUP_KICK_DURATION_S), 0.0, 0.0];
 
+/// An ON-DEMAND disturbance (issue #161 follow-up, item 5): "make falls
+/// testable" -- a repeatable, rising-edge-triggered "knock the board over
+/// now" via [`wire::INPUT_FLAG_KICK`], reusing this same
+/// `apply_external_force` mechanism the startup kick above already gates.
+/// Deliberately a SEPARATE, much larger magnitude, not a reuse of
+/// `STARTUP_KICK_FORCE_N` -- that one is sized to be RECOVERABLE (its own
+/// doc comment: "a guaranteed disturbance to show recovery FROM"), and
+/// measurement confirmed it as such on this plant: `wire-probe --csv`
+/// against the 20 N*s/0.05 s startup kick alone never crossed
+/// `FALLEN_PITCH_RAD` -- pitch stayed within a few degrees and recovered.
+/// This one is sized to reliably NOT be recoverable. Measured
+/// (`wire-probe --csv`'s new `fallen` column, decoded off the actual wire
+/// bytes -- not re-derived from `pitch_rad` -- board at rest, zero
+/// weight-shift/steer throughout, the ONLY input the whole run): 400 N*s
+/// over 0.05 s (20x the startup kick) crossed `FALLEN_PITCH_RAD` (20 deg)
+/// ~0.056 s after the kick's own force-application window (measured against
+/// SIMULATED time, i.e. tick count * `DT_S` -- a verification run under this
+/// dev sandbox's CPU contention showed the sender's own wall clock and the
+/// host's simulated clock can drift apart by multiple real seconds, so this
+/// crate's other schedule-timed tools, e.g. `send-input`'s wall-clock
+/// `--kick-at`, should not be trusted for tight timing correlation here).
+/// The board then went past a full flip (+-180 deg) and stayed there for
+/// the rest of a 10 s run -- genuinely unrecoverable, not borderline. Same
+/// direction/torque convention as the startup kick (force along -X, zero
+/// applied torque -- the pitching moment comes from the wheel-ground
+/// contact being below the force's application point, not from any
+/// deliberately-applied torque).
+const FALL_KICK_DURATION_S: f64 = 0.05;
+const FALL_KICK_FORCE_N: [f64; 3] = [-(400.0 / FALL_KICK_DURATION_S), 0.0, 0.0];
+
 /// Default path for the host's own missed-deadline/tick counters -- internal
 /// tooling for `wire-probe`, NOT part of the Unreal wire (issue #161's wire
 /// table has no room for either, and must not grow one for our own
@@ -403,6 +433,7 @@ struct LatestInput {
     steer: f32,
     armed_bit: bool,
     reset_bit: bool,
+    kick_bit: bool,
 }
 
 impl From<InputIn> for LatestInput {
@@ -414,6 +445,7 @@ impl From<InputIn> for LatestInput {
             steer: p.steer,
             armed_bit: flags & wire::INPUT_FLAG_ARM != 0,
             reset_bit: flags & wire::INPUT_FLAG_RESET != 0,
+            kick_bit: flags & wire::INPUT_FLAG_KICK != 0,
         }
     }
 }
@@ -500,6 +532,14 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     let mut latest_input_at: Option<Instant> = None;
     let mut prev_armed_bit = false;
     let mut prev_reset_bit = false;
+    let mut prev_kick_bit = false;
+    // `Some(t)` while an on-demand fall kick (issue #161 follow-up, item 5)
+    // is in its force-application window, `t` being the sim time it started
+    // -- mirrors `STARTUP_KICK_T0_S`'s fixed window but anchored to whenever
+    // the rising edge arrived rather than a fixed offset from run start.
+    // `None` both before the first trigger and again once a window has
+    // finished, so a later rising edge can retrigger it.
+    let mut fall_kick_window_start_s: Option<f64> = None;
     let mut prev_outside_corridor = false;
     let mut yaw_rad: f32 = 0.0;
     let mut wheel_angle_rad: f32 = 0.0;
@@ -613,6 +653,19 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         prev_armed_bit = input_armed_bit;
         prev_reset_bit = input_reset_bit;
 
+        // On-demand fall kick (issue #161 follow-up, item 5): rising-edge
+        // triggered, like `reset` above, so holding the bit does not restart
+        // it every tick. Does not retrigger while a window is already in
+        // progress (`fall_kick_window_start_s` only goes back to `None`
+        // once that window's force-application section below has finished
+        // it) -- one kick per press.
+        let input_kick_bit = !stale && latest_input.kick_bit;
+        if input_kick_bit && !prev_kick_bit && fall_kick_window_start_s.is_none() {
+            eprintln!("sim-host: input kick bit set -- inducing a fall");
+            fall_kick_window_start_s = Some(t_known_s);
+        }
+        prev_kick_bit = input_kick_bit;
+
         // Speed cap (issue #161 follow-up, MAX_GROUND_SPEED_M_S's own doc
         // comment) -- attenuates weight_shift_fore_aft, not the wheel speed
         // itself: if the board is already moving in the SAME direction this
@@ -683,8 +736,23 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let in_kick_window = cfg.startup_kick
             && (STARTUP_KICK_T0_S..STARTUP_KICK_T0_S + STARTUP_KICK_DURATION_S)
                 .contains(&t_known_s);
+        // On-demand fall kick (issue #161 follow-up, item 5) -- same
+        // pre-step-time window check as the startup kick above, just
+        // anchored to `fall_kick_window_start_s` instead of a fixed
+        // `STARTUP_KICK_T0_S`. Cleared back to `None` once the window has
+        // elapsed so a later rising edge can retrigger it (see where it is
+        // set, above).
+        let in_fall_kick_window = fall_kick_window_start_s
+            .is_some_and(|t0| (t0..t0 + FALL_KICK_DURATION_S).contains(&t_known_s));
+        if let Some(t0) = fall_kick_window_start_s {
+            if t_known_s >= t0 + FALL_KICK_DURATION_S {
+                fall_kick_window_start_s = None;
+            }
+        }
         let force = if in_kick_window {
             STARTUP_KICK_FORCE_N
+        } else if in_fall_kick_window {
+            FALL_KICK_FORCE_N
         } else {
             [0.0; 3]
         };

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -45,6 +45,17 @@ pub const STATE_FLAG_FALLEN: u16 = 1 << 2;
 pub const INPUT_FLAG_ARM: u16 = 1 << 0;
 /// `InputIn::flags` bit 1.
 pub const INPUT_FLAG_RESET: u16 = 1 << 1;
+/// `InputIn::flags` bit 2 -- issue #161 follow-up, item 5: an on-demand
+/// disturbance, rising-edge triggered (send it once, not held), for making
+/// falls testable rather than something you only ever get by accident. Same
+/// `apply_external_force` mechanism `crate::host`'s gated startup kick
+/// already uses, sized instead to reliably cross `crate::host`'s
+/// `FALLEN_PITCH_RAD` -- see that constant's own doc comment for the
+/// measured magnitude and why the startup kick's is not reused as-is.
+/// `InputIn::schema_version` is unchanged: this is a new bit within the
+/// existing `flags` field, not a wider wire, so it is backward compatible
+/// with any sender not yet setting it (reads as 0, no kick).
+pub const INPUT_FLAG_KICK: u16 = 1 << 2;
 
 /// Host SENDS state here.
 pub const STATE_OUT_ADDR: &str = "127.0.0.1:9601";


### PR DESCRIPTION
## What
Item 5 of the CEO's dispatch (issue #161 follow-up): "make falls testable" -- a repeatable, on-demand way to knock the board over, plus a real measurement (not a read of the threshold) confirming the `FALLEN` wire flag actually trips.

## Mechanism
- New `InputIn::flags` bit 2, `INPUT_FLAG_KICK` (wire.rs) -- rising-edge triggered, same `apply_external_force` plumbing the existing gated startup kick uses, tracked the same way `reset_bit` already is.
- `send-input --kick-at SECONDS` fires it (verification tool only, not the AC schedule).
- `wire-probe --csv` gains a `fallen` column decoded directly off the raw wire bytes, so verification checks the actual flag on the wire, not a re-derivation of the same threshold.

## Why the existing startup kick wasn't reused as-is
Measured: the existing 20 N*s startup kick is genuinely recoverable on this plant (consistent with its own doc comment -- it exists to show recovery FROM a disturbance). A distinct, larger magnitude was needed for "induce a fall."

## Verification (real measurements)
- Isolated a minimal test sender (zero weight-shift/steer the whole run, kick only) to rule out any confound from a concurrent schedule.
- 400 N*s over 0.05 s (20x the startup kick) produced a genuine, unrecoverable fall: `FALLEN` crossed ~56 ms after the kick's own force-application window (measured against the host's simulated clock).
- The wire's raw `fallen` bit matched the pitch-threshold crossing exactly -- confirms the actual on-wire flag trips, not just an internal variable.
- Also on record: this dev sandbox's CPU contention was measured to let a sender's wall clock and the host's simulated clock drift apart by multiple real seconds -- `send-input`'s own `--kick-at` wall-clock timing should not be trusted for tight correlation here. Worth knowing for future verification work in this environment.
- `cargo build/fmt/clippy/test --workspace` all clean.

## Not in scope here
The CEO's report of the rider ending up "below the ground plane" is a renderer-side concern (`overboard-game`) -- this PR confirms the wire-level `FALLEN` signal is correct and timely; whether the renderer reacts to it is outside this repo's boundary.