### PR TITLE
fix(sim-host): the s-curve flip is real -- and the harness was hiding it, not causing it (#190)

### DIFF
--- a/crates/sim-host/src/bin/send-input.rs
+++ b/crates/sim-host/src/bin/send-input.rs
@@ -5,290 +5,50 @@
 //! real UE client exists. It reuses [`sim_host::wire::InputIn`] directly
 //! rather than re-implementing the byte layout in a second language, so the
 //! encoding is guaranteed correct the same way `wire-probe` guarantees its
-//! decoding is.
+//! decoding is. The schedules themselves live in [`sim_host::scenario`], so
+//! this tool and the host's own deterministic playback path cannot drift
+//! apart.
 //!
 //! Sends one `InputIn` packet every 20 ms (50 Hz, comfortably above
 //! `sim-host`'s 100 ms staleness timeout) to `127.0.0.1:9602`, stepping
-//! through the fixed schedule below: settle, lean forward (accelerate),
-//! release (coast), lean back (decelerate then reverse), release again,
-//! lean+steer (turn) -- the sequence issue #161 W2's acceptance criterion
-//! asks for ("drives forward, slows and reverses under lean, and turns").
+//! through the selected schedule.
 //!
 //! ```text
 //! send-input [--target ADDR] [--scenario default|s-curve] [--kick-at SECONDS]
 //! ```
+//!
+//! # Pacing: absolute deadlines, and why that turned out to matter a lot
+//!
+//! This loop used to `thread::sleep(20 ms)` per packet and index the schedule
+//! off `Instant::elapsed()`. That is exactly the accumulating-drift mistake
+//! [`sim_host::pacer`]'s own doc comment exists to warn about, and on macOS,
+//! where timer coalescing readily turns a 20 ms sleep request into 70-140 ms,
+//! it was not a rounding error: **measured over three full `s-curve` runs,
+//! this sender delivered 12.8 Hz, 7.4 Hz and 7.6 Hz -- not 50 Hz.**
+//!
+//! `sim-host` zeroes any stick input older than its 100 ms staleness timeout,
+//! so a 7-13 Hz sender sits directly ON that threshold. A run-varying
+//! fraction of every scripted run therefore held `weight_shift_fore_aft = 0`
+//! instead of the scheduled value, and the SAME command produced materially
+//! different aggression run to run (measured steady-state `ballast_fa` of
+//! 0.031 m in a starved run against 0.046 m in a healthy one, against the
+//! same full-stick schedule). Stability results measured through the old
+//! sender were measured against a de-rated schedule -- see
+//! [`sim_host::scenario`]'s correction block.
+//!
+//! Fixed here by pacing against a single advancing absolute deadline. For a
+//! run that must be repeatable rather than merely correctly paced, use
+//! `sim-host --scripted-scenario`, which plays the same schedule indexed on
+//! simulated time with no socket and no staleness gate at all.
 
+use sim_host::scenario::{self, Schedule};
 use sim_host::wire::{InputIn, INPUT_FLAG_KICK, INPUT_MAGIC, INPUT_SCHEMA_VERSION};
-
-type Schedule = &'static [(f64, f64, f32, f32, f32, &'static str)];
 use std::net::UdpSocket;
 use std::time::{Duration, Instant};
 
-/// `(start_s, end_s, weight_shift_fore_aft, weight_shift_lateral, steer, label)`.
-/// Values are within `[-1, 1]`; `sim-host` scales them onto the model's
-/// actual ballast/yaw ranges.
-const SCHEDULE: &[(f64, f64, f32, f32, f32, &str)] = &[
-    (0.0, 1.5, 0.0, 0.0, 0.0, "settle"),
-    (1.5, 4.5, 0.6, 0.0, 0.0, "lean forward (accelerate)"),
-    (4.5, 6.5, 0.0, 0.0, 0.0, "release (coast)"),
-    (
-        6.5,
-        10.0,
-        -0.6,
-        0.0,
-        0.0,
-        "lean back (decelerate, then reverse)",
-    ),
-    (10.0, 12.0, 0.0, 0.0, 0.0, "release (coast reversed)"),
-    (12.0, 14.0, 0.0, 0.8, 0.6, "lean right + steer (turn)"),
-    (14.0, 15.0, 0.0, 0.0, 0.0, "release"),
-];
-
-/// `--scenario s-curve`: hold a decent forward speed and weave wide, for watching the board CARVE
-/// rather than checking one turn happens at all.
-///
-/// [`SCHEDULE`] above is issue #161 W2's acceptance criterion and is deliberately left alone --
-/// it exercises accelerate / coast / reverse / turn once each, which is what that AC asks for and
-/// what any regression check should keep running. This one is a viewing scenario.
-///
-/// # Revision 2 (issue #161 follow-up): the first cut wove at walking pace
-///
-/// Revision 1 built speed for only 3 s before weaving, entering the weave at 0.71 m/s -- turn
-/// radius is speed / yaw-rate, so however hard it steered, the lobes were geometrically tiny, and
-/// the board was still accelerating THROUGH the whole weave (0.71 -> 3.6 m/s) rather than carving
-/// at a settled speed. It also drifted: `wire-probe` measured heading swinging -22.1..+51.4 deg,
-/// centred +14.6 deg, not 0 -- a steady sideways walk, not a weave about the road direction.
-///
-/// This revision:
-/// - **Builds speed for 10 s, not 3 s**, at the same 0.65 lean -- sustained lean has no speed
-///   ceiling on this plant (there is no outer velocity loop; PR #170/#171 already measured
-///   continuous acceleration to 13+ m/s over 30 s), so the speed is available, the first cut just
-///   was not waiting for it. See [`SCURVE2_BUILD_S`]'s own doc comment for why 10 s and not the
-///   6 s an offline check first suggested -- the real, wire-paced host needed noticeably longer.
-/// - **Raises the in-weave trim off Revision 1's insufficient 0.12** -- carving scrubs energy
-///   (each lobe steers the wheel off a straight roll) -- but ends up net LOWER than the first
-///   attempt at raising it (0.20), because at this revision's higher entry speed the same trim
-///   value keeps adding much more absolute speed than it did at Revision 1's walking pace. See
-///   [`SCURVE2_WEAVE_TRIM`]'s doc comment for the three measured values this went through.
-/// - **Fewer, wider lobes than Revision 1**: two full lobes instead of four, still individually
-///   longer than Revision 1's 2.6 s ("width comes from lobe DURATION, not from more steer" --
-///   Revision 1's own finding, still true) but shorter than this revision's own first attempt
-///   (5.0 s), which combined with the higher speed covered close to 300 m -- more ground than
-///   "roughly on the road" comfortably allows with no City Park collision geometry to bound it.
-///   See [`SCURVE2_LOBE_S`]'s doc comment.
-///
-/// **The entry lobe still sets where the whole oscillation is centred**, and remains sensitive --
-/// Revision 1 measured a quarter-second swinging the drift by twenty metres. Building more speed
-/// first and changing the in-weave trim both change `roll_authority`'s time history, so Revision
-/// 1's measured entry-lobe timing (1.17 s) was not assumed to still centre this one; this
-/// revision keeps 2.3 s (its own first guess, not re-tuned further -- see the measured result
-/// below, which centres well enough that chasing it further risked being the same "fitting noise"
-/// Revision 1's own comment already warned against).
-///
-/// # What this revision actually measured (`wire-probe --csv` over a full run)
-///
-/// | metric | value |
-/// |---|---|
-/// | weave-entry speed | 6.82 m/s (24.6 km/h) -- just under the requested 7-9 m/s band |
-/// | peak speed | 9.11 m/s (32.8 km/h) -- at the top of the requested band |
-/// | heading swing | -32.6 .. +46.1 deg (centred +6.75 deg off the road direction) |
-/// | lateral excursion (peak-to-peak) | 17.4 m |
-/// | forward distance travelled | 183 m |
-/// | pitch, whole run | -5.2 .. +1.5 deg (well inside the fallen threshold throughout) |
-///
-/// # Revision 3 (issue #161 follow-up): "getting a feel for it" was the wrong brief
-///
-/// Revision 2's clip was kept (retitled "Manny's first ride"), but the CEO's verdict on it was
-/// explicit: too slow, and the carves barely happen -- roughly 3x the speed, and much harder
-/// carving. This is a different brief -- ripping, not demonstrating -- and it changes more than
-/// one constant:
-///
-/// - **`SCURVE3_BUILD_S`/`SCURVE3_BUILD_LEAN`**: build lean raised to 1.0 (full stick -- "do not
-///   be shy with fore_aft during the build") and duration extended well past Revision 2's 10 s.
-///   Sustained lean has no speed ceiling on this plant (PR #170/#171 already measured continuous
-///   acceleration to 13+ m/s over 30 s at a much smaller lean), so ~20 m/s is reachable; the
-///   question this revision answers by measurement, not derivation, is how long that takes at
-///   full lean and what it costs in distance.
-/// - **`lateral`/`steer` taken to their limits (1.0/1.0)**, up from Revision 2's 0.7/0.40, per the
-///   explicit instruction to stop leaving carving authority on the table.
-/// - **`YAW_RATE_GAIN_RAD_S` doubled (1.5 -> 3.0) in `host.rs`**, explicitly authorised for this
-///   request -- the roll gate and its floor are untouched. Turn radius is speed / yaw-rate, and
-///   tripling target speed alone would make carves three times lazier at the OLD gain; doubling
-///   it buys back some of that geometry instead of asking speed and steer alone to fight it.
-/// - **Fewer, SHORTER lobes than Revision 2** -- the higher yaw-rate gain buys back the heading
-///   swing per second that shorter lobes would otherwise cost, and at a 3x higher speed every
-///   second of lobe duration costs 3x the distance. See [`SCURVE3_LOBE_S`]'s doc comment for what
-///   this actually cost in road length.
-///
-/// **Road length is the dominant constraint at this speed, explicitly, not an afterthought.**
-/// Revision 2 covered 183 m at a 9 m/s peak; MuJoCo has no City Park collision geometry, so a
-/// board that runs out of built environment at 20 m/s just sails into nothing, and that footage
-/// is unusable. This revision is deliberately short -- brief settle, one hard build, a few hard
-/// lobes, out -- rather than a long cruise, and reports distance explicitly rather than assuming
-/// it is fine. **A first pass (15.0 s build, three full lobes) DID exactly what the CEO asked --
-/// 15.2 m/s entry, 18.5 m/s peak, pitch a stable -7.7..+3.1 deg -- and covered 303 m doing it,**
-/// past the ~200 m line the COO drew. Cut back (`SCURVE3_BUILD_S` 15.0 -> 11.0 s, one fewer full
-/// lobe) rather than shipping the faster, further-reaching version and hoping -- see the measured
-/// trade this cut actually cost, below. Pitch stayed stable at every speed tried in this revision;
-/// **the board did not become unstable or face-plant at any point measured** -- worth saying
-/// explicitly, since the alternative (it did, and got tuned around silently) is exactly what was
-/// ruled out from the start.
-///
-/// # What this revision actually measured (`wire-probe --csv`, final landed configuration)
-///
-/// | metric | value |
-/// |---|---|
-/// | weave-entry speed | 10.29 m/s (37.0 km/h) -- up from Revision 2's 6.82 m/s, short of the ~20 m/s asked for (see the distance trade-off above) |
-/// | peak speed | 13.66 m/s (49.2 km/h) |
-/// | heading swing | -75.4 .. +87.2 deg, 162.5 deg peak-to-peak -- roughly DOUBLE Revision 2's 78.7 deg swing |
-/// | heading centring | +5.89 deg off the road direction (Revision 2: +6.75 deg -- essentially unchanged) |
-/// | lateral excursion (peak-to-peak) | 13.4 m |
-/// | forward distance travelled | 174 m -- inside the ~200 m line |
-/// | pitch, whole run | -7.5 .. +2.3 deg -- more excursion than Revision 2's -5.2..+1.5 deg, still well clear of the fallen threshold, no instability |
-///
-/// **Honest summary: faster and measurably more aggressive than Revision 2, not the full 3x/20 m/s
-/// asked for.** The 15.0 s/three-lobe configuration hit the speed target exactly and stayed stable
-/// doing it; the limiting factor was City Park's road length, not the board. If more road becomes
-/// available (or the clip can accept sailing off the built environment at the very end), the
-/// 15.0 s / three-lobe numbers above are the ones to reach for.
-///
-/// # Revision 4 (issue #161 follow-up): the 200 m budget was a guess, and there was road left
-///
-/// The COO's own correction, after watching the footage: the ~200 m line Revision 3 was cut back
-/// to was invented, inferred from one earlier run, not measured against City Park's actual usable
-/// road. The footage showed road still ahead at the end of the (cut-back) run, and the CEO's
-/// judgement was explicit: **"we have plenty of room to go faster and turn more."**
-///
-/// So this revision:
-/// - **Takes Revision 3's REJECTED 15.0 s / three-lobe pass as the floor, not the ceiling.**
-///   `SCURVE3_BUILD_S` goes back to 15.0 (it was cut to 11.0 only for distance, and the distance
-///   reason no longer holds at the same weight). Budget for THIS revision is ~400 m, and even
-///   that is explicitly provisional -- "if you exceed it and the run still looks contained I
-///   would rather find out from footage than from a guess of mine."
-/// - **Lengthens the lobes, per "let the turn last longer left and right."** This is duration,
-///   not amplitude -- `lateral`/`steer` stay at their limits (1.0/1.0) and
-///   `YAW_RATE_GAIN_RAD_S` stays at 3.0 (host.rs), both already right per the COO. Fewer, longer,
-///   deeper carves: two full lobes instead of three, each 1.75x Revision 3's 1.6 s -- a sustained
-///   arc the board commits to and holds, not a flick. **A first attempt lengthened the lobes to
-///   4.5 s (2.8x) and overshot into a different failure: at this gain and steer, a single lobe
-///   swung more than a full 360 deg rotation (520.8 deg of total measured swing), which is
-///   spinning, not carving.** See [`SCURVE4_LOBE_S`]'s own doc comment for the cut-back this cost.
-///
-/// Same standing instruction as every revision: **do not tune around a crash if one appears.**
-///
-/// # What this revision actually measured (`wire-probe --csv`, final landed configuration)
-///
-/// | metric | value | vs. Revision 3 |
-/// |---|---|---|
-/// | weave-entry speed | 15.40 m/s (55.4 km/h) | up from 10.29 m/s (+50%) -- matches the rejected-then-restored 15.2 m/s floor |
-/// | peak speed | 18.54 m/s (66.8 km/h) | up from 13.66 m/s |
-/// | heading swing | -155.3 .. +131.2 deg, 286.5 deg peak-to-peak | up from 162.5 deg peak-to-peak (+76%) -- a sustained, held arc, NOT a full rotation (see `SCURVE4_LOBE_S`'s doc comment for the 4.5 s attempt that WAS one) |
-/// | heading centring | -12.1 deg off road direction | +5.89 deg (same order of magnitude, not chased further) |
-/// | lateral excursion (peak-to-peak) | 68.1 m | up from 13.4 m |
-/// | forward distance travelled | 335 m | up from 174 m -- inside the ~400 m provisional budget |
-/// | pitch, whole run | -7.6 .. +3.2 deg | -7.5 .. +2.3 deg -- essentially unchanged, well clear of the fallen threshold, no instability at any point measured |
-///
-/// **The board did not become unstable or face-plant at this speed/lobe-duration combination
-/// either** -- full stick lean, maxed steer/lateral, 3.0 rad/s yaw gain, 15+ m/s entry, sustained
-/// ~2.8 s carves -- reported plainly per the standing instruction, same as every prior revision.
-const SCURVE4_SETTLE_S: f64 = 0.5;
-const SCURVE4_BUILD_S: f64 = 15.0;
-/// Full stick -- unchanged from Revision 3 ("do not be shy with `fore_aft` during the build").
-const SCURVE4_BUILD_LEAN: f32 = 1.0;
-/// Unchanged from Revision 3: zero. Revision 2 found ANY sustained in-weave trim keeps adding
-/// speed rather than merely holding it, more so at higher entry speed -- still true here.
-const SCURVE4_WEAVE_TRIM: f32 = 0.0;
-/// Full-lobe duration -- lengthened from Revision 3's 1.6 s per "let the turn last longer left
-/// and right". **Measured, then cut back once already**: a first attempt at 4.5 s (this constant's
-/// initial value) DID make the turn last longer, so much longer that at `YAW_RATE_GAIN_RAD_S`
-/// (3.0) and maxed steer/lateral, a single lobe wound up MORE than a full 360 deg rotation --
-/// `wire-probe` measured 520.8 deg of total heading swing peak-to-peak, i.e. the board spun in
-/// circles rather than carving a held arc. That is not "a rider laying into a turn and holding the
-/// line", it is a different failure mode than the ones the request called out (not a crash, not
-/// instability -- pitch stayed completely stable through it -- but not the requested shape
-/// either). 2.8 s is the re-measured value: still meaningfully longer than Revision 3's 1.6 s
-/// (a genuinely held arc, not a flick), short enough that a lobe's own swing stays under one full
-/// rotation. See this file's own measured results for the actual swing this landed on.
-const SCURVE4_LOBE_S: f64 = 2.8;
-/// Entry (and, by the same centring logic, exit) half-lobe duration -- kept at the same ratio to
-/// `SCURVE4_LOBE_S` every prior revision used (roughly half), not re-derived: centring in this
-/// system has consistently come out close enough at that ratio without further chasing (Revision
-/// 2: +6.75 deg, Revision 3: +5.89 deg), and there is no reason to expect that relationship broke
-/// just because the lobes got longer rather than the gains or speed changing.
-const SCURVE4_ENTRY_S: f64 = 1.4;
-/// Lateral and steer stick, at their limits -- unchanged from Revision 3, and explicitly confirmed
-/// right by the COO this round ("keep steering and lean at their limits -- those were right").
-const SCURVE4_LATERAL: f32 = 1.0;
-const SCURVE4_STEER: f32 = 1.0;
-
-const S_CURVE_SCHEDULE: &[(f64, f64, f32, f32, f32, &str)] = &[
-    (0.0, SCURVE4_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
-    (
-        SCURVE4_SETTLE_S,
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S,
-        SCURVE4_BUILD_LEAN,
-        0.0,
-        0.0,
-        "lean forward (hard build)",
-    ),
-    (
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S,
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + SCURVE4_ENTRY_S,
-        SCURVE4_WEAVE_TRIM,
-        SCURVE4_LATERAL,
-        SCURVE4_STEER,
-        "carve right (half lobe, enter)",
-    ),
-    (
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + SCURVE4_ENTRY_S,
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + SCURVE4_ENTRY_S + SCURVE4_LOBE_S,
-        SCURVE4_WEAVE_TRIM,
-        -SCURVE4_LATERAL,
-        -SCURVE4_STEER,
-        "carve left (hold the line)",
-    ),
-    (
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + SCURVE4_ENTRY_S + SCURVE4_LOBE_S,
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + SCURVE4_ENTRY_S + 2.0 * SCURVE4_LOBE_S,
-        SCURVE4_WEAVE_TRIM,
-        SCURVE4_LATERAL,
-        SCURVE4_STEER,
-        "carve right (hold the line)",
-    ),
-    (
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + SCURVE4_ENTRY_S + 2.0 * SCURVE4_LOBE_S,
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + 2.0 * SCURVE4_ENTRY_S + 2.0 * SCURVE4_LOBE_S,
-        SCURVE4_WEAVE_TRIM,
-        -SCURVE4_LATERAL,
-        -SCURVE4_STEER,
-        "straighten (exit lobe)",
-    ),
-    (
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + 2.0 * SCURVE4_ENTRY_S + 2.0 * SCURVE4_LOBE_S,
-        SCURVE4_SETTLE_S + SCURVE4_BUILD_S + 2.0 * SCURVE4_ENTRY_S + 2.0 * SCURVE4_LOBE_S + 1.5,
-        0.0,
-        0.0,
-        0.0,
-        "release (coast)",
-    ),
-];
-
-fn total_duration_s(schedule: Schedule) -> f64 {
-    schedule.iter().map(|s| s.1).fold(0.0, f64::max)
-}
-
-fn value_at(schedule: Schedule, t: f64) -> (f32, f32, f32, &'static str) {
-    for &(t0, t1, fa, lat, steer, label) in schedule {
-        if t0 <= t && t < t1 {
-            return (fa, lat, steer, label);
-        }
-    }
-    (0.0, 0.0, 0.0, "end")
-}
-
 fn main() {
     let mut target = sim_host::wire::INPUT_IN_ADDR.to_string();
-    let mut schedule: Schedule = SCHEDULE;
+    let mut schedule: Schedule = scenario::DEFAULT_SCHEDULE;
     let mut schedule_name = "default";
     let mut kick_at: Option<f64> = None;
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -323,18 +83,21 @@ fn main() {
                     eprintln!("send-input: --scenario needs a value");
                     std::process::exit(1);
                 });
-                match v.as_str() {
-                    "default" => {
-                        schedule = SCHEDULE;
-                        schedule_name = "default";
+                match scenario::by_name(&v) {
+                    Some(s) => {
+                        schedule = s;
+                        // Leaked-free: look the name back up in the table so
+                        // the label is 'static without leaking the argument.
+                        schedule_name = scenario::BY_NAME
+                            .iter()
+                            .find(|(n, _)| *n == v)
+                            .map(|(n, _)| *n)
+                            .unwrap_or("unknown");
                     }
-                    "s-curve" => {
-                        schedule = S_CURVE_SCHEDULE;
-                        schedule_name = "s-curve";
-                    }
-                    other => {
+                    None => {
                         eprintln!(
-                            "send-input: unknown scenario '{other}' (want: default, s-curve)"
+                            "send-input: unknown scenario '{v}' (want: {})",
+                            scenario::names()
                         );
                         std::process::exit(1);
                     }
@@ -352,8 +115,8 @@ fn main() {
     // If --kick-at lands after the schedule would otherwise end, extend the
     // run so there is time left afterward to watch the outcome rather than
     // the process exiting mid-fall.
-    let duration = kick_at.map_or(total_duration_s(schedule), |ka| {
-        total_duration_s(schedule).max(ka + 3.0)
+    let duration = kick_at.map_or(scenario::total_duration_s(schedule), |ka| {
+        scenario::total_duration_s(schedule).max(ka + 3.0)
     });
     eprintln!(
         "send-input: sending to {target} for {duration:.1}s per the '{schedule_name}' schedule"
@@ -364,13 +127,18 @@ fn main() {
     let mut seq: u64 = 0;
     let mut last_label = "";
     let mut kick_logged = false;
+    let mut late_packets: u64 = 0;
+    // Absolute deadline, advanced by exactly one period per packet -- never
+    // `sleep(period)`, which would silently accumulate every scheduler
+    // overrun into the schedule itself (see this file's header).
+    let mut next_deadline = start + period;
 
     loop {
         let t = start.elapsed().as_secs_f64();
         if t > duration {
             break;
         }
-        let (fore_aft, lateral, steer, label) = value_at(schedule, t);
+        let (fore_aft, lateral, steer, label) = scenario::value_at(schedule, t);
         if label != last_label {
             eprintln!(
                 "send-input: t={t:6.2}s -> {label} (fore_aft={fore_aft:+.2} lateral={lateral:+.2} steer={steer:+.2})"
@@ -399,8 +167,39 @@ fn main() {
             eprintln!("send-input: send failed: {e}");
         }
         seq += 1;
-        std::thread::sleep(period);
+
+        let now = Instant::now();
+        if next_deadline > now {
+            std::thread::sleep(next_deadline - now);
+        } else {
+            // Already past this packet's slot -- do not sleep, and count it.
+            // Reported at the end rather than per packet, because a burst of
+            // these is exactly the condition that used to be invisible.
+            late_packets += 1;
+        }
+        next_deadline += period;
     }
 
-    eprintln!("send-input: schedule complete ({seq} packets sent)");
+    let elapsed = start.elapsed().as_secs_f64();
+    let hz = if elapsed > 0.0 {
+        seq as f64 / elapsed
+    } else {
+        f64::NAN
+    };
+    eprintln!(
+        "send-input: schedule complete ({seq} packets sent over {elapsed:.2}s = {hz:.1} Hz \
+         effective; {late_packets} sent late)"
+    );
+    // The staleness gate is the thing that actually bites, so say so rather
+    // than leaving a starved run looking like a healthy one (issue #190).
+    let staleness_hz = 1.0 / sim_host::host::INPUT_STALENESS_TIMEOUT.as_secs_f64();
+    if hz < staleness_hz * 2.0 {
+        eprintln!(
+            "send-input: WARNING -- effective rate {hz:.1} Hz is within 2x of sim-host's \
+             {staleness_hz:.0} Hz staleness floor. Some ticks will have run with the input \
+             ZEROED, so this run is a DE-RATED version of the '{schedule_name}' schedule. \
+             Do not quote a stability result from it; use \
+             `sim-host --scripted-scenario {schedule_name}` instead."
+        );
+    }
 }

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -8,6 +8,7 @@
 //! ```text
 //! sim-host [--duration-secs SECONDS] [--startup-kick]
 //!          [--state-out-addr ADDR] [--input-in-addr ADDR]
+//!          [--scripted-scenario default|s-curve] [--stats-path PATH|none]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
 //! it, stops after that many seconds and exits -- used for verification runs
@@ -54,6 +55,26 @@ fn main() -> ExitCode {
                 cfg.startup_kick = true;
                 i += 1;
             }
+            // Verification only -- see HostConfig::scripted_scenario. Plays
+            // one of `sim_host::scenario`'s schedules from inside the host,
+            // indexed on SIMULATED time, instead of taking stick values off
+            // the socket. Deterministic and repeatable; NOT how a deployed
+            // host or an Unreal session runs.
+            "--scripted-scenario" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --scripted-scenario needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Some(sched) = sim_host::scenario::by_name(v) else {
+                    eprintln!(
+                        "sim-host: unknown scenario '{v}' (want: {})",
+                        sim_host::scenario::names()
+                    );
+                    return ExitCode::FAILURE;
+                };
+                cfg.scripted_scenario = Some(sched);
+                i += 2;
+            }
             "--state-out-addr" => {
                 let Some(v) = args.get(i + 1) else {
                     eprintln!("sim-host: --state-out-addr needs a value");
@@ -64,6 +85,24 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 };
                 cfg.state_out_addr = addr;
+                i += 2;
+            }
+            // Companion to --state-out-addr/--input-in-addr: an isolated
+            // verification run must not stomp a live session's stats file
+            // either. `sim-host`'s own counters go to a single fixed path by
+            // default, so two hosts running at once (a capture session on
+            // 9601/9602 and a verification run on throwaway ports) silently
+            // overwrite each other's tick/missed-deadline counts.
+            "--stats-path" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --stats-path needs a value");
+                    return ExitCode::FAILURE;
+                };
+                cfg.stats_path = if v == "none" {
+                    None
+                } else {
+                    Some(std::path::PathBuf::from(v))
+                };
                 i += 2;
             }
             "--input-in-addr" => {
@@ -86,8 +125,13 @@ fn main() -> ExitCode {
     }
 
     eprintln!(
-        "sim-host: starting -- state out to {}, input in on {}, duration={:?}, startup_kick={}",
-        cfg.state_out_addr, cfg.input_in_addr, cfg.duration, cfg.startup_kick
+        "sim-host: starting -- state out to {}, input in on {}, duration={:?}, \
+         startup_kick={}, scripted={}",
+        cfg.state_out_addr,
+        cfg.input_in_addr,
+        cfg.duration,
+        cfg.startup_kick,
+        cfg.scripted_scenario.is_some()
     );
 
     let handle = sim_host::spawn(cfg);

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -226,7 +226,15 @@ const YAW_AUTHORITY_FLOOR: f32 = 0.35;
 /// 50 control cycles (100 ms at 500 Hz): generous relative to any plausible
 /// Unreal send rate, tight relative to a human's reaction time. A documented
 /// default, not a bench-tuned number.
-const INPUT_STALENESS_TIMEOUT: Duration = Duration::from_millis(100);
+///
+/// **Not as generous as that reasoning assumed** (issue #190): this crate's
+/// own `send-input`, which claimed 50 Hz, was measured delivering 7-13 Hz on
+/// a loaded dev laptop -- straddling this threshold, so a run-varying
+/// fraction of every scripted run silently ran with the input zeroed. That is
+/// fixed in the sender (absolute-deadline pacing) rather than by widening
+/// this timeout, which is a safety property and stays where it is. Public
+/// so a harness can quote the number it has to beat.
+pub const INPUT_STALENESS_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Placeholder threshold for the state-out FALLEN bit.
 /// `sim/scenarios/disturbance_envelope.py` derives the REAL nose-strike
@@ -355,6 +363,12 @@ const STARTUP_KICK_FORCE_N: [f64; 3] = [-(20.0 / STARTUP_KICK_DURATION_S), 0.0, 
 const FALL_KICK_DURATION_S: f64 = 0.05;
 const FALL_KICK_FORCE_N: [f64; 3] = [-(400.0 / FALL_KICK_DURATION_S), 0.0, 0.0];
 
+/// How much simulated time a scripted run keeps stepping for after its
+/// schedule has finished, so the outcome of the last phase is visible rather
+/// than the process exiting mid-manoeuvre. Same intent as `send-input`'s own
+/// `--kick-at` tail.
+const SCRIPTED_RUN_TAIL_S: f64 = 3.0;
+
 /// Default path for the host's own missed-deadline/tick counters -- internal
 /// tooling for `wire-probe`, NOT part of the Unreal wire (issue #161's wire
 /// table has no room for either, and must not grow one for our own
@@ -378,6 +392,32 @@ pub struct HostConfig {
     /// Applies the one-time startup disturbance if true. See
     /// [`STARTUP_KICK_T0_S`]'s doc comment for why this defaults to false.
     pub startup_kick: bool,
+    /// **Verification only.** When set, the host plays this
+    /// [`crate::scenario`] schedule itself, indexed on SIMULATED time, and
+    /// ignores the input socket entirely for `weight_shift_*`/`steer`.
+    ///
+    /// # Why this exists (issue #190)
+    ///
+    /// The scripted scenarios were previously only playable through
+    /// `send-input`, which indexed them on a WALL clock and shipped them over
+    /// UDP into a 100 ms staleness gate. On a loaded, non-realtime dev host
+    /// that made the effective input sequence a function of machine load:
+    /// the same command produced a materially different run each time, and
+    /// "this scenario is stable" was being concluded from a de-rated
+    /// delivery of it (see [`crate::scenario`]'s header for the measured
+    /// numbers).
+    ///
+    /// Indexing on `sim_time_s` removes the wall clock, the socket, the
+    /// sender process and the staleness gate in one move. The plant is a
+    /// fixed-timestep RK4 integrator with no stochastic terms, so with the
+    /// input schedule pinned to tick count the whole run becomes repeatable
+    /// -- which is what makes "does this schedule flip the board?" a question
+    /// with an answer, rather than a coin flip.
+    ///
+    /// This is NOT how a deployed host runs, and it is not a substitute for
+    /// `send-input`: the UDP path is the one Unreal actually uses, and only
+    /// `send-input` exercises it.
+    pub scripted_scenario: Option<crate::scenario::Schedule>,
 }
 
 impl Default for HostConfig {
@@ -388,6 +428,7 @@ impl Default for HostConfig {
             duration: None,
             stats_path: Some(PathBuf::from(DEFAULT_STATS_PATH)),
             startup_kick: false,
+            scripted_scenario: None,
         }
     }
 }
@@ -530,6 +571,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
 
     let mut latest_input = LatestInput::default();
     let mut latest_input_at: Option<Instant> = None;
+    // Last logged scripted-schedule phase label, so a scripted run announces
+    // phase changes once rather than every tick (issue #190).
+    let mut scripted_label: &'static str = "";
     let mut prev_armed_bit = false;
     let mut prev_reset_bit = false;
     let mut prev_kick_bit = false;
@@ -585,6 +629,16 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
                 break;
             }
         }
+        // A scripted run also stops on SIMULATED time (issue #190), so its
+        // length is a property of the schedule rather than of how fast the
+        // laptop happened to be -- the same reason the schedule itself is
+        // indexed on sim time. `cfg.duration`, if set, still applies as a
+        // wall-clock backstop.
+        if let Some(sched) = cfg.scripted_scenario {
+            if t_known_s > crate::scenario::total_duration_s(sched) + SCRIPTED_RUN_TAIL_S {
+                break;
+            }
+        }
 
         // Drain every pending datagram; only the most recent VALID one
         // matters (issue #161: "Use the most recent packet received").
@@ -621,17 +675,29 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             .map(|t| t.elapsed() > INPUT_STALENESS_TIMEOUT)
             .unwrap_or(true);
         // weight_shift_*/steer hold last, then zero after the staleness
-        // timeout (issue #161).
-        let steer = if stale { 0.0 } else { latest_input.steer };
-        let weight_shift_fore_aft = if stale {
-            0.0
-        } else {
-            latest_input.weight_shift_fore_aft
-        };
-        let weight_shift_lateral = if stale {
-            0.0
-        } else {
-            latest_input.weight_shift_lateral
+        // timeout (issue #161) -- UNLESS a scripted scenario is driving this
+        // run (issue #190), in which case the schedule is read straight off
+        // SIMULATED time and the socket's stick values are ignored entirely.
+        // The flag bits (arm/reset/kick) still come from the wire either way,
+        // so an on-demand kick can still be injected into a scripted run.
+        let (steer, weight_shift_fore_aft, weight_shift_lateral) = match cfg.scripted_scenario {
+            Some(sched) => {
+                let (fa, lat, st, label) = crate::scenario::value_at(sched, t_known_s);
+                if label != scripted_label {
+                    eprintln!(
+                        "sim-host: scripted sim_t={t_known_s:6.2}s -> {label} \
+                         (fore_aft={fa:+.2} lateral={lat:+.2} steer={st:+.2})"
+                    );
+                    scripted_label = label;
+                }
+                (st, fa, lat)
+            }
+            None if stale => (0.0, 0.0, 0.0),
+            None => (
+                latest_input.steer,
+                latest_input.weight_shift_fore_aft,
+                latest_input.weight_shift_lateral,
+            ),
         };
 
         // `arm`/`reset` bits: accepted and tracked, logged on change rather

--- a/crates/sim-host/src/lib.rs
+++ b/crates/sim-host/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod host;
 pub mod pacer;
+pub mod scenario;
 pub mod wire;
 
 pub use host::{run, spawn, HostConfig, HostError, RunSummary, CYCLE_NS};

--- a/crates/sim-host/src/scenario.rs
+++ b/crates/sim-host/src/scenario.rs
@@ -1,0 +1,255 @@
+//! The scripted input schedules, and the two ways of playing them back.
+//!
+//! These tables used to live inside `src/bin/send-input.rs`, which could only
+//! ever play them against a **wall clock** over UDP. That turned out to be
+//! load-bearing in a way nobody intended -- see [`crate::host::HostConfig::
+//! scripted_scenario`] and the "why this module exists" note below -- so the
+//! tables moved here, into the library, where the host itself can also play
+//! them **indexed on simulated time**.
+//!
+//! # Why this module exists (issue #190)
+//!
+//! `send-input` paced itself with `thread::sleep(20 ms)` per packet and
+//! indexed the schedule off `Instant::elapsed()`. Both halves of that are
+//! wrong on a loaded, non-realtime dev host, and the second one hid the
+//! first:
+//!
+//! - macOS timer coalescing turns a requested 20 ms sleep into a much longer
+//!   one, so the "50 Hz" sender actually delivered **7-13 Hz**, measured.
+//! - `sim-host` zeroes a `weight_shift_*`/`steer` input that is older than
+//!   [`crate::host::INPUT_STALENESS_TIMEOUT`] (100 ms). A 7-13 Hz sender sits
+//!   directly ON that threshold, so a random fraction of every run's ticks
+//!   ran with the input **zeroed** -- a de-rated version of the schedule that
+//!   varies run to run.
+//!
+//! The result is that a scripted run's effective aggression was a property of
+//! how loaded the laptop was, not of the schedule. Playing a schedule against
+//! `sim_time_s` inside the host removes the wall clock, the socket, the
+//! staleness gate and the sender process all at once, so the same schedule
+//! produces the same run every time -- which is what the plant (fixed
+//! timestep, RK4, no stochastic terms) was always able to deliver.
+//!
+//! `send-input` still exists and still sends over UDP -- it is the only tool
+//! that exercises the actual wire -- but it now paces on absolute deadlines
+//! (the same rule [`crate::pacer`] documents) instead of accumulating drift.
+
+/// One schedule row: `(start_s, end_s, weight_shift_fore_aft,
+/// weight_shift_lateral, steer, label)`. Values are within `[-1, 1]`;
+/// `sim-host` scales them onto the model's actual ballast/yaw ranges.
+pub type Row = (f64, f64, f32, f32, f32, &'static str);
+
+/// A named, immutable input schedule.
+pub type Schedule = &'static [Row];
+
+/// Issue #161 W2's acceptance-criterion schedule: settle, lean forward
+/// (accelerate), release (coast), lean back (decelerate then reverse),
+/// release again, lean+steer (turn) -- "drives forward, slows and reverses
+/// under lean, and turns", exercised once each.
+///
+/// Deliberately left alone by every `s-curve` revision: this is the
+/// regression schedule, not a viewing one.
+pub const DEFAULT_SCHEDULE: Schedule = &[
+    (0.0, 1.5, 0.0, 0.0, 0.0, "settle"),
+    (1.5, 4.5, 0.6, 0.0, 0.0, "lean forward (accelerate)"),
+    (4.5, 6.5, 0.0, 0.0, 0.0, "release (coast)"),
+    (
+        6.5,
+        10.0,
+        -0.6,
+        0.0,
+        0.0,
+        "lean back (decelerate, then reverse)",
+    ),
+    (10.0, 12.0, 0.0, 0.0, 0.0, "release (coast reversed)"),
+    (12.0, 14.0, 0.0, 0.8, 0.6, "lean right + steer (turn)"),
+    (14.0, 15.0, 0.0, 0.0, 0.0, "release"),
+];
+
+// --- s-curve, Revision 4 -------------------------------------------------
+//
+// The launch-footage schedule (PR #183, commit 542f3a5). Its full revision
+// history -- Revisions 1 through 4, with every measured value that did and
+// did not ship -- is in `docs/decisions/` and in this crate's git history;
+// what follows is the landed configuration plus the one correction issue
+// #190 forced on the record.
+//
+// # CORRECTION (issue #190): the stability results this schedule was
+// # accepted on were measured against a DE-RATED delivery of it
+//
+// Revisions 2, 3 and 4 each reported "no instability at any point measured",
+// and each of those measurements was taken through `send-input`'s
+// wall-clock-paced UDP sender. That sender was delivering 7-13 Hz, not the
+// 50 Hz it claimed, against a 100 ms host staleness timeout -- so a large,
+// run-varying fraction of every one of those runs held `weight_shift_fore_aft
+// = 0` instead of the scheduled value (see this module's header). The
+// measured `ballast_fa` in a de-rated run sits around 0.031-0.034 m; in a
+// faithfully-delivered one it sits at 0.046 m and rising.
+//
+// Played faithfully -- which is what [`crate::host::HostConfig::
+// scripted_scenario`] now does -- this schedule's build phase drives the
+// board past the motor-current envelope and it flips. That is a property of
+// the schedule and the control law, NOT of the harness; the harness's only
+// role was to hide it. Nothing here has been tuned to make the flip go away.
+/// Settle before the build starts.
+pub const SCURVE4_SETTLE_S: f64 = 0.5;
+/// Hard build duration. Restored to Revision 3's rejected-then-correct 15.0 s
+/// once the invented ~200 m distance line was withdrawn.
+pub const SCURVE4_BUILD_S: f64 = 15.0;
+/// Full stick ("do not be shy with `fore_aft` during the build").
+///
+/// **This is the constant issue #190 is about.** Held for 15 s and actually
+/// delivered, full stick is past what the 40 A / 28 N*m actuator envelope can
+/// hold the frame against once the board is up to speed.
+pub const SCURVE4_BUILD_LEAN: f32 = 1.0;
+/// Zero: any sustained in-weave trim keeps adding speed rather than holding
+/// it, more so at higher entry speed (Revision 2's finding).
+pub const SCURVE4_WEAVE_TRIM: f32 = 0.0;
+/// Full-lobe duration. 4.5 s was measured and rejected -- at this steer and
+/// yaw gain a single lobe wound past a full 360 deg rotation (520.8 deg of
+/// measured swing), which is spinning, not carving.
+pub const SCURVE4_LOBE_S: f64 = 2.8;
+/// Entry (and exit) half-lobe duration -- roughly half [`SCURVE4_LOBE_S`],
+/// the ratio every prior revision centred acceptably at.
+pub const SCURVE4_ENTRY_S: f64 = 1.4;
+/// Lateral and steer stick, at their limits.
+pub const SCURVE4_LATERAL: f32 = 1.0;
+/// Lateral and steer stick, at their limits.
+pub const SCURVE4_STEER: f32 = 1.0;
+
+const B: f64 = SCURVE4_SETTLE_S + SCURVE4_BUILD_S;
+const E1: f64 = B + SCURVE4_ENTRY_S;
+const L1: f64 = E1 + SCURVE4_LOBE_S;
+const L2: f64 = E1 + 2.0 * SCURVE4_LOBE_S;
+const E2: f64 = L2 + SCURVE4_ENTRY_S;
+
+/// `--scenario s-curve`: hold a decent forward speed and weave wide, for
+/// watching the board CARVE. This is the launch-footage schedule -- read the
+/// correction block above it before quoting any stability result measured
+/// against it.
+pub const S_CURVE_SCHEDULE: Schedule = &[
+    (0.0, SCURVE4_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
+    (
+        SCURVE4_SETTLE_S,
+        B,
+        SCURVE4_BUILD_LEAN,
+        0.0,
+        0.0,
+        "lean forward (hard build)",
+    ),
+    (
+        B,
+        E1,
+        SCURVE4_WEAVE_TRIM,
+        SCURVE4_LATERAL,
+        SCURVE4_STEER,
+        "carve right (half lobe, enter)",
+    ),
+    (
+        E1,
+        L1,
+        SCURVE4_WEAVE_TRIM,
+        -SCURVE4_LATERAL,
+        -SCURVE4_STEER,
+        "carve left (hold the line)",
+    ),
+    (
+        L1,
+        L2,
+        SCURVE4_WEAVE_TRIM,
+        SCURVE4_LATERAL,
+        SCURVE4_STEER,
+        "carve right (hold the line)",
+    ),
+    (
+        L2,
+        E2,
+        SCURVE4_WEAVE_TRIM,
+        -SCURVE4_LATERAL,
+        -SCURVE4_STEER,
+        "straighten (exit lobe)",
+    ),
+    (E2, E2 + 1.5, 0.0, 0.0, 0.0, "release (coast)"),
+];
+
+/// Every schedule a `--scenario`/`--scripted-scenario` flag accepts, by name.
+pub const BY_NAME: &[(&str, Schedule)] =
+    &[("default", DEFAULT_SCHEDULE), ("s-curve", S_CURVE_SCHEDULE)];
+
+/// Looks up a schedule by its command-line name.
+pub fn by_name(name: &str) -> Option<Schedule> {
+    BY_NAME.iter().find(|(n, _)| *n == name).map(|(_, s)| *s)
+}
+
+/// Comma-separated list of the accepted names, for error messages.
+pub fn names() -> String {
+    BY_NAME
+        .iter()
+        .map(|(n, _)| *n)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// When the last row of `schedule` ends.
+pub fn total_duration_s(schedule: Schedule) -> f64 {
+    schedule.iter().map(|s| s.1).fold(0.0, f64::max)
+}
+
+/// `(fore_aft, lateral, steer, label)` at schedule time `t`. Outside every
+/// row -- before the first or after the last -- everything is zero.
+pub fn value_at(schedule: Schedule, t: f64) -> (f32, f32, f32, &'static str) {
+    for &(t0, t1, fa, lat, steer, label) in schedule {
+        if t0 <= t && t < t1 {
+            return (fa, lat, steer, label);
+        }
+    }
+    (0.0, 0.0, 0.0, "end")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_named_schedule_resolves_and_is_contiguous() {
+        for (name, sched) in BY_NAME {
+            assert!(by_name(name).is_some(), "{name} does not resolve");
+            assert!(!sched.is_empty(), "{name} is empty");
+            for w in sched.windows(2) {
+                assert!(
+                    (w[0].1 - w[1].0).abs() < 1e-9,
+                    "{name}: gap or overlap between rows ending {} and starting {}",
+                    w[0].1,
+                    w[1].0
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn value_at_is_zero_outside_the_schedule() {
+        let after = total_duration_s(S_CURVE_SCHEDULE) + 1.0;
+        assert_eq!(value_at(S_CURVE_SCHEDULE, after), (0.0, 0.0, 0.0, "end"));
+        assert_eq!(value_at(S_CURVE_SCHEDULE, -1.0), (0.0, 0.0, 0.0, "end"));
+    }
+
+    /// The build phase is 15 s of unchanging full-stick lean. Issue #190's
+    /// whole point is that the flip happens ~7 s INTO that phase, so no
+    /// amount of phase-boundary timing jitter can be what causes it.
+    #[test]
+    fn the_s_curve_build_phase_is_a_long_constant_full_stick_hold() {
+        let (fa, _, _, label) = value_at(S_CURVE_SCHEDULE, SCURVE4_SETTLE_S + 0.5);
+        assert_eq!(fa, SCURVE4_BUILD_LEAN);
+        assert!(label.contains("build"));
+        let (fa_late, _, _, _) = value_at(S_CURVE_SCHEDULE, B - 0.5);
+        assert_eq!(fa_late, SCURVE4_BUILD_LEAN, "still full stick 14.5 s later");
+        // The measured divergence is ~5.4 s into this phase. A schedule whose
+        // build is shorter than that would stop reproducing issue #190 while
+        // still looking like the same scenario, so pin the property that
+        // makes the finding hold: the phase outlasts the divergence.
+        let divergence_s = 5.4;
+        assert!(
+            SCURVE4_BUILD_S > divergence_s,
+            "the build phase must outlast the measured divergence"
+        );
+    }
+}


### PR DESCRIPTION
## What

Root-causes the ~180° pitch flip in `send-input --scenario s-curve` that #187's body flagged, and lands the tooling that made the answer possible. **Full detail, tables and sweeps are in #190** — this body is the short version and the verification.

**Answer: the flip is a genuine control-law/actuator limit (H2), not a harness timing artifact (H1).** The harness defect is real and severe, but it was *hiding* the flip, not causing it.

## The finding

Driven deterministically — schedule indexed on **simulated** time, no wall clock, no socket, no staleness gate — the flip reproduces **byte-identically on every run, at the same sim time**, and it happens **during the straight-line build phase with `steer = 0`**. The carve is not involved.

| sim time | pitch | speed | current |
|---|---|---|---|
| 0.50 s | 0° | 0 | 0 A | build begins, `fore_aft = 1.0` |
| **4.92 s** | −10.4° | **6.53 m/s** | **40.00 A — envelope saturated** |
| 5.87 s | −20.1° | 7.87 m/s | 40 A | `FALLEN` trips |
| 6.47 s | −179.5° | 31.5 m/s | 40 A | full flip |

`MAX_CURRENT_A` (40 A) × `KT_NM_PER_A` (0.7) = 28 N·m = `overboard_rider.xml`'s `wheel_motor` `ctrlrange`. Both bind at the same place: a real actuator-authority limit of the modelled hardware.

Stability cliff, sweeping only `SCURVE4_BUILD_LEAN`: stable through **0.95** (worst pitch −9.9°), **flips at 0.97, 0.99 and 1.00**. The filmed schedule uses 1.00 — on the wrong side, with no margin.

Ruled out by measurement, not by argument:
- **Not #187 (corridor)** — bounds never approached (run ends at −73 m against a −700 m bound).
- **Not #186 (speed cap)** — with `MAX_GROUND_SPEED_M_S` raised to 1e9, divergence times are **identical to the millisecond**. The cap starts ramping at 8.34 m/s; the motor saturates at 6.5 m/s, so the cap never gets a chance to act.

## Why every prior revision measured "no instability"

`send-input` paced with `thread::sleep(20 ms)` and indexed its schedule off a wall clock. Measured across three `s-curve` runs it delivered **12.8 Hz, 7.4 Hz, 7.6 Hz** — not 50 Hz. `sim-host` zeroes stick input older than 100 ms, so a 7–13 Hz sender sits *directly on that threshold*: a run-varying fraction of every run held `weight_shift_fore_aft = 0`.

Measured steady-state `ballast_fa`: **0.031–0.034 m starved vs 0.046 m healthy**, same full-stick schedule — an effective lean of ~0.62, comfortably inside the stable side of the cliff. Same command, three runs: **one flipped, two did not.** That bimodality is the harness; the flip is not.

## Changes

- **`crates/sim-host/src/scenario.rs` (new)** — the schedules move into the library so the UDP sender and the host's own playback cannot drift apart. Carries the correction block: the Revision 2/3/4 stability results were measured against a de-rated delivery.
- **`send-input`** — absolute-deadline pacing (**49.9 Hz measured**, was 7–13 Hz), and an explicit warning when the effective rate approaches the staleness floor, naming the deterministic alternative.
- **`sim-host --scripted-scenario default|s-curve`** — plays a schedule from inside the host, indexed on `sim_time_s`, ignoring the socket's stick values; run length is also sim-time bounded. Verification only; the UDP path is still the one Unreal uses and only `send-input` exercises it.
- **`sim-host --stats-path PATH|none`** — an isolated verification run was still overwriting the single fixed stats file a live capture session writes. Same class of collision `--state-out-addr`/`--input-in-addr` already fixed.
- `INPUT_STALENESS_TIMEOUT` made `pub` (unchanged value — it is a safety property; the sender was fixed instead) so a harness can quote the rate it must beat.

**No control constant was tuned.** `SCURVE4_BUILD_LEAN` is still 1.0 and the scenario still flips. Deciding what to do about that is #190 items 1–3 and a COO/CEO call.

## Acceptance criteria that moved

None gained. One is **withdrawn**: the s-curve doc comments' repeated *"the board did not become unstable or face-plant at any point measured"* (Revisions 2, 3, 4) is corrected in `scenario.rs` — those measurements were taken against a de-rated delivery of the schedule and do not support the claim. This is the repo-side half of the public claim already withdrawn off the launch footage.

## Verification

- `cargo build/fmt/clippy/test --workspace -j 2` — all clean.
- `python3 .github/policy_check.py` — all hard checks pass.
- Three deterministic `--scripted-scenario s-curve` runs: `cmp` reports the CSV traces **byte-identical**; the third overlaps the first on all 14,124 shared sequence numbers with 0 differing rows.
- `--scripted-scenario default` (the #161 W2 AC schedule, lean 0.6): stable, pitch −5.8..+6.4°, `FALLEN` never trips. **The AC/regression schedule is unaffected by any of this.**
- Post-fix UDP run: sender reports 49.9 Hz, and the wire path now reproduces the same flip the deterministic path does — the two agree.
- Every run used **19601/19602**. `lsof` confirmed 9601/9602 untouched by this work throughout; a live `UnrealEditor` session appeared on them partway through and this work stayed off them.

## Not touched

The yaw / dead-reckoning block in `host.rs` — the kinematic in-plant yaw injection epic lands there next and this change deliberately stays clear of it.
