### PR TITLE
feat(sim-host): make MuJoCo's pose authoritative -- kinematic in-plant yaw injection (#163)

### DIFF
--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -59,6 +59,9 @@ extern "C" {
     fn plant_mujoco_actuator_id(model: *mut c_void, name: *const c_char) -> c_int;
     fn plant_mujoco_joint_id(model: *mut c_void, name: *const c_char) -> c_int;
     fn plant_mujoco_joint_qposadr(model: *mut c_void, joint_id: c_int) -> c_int;
+    fn plant_mujoco_joint_dofadr(model: *mut c_void, joint_id: c_int) -> c_int;
+    fn plant_mujoco_set_qpos_range(data: *mut c_void, adr: c_int, src: *const f64, n: c_int);
+    fn plant_mujoco_set_qvel_range(data: *mut c_void, adr: c_int, src: *const f64, n: c_int);
 }
 
 /// The linked libmujoco's own `mj_versionString()`.
@@ -242,6 +245,64 @@ impl Plant {
         out
     }
 
+    /// Writes `values` into `mjData::qpos` starting at `adr` -- the ONLY write
+    /// path into the state vector this crate exposes, added for the kinematic
+    /// in-plant yaw injection (issue #163). See
+    /// [`Plant::set_qvel_range`] for the ordering rule both share.
+    ///
+    /// A RANGE write rather than a whole-array one on purpose: the caller
+    /// names exactly which joint's slots it means, so a mistake corrupts one
+    /// joint instead of the entire state.
+    ///
+    /// # Panics
+    /// If `adr + values.len()` exceeds `nq`.
+    pub fn set_qpos_range(&mut self, adr: usize, values: &[f64]) {
+        assert!(
+            adr + values.len() <= self.nq(),
+            "set_qpos_range: [{adr}, {}) is out of bounds for nq={}",
+            adr + values.len(),
+            self.nq()
+        );
+        // SAFETY: `self.data` is non-null and owned for the life of `self`;
+        // the assertion above proves the write stays inside `mjData::qpos`.
+        unsafe {
+            plant_mujoco_set_qpos_range(
+                self.data,
+                adr as c_int,
+                values.as_ptr(),
+                values.len() as c_int,
+            )
+        };
+    }
+
+    /// Writes `values` into `mjData::qvel` starting at `adr` (issue #163).
+    ///
+    /// **Call this BEFORE [`Plant::step`], never after.** `mj_step` runs the
+    /// forward kinematics that turn a written `qpos`/`qvel` into a consistent
+    /// `xpos`/`xquat`/`xmat`, so anything read between the write and the next
+    /// step is stale -- the same before-vs-after-the-step seam
+    /// [`Plant::set_ctrl`] already documents.
+    ///
+    /// # Panics
+    /// If `adr + values.len()` exceeds `nv`.
+    pub fn set_qvel_range(&mut self, adr: usize, values: &[f64]) {
+        assert!(
+            adr + values.len() <= self.nv(),
+            "set_qvel_range: [{adr}, {}) is out of bounds for nv={}",
+            adr + values.len(),
+            self.nv()
+        );
+        // SAFETY: see `set_qpos_range`.
+        unsafe {
+            plant_mujoco_set_qvel_range(
+                self.data,
+                adr as c_int,
+                values.as_ptr(),
+                values.len() as c_int,
+            )
+        };
+    }
+
     /// `mjModel::opt.timestep`, seconds -- issue #107 (I1c) AC2: `hal`'s
     /// `wait_observe()` must step this plant `control_period / mj_timestep`
     /// times, and that ratio must be an exact integer. Read from the model
@@ -370,6 +431,27 @@ impl Plant {
         }
         // SAFETY: `id` was just resolved against this same model.
         let adr = unsafe { plant_mujoco_joint_qposadr(self.model, id) };
+        Some(adr as usize)
+    }
+
+    /// `mjModel::jnt_dofadr` for the joint named `name`, or `None` if the model
+    /// has no such joint -- the index into `Plant::qvel()`'s vector where that
+    /// joint's own degrees of freedom start.
+    ///
+    /// **Not interchangeable with [`Plant::joint_qposadr`].** A free joint is 7
+    /// `qpos` values but only 6 `qvel` ones, so the two addresses diverge for
+    /// every joint declared after one -- reaching `qvel` through a `qpos`
+    /// address silently writes the wrong slots. Added with the kinematic
+    /// in-plant yaw injection (issue #163), which writes both.
+    pub fn joint_dofadr(&self, name: &str) -> Option<usize> {
+        let name_c = CString::new(name).expect("joint name must not contain a NUL byte");
+        // SAFETY: see `joint_qposadr`.
+        let id = unsafe { plant_mujoco_joint_id(self.model, name_c.as_ptr()) };
+        if id < 0 {
+            return None;
+        }
+        // SAFETY: `id` was just resolved against this same model.
+        let adr = unsafe { plant_mujoco_joint_dofadr(self.model, id) };
         Some(adr as usize)
     }
 

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -196,3 +196,32 @@ int plant_mujoco_joint_id(void* model, const char* name) {
 int plant_mujoco_joint_qposadr(void* model, int joint_id) {
   return ((mjModel*)model)->jnt_qposadr[joint_id];
 }
+
+// `mjModel::jnt_dofadr` -- the index into qvel/qfrc, which is NOT the same as
+// jnt_qposadr the moment any joint in the model is a ball or a free joint (a
+// free joint is 7 qpos but only 6 qvel). Added for the kinematic in-plant yaw
+// injection (issue #163): the host rotates the board's free-joint orientation
+// AND its world linear velocity, and reaching qvel through the qpos address
+// would silently write the wrong slots on any model with a quaternion in it.
+int plant_mujoco_joint_dofadr(void* model, int joint_id) {
+  return ((mjModel*)model)->jnt_dofadr[joint_id];
+}
+
+// The only WRITE path into qpos/qvel this crate exposes, and deliberately a
+// RANGE write rather than a whole-array one (issue #163's kinematic yaw
+// injection): the caller names exactly which slots it means, so a bug can
+// corrupt one joint rather than smearing the entire state vector. Bounds are
+// checked on the Rust side against nq/nv before either is called.
+//
+// Ownership: `src` must point to at least `n` doubles. Callers must call these
+// BEFORE plant_mujoco_step, never after -- same ordering rule as
+// plant_mujoco_set_ctrl, and for the same reason: mj_step's own forward
+// kinematics is what turns a written qpos into a consistent xpos/xquat/xmat,
+// so anything read between the write and the next step is stale.
+void plant_mujoco_set_qpos_range(void* data, int adr, const double* src, int n) {
+  memcpy(((mjData*)data)->qpos + adr, src, (size_t)n * sizeof(double));
+}
+
+void plant_mujoco_set_qvel_range(void* data, int adr, const double* src, int n) {
+  memcpy(((mjData*)data)->qvel + adr, src, (size_t)n * sizeof(double));
+}

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -138,6 +138,13 @@ pub struct SimBackend {
     /// joint position issue #161 wire v2 puts on the state-out wire.
     ballast_fa_qposadr: Option<usize>,
     ballast_lateral_qposadr: Option<usize>,
+    /// `mjModel::jnt_qposadr` / `jnt_dofadr` for the board's `frame_free`
+    /// free joint, if the open model declares one. Resolved once in `open()`;
+    /// used only by [`SimBackend::inject_kinematic_yaw`]. BOTH addresses are
+    /// kept because a free joint spans 7 `qpos` but only 6 `qvel` -- see
+    /// `plant_mujoco::Plant::joint_dofadr`.
+    frame_free_qposadr: Option<usize>,
+    frame_free_dofadr: Option<usize>,
     cycle: u64,
     open: bool,
     armed: bool,
@@ -310,6 +317,119 @@ impl SimBackend {
             .unwrap_or(0.0);
         (fore_aft, lateral)
     }
+
+    /// Rotates the board's free joint about the WORLD vertical axis through
+    /// its own current x/y by `dyaw_rad`, so that the next
+    /// [`BoardObserve::wait_observe`] integrates the board's translation along
+    /// the new heading (issue #163 -- kinematic in-plant yaw injection).
+    ///
+    /// **This is a kinematic injection, not a torque.** No yaw moment is
+    /// generated anywhere: the heading is imposed on the state vector, and
+    /// MuJoCo then does the rest -- position, ground path and every contact
+    /// are integrated at that heading by the solver, against real collision
+    /// geometry. Compare the mechanism it replaces (`sim-host` dead-reckoning
+    /// `pos` on the wire while the plant translated along one fixed axis
+    /// underneath), which left MuJoCo's own position unrelated to what a
+    /// renderer drew and made collision geometry untestable.
+    ///
+    /// Three things happen, and the third one is the subtle one:
+    ///
+    /// 1. The free joint's quaternion is PRE-multiplied by `quat_z(dyaw)`.
+    ///    Pre- (world-frame), not post- (body-frame): a rolled or pitched
+    ///    board must yaw about the world vertical, not about its own tilted
+    ///    axis, or the heading walks out of the ground plane.
+    /// 2. The free joint's LINEAR velocity is rotated by the same `dyaw`. A
+    ///    free joint's linear `qvel` is expressed in the WORLD frame, so
+    ///    rotating the body without it would leave the board travelling its
+    ///    old direction with a new nose angle -- crabbing, which is precisely
+    ///    the artefact that reads as a physics bug.
+    /// 3. The free joint's ANGULAR velocity is left alone. A free joint's
+    ///    angular `qvel` is expressed in the BODY frame (MuJoCo's own
+    ///    convention, and the asymmetry with the linear half is deliberate on
+    ///    MuJoCo's part), so it is already relative to the rotated body and
+    ///    rotating it again would double-count the injection as a spurious
+    ///    yaw rate.
+    ///
+    /// Nothing else in the state is touched -- the free joint's POSITION is
+    /// left exactly where it was, which is what makes this a rotation about
+    /// the vertical axis through the board rather than about the world origin,
+    /// and every child joint (`wheel_hinge`, the two ballast slides) is
+    /// expressed relative to this body and so follows it for free.
+    ///
+    /// **`dyaw_rad == 0.0` is a literal no-op**, returning before any read or
+    /// write: with zero steer the plant must evolve bit-identically to the
+    /// pre-injection code, and that guarantee is worth more than the branch
+    /// costs.
+    ///
+    /// Call this BEFORE `wait_observe`, like
+    /// [`SimBackend::apply_external_force`] and
+    /// [`SimBackend::set_ballast_targets`] -- but unlike those it takes effect
+    /// IMMEDIATELY on the state vector rather than being buffered, so it is
+    /// applied ONCE per call and must not be re-issued for the same tick.
+    ///
+    /// A no-op on a model that declares no `frame_free` joint, the same
+    /// tolerance [`SimBackend::set_ballast_targets`] has.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn inject_kinematic_yaw(&mut self, dyaw_rad: f64) {
+        if dyaw_rad == 0.0 {
+            return;
+        }
+        let (Some(qadr), Some(vadr)) = (self.frame_free_qposadr, self.frame_free_dofadr) else {
+            return;
+        };
+        let plant = self
+            .plant
+            .as_mut()
+            .expect("inject_kinematic_yaw: backend is not open");
+
+        // 1. Attitude: q <- quat_z(dyaw) * q.
+        let qpos = plant.qpos();
+        let q = [
+            qpos[qadr + 3],
+            qpos[qadr + 4],
+            qpos[qadr + 5],
+            qpos[qadr + 6],
+        ];
+        let (half_s, half_c) = (dyaw_rad * 0.5).sin_cos();
+        let mut rotated = quat_mul([half_c, 0.0, 0.0, half_s], q);
+        // Renormalized explicitly rather than trusting the product of two unit
+        // quaternions to stay unit: this runs 500 times a second for an
+        // open-ended session, and MuJoCo's own renormalization inside
+        // mj_integratePos is not something this crate should depend on for a
+        // value it wrote itself.
+        let norm = (rotated.iter().map(|v| v * v).sum::<f64>()).sqrt();
+        if norm > 0.0 {
+            for v in rotated.iter_mut() {
+                *v /= norm;
+            }
+        }
+        plant.set_qpos_range(qadr + 3, &rotated);
+
+        // 2. World-frame linear velocity, rotated about +Z by the same angle.
+        //    vz is untouched, hence a 2-element write.
+        let qvel = plant.qvel();
+        let (s, c) = dyaw_rad.sin_cos();
+        let (vx, vy) = (qvel[vadr], qvel[vadr + 1]);
+        plant.set_qvel_range(vadr, &[c * vx - s * vy, s * vx + c * vy]);
+
+        // 3. Body-frame angular velocity (qvel[vadr + 3 ..= vadr + 5]): NOT
+        //    touched, on purpose. See this method's doc comment.
+    }
+}
+
+/// Hamilton product of two `[w, x, y, z]` quaternions, `a` then `b` read
+/// right-to-left: the result applies `b`'s rotation first, then `a`'s.
+fn quat_mul(a: [f64; 4], b: [f64; 4]) -> [f64; 4] {
+    let [aw, ax, ay, az] = a;
+    let [bw, bx, by, bz] = b;
+    [
+        aw * bw - ax * bx - ay * by - az * bz,
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+    ]
 }
 
 impl BoardObserve for SimBackend {
@@ -378,6 +498,12 @@ impl BoardObserve for SimBackend {
         // actuator that happens to drive it (issue #161 wire v2).
         self.ballast_fa_qposadr = plant.joint_qposadr("ballast_fa");
         self.ballast_lateral_qposadr = plant.joint_qposadr("ballast_lat");
+        // The board's own free joint -- both models declare it (`frame_free`).
+        // Resolved leniently (`Option`, not `expect`) for the same reason the
+        // ballast lookups are: this backend must keep opening a model that
+        // does not happen to declare the thing an optional feature needs.
+        self.frame_free_qposadr = plant.joint_qposadr("frame_free");
+        self.frame_free_dofadr = plant.joint_dofadr("frame_free");
 
         self.plant = Some(plant);
         self.cycle = 0;
@@ -823,6 +949,122 @@ mod tests {
             28.0,
             "40 A * KT_NM_PER_A must equal the model's ctrlrange bound (28 N*m); \
              see overboard_onewheel.xml's <motor ... ctrlrange=\"-28 28\">"
+        );
+    }
+
+    // ---- kinematic in-plant yaw injection (issue #163) ------------------
+
+    /// GUARD 1, at the layer that can actually break the plant: a zero
+    /// increment must be a LITERAL no-op -- no read, no write, and a state
+    /// vector that is bit-identical afterwards. Every scenario that never
+    /// touches `steer` depends on this, and "close enough" is not the claim.
+    #[test]
+    fn a_zero_yaw_injection_is_bit_identical() {
+        let mut b = armed();
+        b.wait_observe().unwrap();
+        let qpos_before = b.truth_qpos();
+        let quat_before = b.truth_frame_xquat();
+
+        b.inject_kinematic_yaw(0.0);
+
+        assert_eq!(b.truth_qpos(), qpos_before);
+        assert_eq!(b.truth_frame_xquat(), quat_before);
+    }
+
+    /// The attitude half of the injection: the free joint's quaternion must
+    /// pick up exactly the requested rotation about the WORLD +Z, and the
+    /// board's position must not move (this is a rotation about the vertical
+    /// axis through the board, not about the world origin).
+    #[test]
+    fn injecting_yaw_rotates_the_free_joint_about_world_z() {
+        let mut b = armed();
+        b.wait_observe().unwrap();
+        let before = b.truth_qpos();
+        let dyaw = 0.25f64;
+
+        b.inject_kinematic_yaw(dyaw);
+        // xquat is only refreshed by a step, so read qpos, which is written
+        // directly -- and step once to confirm the plant accepts it.
+        let after = b.truth_qpos();
+
+        // Free joint is qpos[0..7] on both models: x, y, z, then w, x, y, z.
+        assert_eq!(&after[0..3], &before[0..3], "the board must not translate");
+        let q = [after[3], after[4], after[5], after[6]];
+        // Yaw out of a quaternion: atan2(2(wz + xy), 1 - 2(y^2 + z^2)).
+        let yaw =
+            (2.0 * (q[0] * q[3] + q[1] * q[2])).atan2(1.0 - 2.0 * (q[2] * q[2] + q[3] * q[3]));
+        assert!(
+            (yaw - dyaw).abs() < 1e-9,
+            "expected {dyaw} rad of world yaw, got {yaw}"
+        );
+        let norm = q.iter().map(|v| v * v).sum::<f64>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-12, "quaternion must stay unit");
+
+        b.wait_observe().unwrap();
+    }
+
+    /// The velocity half, and the reason the injection is not just a
+    /// quaternion write: a free joint's LINEAR `qvel` is world-frame, so it
+    /// has to be rotated with the body or the board keeps travelling its old
+    /// direction with a new nose angle -- crabbing.
+    ///
+    /// Driven at 90 deg so the check is unambiguous: motion purely along -X
+    /// must come out purely along -Y.
+    #[test]
+    fn injecting_yaw_rotates_world_linear_velocity_but_not_body_angular() {
+        let mut b = armed();
+        b.wait_observe().unwrap();
+        // Give the board a clean world velocity to rotate, and a body-frame
+        // angular velocity that must survive untouched.
+        b.plant
+            .as_mut()
+            .unwrap()
+            .set_qvel_range(0, &[-3.0, 0.0, 0.0, 0.11, 0.22, 0.33]);
+
+        b.inject_kinematic_yaw(std::f64::consts::FRAC_PI_2);
+
+        let v = b.plant.as_ref().unwrap().qvel();
+        assert!(
+            v[0].abs() < 1e-9,
+            "world vx should have rotated away, got {}",
+            v[0]
+        );
+        assert!(
+            (v[1] - -3.0).abs() < 1e-9,
+            "world vy should now carry the speed, got {}",
+            v[1]
+        );
+        assert_eq!(v[2], 0.0, "vertical speed must not be touched");
+        // Body-frame angular velocity: untouched, on purpose. Rotating it too
+        // would double-count the injection as a spurious yaw RATE.
+        assert_eq!((v[3], v[4], v[5]), (0.11, 0.22, 0.33));
+    }
+
+    /// The property the whole approach is for: with a heading injected, the
+    /// plant's own integration carries the board along the NEW direction.
+    /// Nothing outside MuJoCo computes this path.
+    #[test]
+    fn the_plant_itself_translates_along_the_injected_heading() {
+        let mut b = armed();
+        b.wait_observe().unwrap();
+        // Roll the board forward along its -X at a steady clip.
+        b.plant
+            .as_mut()
+            .unwrap()
+            .set_qvel_range(0, &[-4.0, 0.0, 0.0]);
+        b.inject_kinematic_yaw(std::f64::consts::FRAC_PI_2);
+
+        let start = b.truth_frame_xpos();
+        for _ in 0..50 {
+            b.wait_observe().unwrap();
+        }
+        let end = b.truth_frame_xpos();
+
+        let (dx, dy) = (end[0] - start[0], end[1] - start[1]);
+        assert!(
+            dy < -0.1 && dy.abs() > dx.abs() * 5.0,
+            "after a 90 deg injection the board should travel along -Y, not -X \
+             (moved dx={dx:.4} m, dy={dy:.4} m)"
         );
     }
 }

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -29,6 +29,74 @@
 //! driverless-plant, `pitch_ref`-only inner loop but became actively wrong
 //! the moment this file switched to a ridden plant with a driven ballast --
 //! nothing in this loop opposes net forward motion, and nothing should.
+//!
+//! # Issue #163: the heading now lives INSIDE the plant
+//!
+//! This host used to carry a synthetic heading alongside the physics: a
+//! `yaw_rad` integrated from `steer`, composed onto MuJoCo's truth quaternion
+//! on the way out, with the ground path dead-reckoned from real forward speed
+//! projected along it. MuJoCo's own board only ever translated along one axis
+//! underneath, so its true position bore no relation to what a renderer drew
+//! -- which is why the drivable corridor had to be a soft host-side lean
+//! rather than actual collision geometry.
+//!
+//! The same steering law now writes its increment straight into the plant's
+//! free joint before each physics step (see the yaw block at the bottom of
+//! [`run`], and `sim_backend::SimBackend::inject_kinematic_yaw`). **The
+//! collision goal never required yaw to be physically GENERATED -- only
+//! MuJoCo's pose to be AUTHORITATIVE**, and those are different problems.
+//! Steering is still commanded rather than emergent: no tire model produces
+//! this turn, and the `Playable Sim` declaration keeps saying so. But
+//! position, ground path and every contact are now simulated at that heading,
+//! nothing is dead-reckoned, and the MJCF is untouched.
+//!
+//! ## What it measured
+//!
+//! Every figure below is master vs this branch, run through
+//! `--scripted-scenario` (issue #190/#191's sim-time-indexed player, so the
+//! input path has no socket and no wall clock in it) and decoded off the wire
+//! at full float precision -- not `wire-probe --csv`, whose 6-decimal
+//! rounding cannot demonstrate bit identity.
+//!
+//! **Zero steer is bit-identical.** `--startup-kick` with no scenario and no
+//! sender, so `steer` is 0 for the whole run; 7,854 common ticks. `pitch`,
+//! `quat` (all four), `wheel_angle`, `wheel_rate`, `motor_current`,
+//! `rider_fore_aft`, `rider_lateral`, `pos_z`, `sim_time` and `flags` are ALL
+//! bit-identical. The plant is untouched, which is exactly what the
+//! `dyaw == 0` gate exists to guarantee.
+//!
+//! Only `pos_x`/`pos_y` differ, which is the point of the change: those are
+//! where the dead-reckoned path used to be reported and are now MuJoCo's own.
+//! **The gap between them is the size of the error the old design was
+//! shipping**: 14.7 mm over 7.37 m of travel (0.2%) in x, and 8.2 um in y --
+//! where dead reckoning reported y as exactly 0.0, because it could not
+//! represent lateral motion at all.
+//!
+//! **With steer on, the plant lands where the reckoning said it would.**
+//! `--scripted-scenario default`, 9,000 ticks, tick-for-tick: `pitch` differs
+//! by at most 2.1e-9 rad (1.2e-7 deg), `wheel_rate` by 4.8e-7 rad/s,
+//! `motor_current` by 3.9e-7 A, the largest quaternion component by 8.3e-5,
+//! and the commanded heading by 1.7e-4 rad. The path itself: 4.4 cm over a
+//! 16 m run (0.28%) in x, 1.5 cm in y. The pitch envelope is IDENTICAL to
+//! master's on the same schedule, -5.842..+6.390 deg -- the same envelope the
+//! corridor-brake run recorded, and well inside the 10 deg carving limit.
+//!
+//! The reconstruction that comparison rests on is itself checked: replaying
+//! the deleted dead-reckoning integral offline against master's own run
+//! reproduces master's reported track to 0.0000 m, so it is the deleted
+//! block and not an approximation of it. Truth attitude tracks the commanded
+//! heading to 0.19 deg, and master's own truth attitude differs from its
+//! `yaw_rad` by the same 0.19 deg -- that residual is the plant's own
+//! contact-driven yaw, not the injection fighting the physics.
+//!
+//! **The `s-curve` flip (issue #190) is untouched.** Driven deterministically,
+//! master and branch cross 20, 90 and 170 deg of pitch on the IDENTICAL tick
+//! (seq 2933 / t = 5.868 s, seq 3070, seq 3216), and every physics column is
+//! bit-identical for the first 7,375 ticks -- the whole zero-steer portion of
+//! that run, which is where the flip happens. The two traces only separate
+//! once `steer` goes non-zero at t = 14.75 s, by which point both boards are
+//! already tumbling and diverge chaotically. That flip is issue #190's, and
+//! nothing here moves it.
 
 use crate::pacer::Pacer;
 use crate::wire::{self, InputIn, StateOut};
@@ -90,6 +158,13 @@ const BALLAST_RANGE_M: f32 = 0.05;
 /// Non-physical game channel, SHAPED by [`ROLL_FULL_YAW_AUTHORITY_RAD`]
 /// below -- the simulated wheel is a cylinder and cannot physically carve
 /// (issue #161). The real lean-steer controller is Tuesday.
+///
+/// **Unchanged in value and in law by issue #163's kinematic in-plant yaw
+/// injection.** What changed is only where the resulting heading is APPLIED:
+/// this same `steer * k * v * roll_authority` rate is now integrated into
+/// MuJoCo's own free joint before each physics step, instead of being
+/// composed onto the plant's output afterwards. The steering feel is signed
+/// off and must not move; see [`run`]'s own yaw block.
 ///
 /// # Revision history (moved through 1.5 -> 3.0 -> speed-proportional)
 ///
@@ -244,38 +319,27 @@ pub const INPUT_STALENESS_TIMEOUT: Duration = Duration::from_millis(100);
 /// clearly down", not precise enough to gate a published claim.
 const FALLEN_PITCH_RAD: f32 = 20.0 * std::f32::consts::PI / 180.0;
 
-/// Soft, host-side drivable-corridor bounds in the DEAD-RECKONED frame
-/// (`dr_pos_x_m`/`dr_pos_y_m` -- see the PARTIALLY SYNTHETIC POSITION block
-/// below), NOT MuJoCo collision geometry -- issue #161 follow-up, item 4:
-/// the CEO wants the board to stop passing through walls, curbs and map
-/// boundaries.
+/// Soft, host-side drivable-corridor bounds, checked against **MuJoCo's own
+/// truth position** -- issue #161 follow-up, item 4: the CEO wants the board
+/// to stop passing through walls, curbs and map boundaries.
 ///
-/// **Why MuJoCo-frame collision geometry cannot work here (Option A per the
-/// COO, not Option B, and NOT today):** since the dead-reckoning fix
-/// (issue #161/#169, PR #172), `pos`'s x/y on the wire -- and therefore
-/// what the renderer shows on screen -- are dead-reckoned from real forward
-/// speed projected along the SYNTHETIC yaw heading. MuJoCo's own plant
-/// never turns; it only ever translates along its own -X axis. So the
-/// position MuJoCo's physics engine actually occupies bears no relation to
-/// where the board appears on screen, and collision geometry added to the
-/// MJCF would be tested against the WRONG position entirely -- the board
-/// would bounce off invisible walls in the wrong place and pass through
-/// the visible ones anyway. This is the accumulated cost of the
-/// yaw-as-overlay design (the right call at the time; it got a launch demo
-/// shipped), and boundaries are where it stops paying for free.
+/// **CHANGED (issue #163, kinematic in-plant yaw injection): this used to be
+/// checked in the DEAD-RECKONED frame, and no longer is.** The original
+/// version of this comment explained at length why MuJoCo-frame bounds could
+/// not work: `pos`'s x/y on the wire were dead-reckoned from real forward
+/// speed projected along a synthetic heading, MuJoCo's own plant never turned
+/// (it only ever translated along its own -X axis), so the position the
+/// physics engine occupied bore no relation to where the board appeared on
+/// screen. That is no longer true. The host now rotates the board's free
+/// joint inside the plant every tick, so MuJoCo integrates the ground path
+/// itself and its truth position IS the on-screen position. These bounds are
+/// therefore now checked against `truth_pos_x_m`/`truth_pos_y_m` directly.
 ///
-/// The real fix (Option B, the COO's own framing) is making yaw physical --
-/// the board genuinely turning in MuJoCo so its true position is 2D and
-/// collision geometry can be tested against it directly. That would ALSO
-/// delete the dead-reckoning `Playable Sim` declaration line entirely,
-/// since the path would stop being invented -- an honesty improvement, not
-/// just an engineering one. It is also a change to how the plant moves,
-/// the day before launch, against a control law tuned for the 1-D case --
-/// explicitly NOT attempted here. This corridor is the stopgap (Option A):
-/// when the dead-reckoned position leaves it, arrest forward motion. Not
-/// real collision -- the board still passes through the VISUAL geometry --
-/// but it stops travelling further away from the road, which is the
-/// visible problem this fixes today.
+/// This remains a SOFT corridor -- a lean applied against travel, not a
+/// contact -- because the model still declares no wall geometry. What has
+/// changed is that adding some would now work: collision geometry in the MJCF
+/// would be tested against the same position the renderer draws, which is the
+/// thing the dead-reckoned design foreclosed.
 ///
 /// Derived from the actual UE <-> MuJoCo origin mapping the COO supplied
 /// (`OB_City`'s `BoardActor`, printed on launch: "MuJoCo origin -> UE
@@ -297,13 +361,25 @@ const FALLEN_PITCH_RAD: f32 = 20.0 * std::f32::consts::PI / 180.0;
 /// m for the measurement run and `send-input`'s `default` schedule (the
 /// stable, already-validated AC schedule -- not `s-curve`) driven straight
 /// at it. The edge-triggered log fired exactly once, at `(-3.0, 0.0)`;
-/// `dr_pos_x_m` then overshot to -10.3 m under residual momentum before the
+/// the reported position (then dead-reckoned, now truth) overshot to -10.3 m
+/// under residual momentum before the
 /// brake arrested it, settling to a steady -9.4..-10.3 m band for the rest
 /// of the run rather than continuing to run away -- an active brake against
 /// momentum, not a teleport back to the line, exactly as designed. Pitch
 /// stayed within -5.8..+6.4 deg throughout: the corridor brake itself did
 /// not destabilize the board. Bound reverted to -700.0 after the
 /// measurement.
+///
+/// **Re-verified after the switch to truth position** (issue #163), by the
+/// identical method -- `CORRIDOR_X_MIN_M` temporarily tightened to -3.0 m,
+/// `send-input`'s `default` schedule driven at it, bound reverted afterwards.
+/// The edge-triggered log fired exactly once, again at `(-3.0, 0.0)`; truth
+/// `x` overshot to -7.6 m under residual momentum, then held at -7.3 m for
+/// the rest of the run, and pitch stayed within -4.7..+6.2 deg. Same
+/// behaviour, and the overshoot differs from the -10.3 m above only because
+/// the board is carrying a different speed at the crossing -- `send-input`
+/// is a wall-clock sender against a tick-paced host, so no two runs of the
+/// same schedule cross the line at the same moment.
 const CORRIDOR_X_MIN_M: f64 = -700.0;
 const CORRIDOR_X_MAX_M: f64 = 50.0;
 const CORRIDOR_HALF_WIDTH_M: f64 = 8.6;
@@ -494,20 +570,41 @@ impl From<InputIn> for LatestInput {
 /// Spawns the control loop on its own dedicated thread (issue #161: "not on
 /// the main thread") and returns the join handle. The caller decides what to
 /// do with the calling thread -- `src/bin/sim-host.rs` just joins it.
-/// Hamilton product of two `[w, x, y, z]` quaternions.
+/// Body-frame pitch and roll, radians, from the `frame` body's world rotation
+/// matrix (row-major `xmat`) and the world-frame heading currently baked into
+/// the plant.
 ///
-/// Order is `a` then `b` read right-to-left: the result applies `b`'s rotation first, then `a`'s.
-/// Used to compose the synthetic heading (`a`) onto MuJoCo's truth attitude (`b`) -- see the call
-/// site for why that order, and not the other one, is the correct composition.
-fn quat_mul(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
-    let [aw, ax, ay, az] = a;
-    let [bw, bx, by, bz] = b;
-    [
-        aw * bw - ax * bx - ay * by - az * bz,
-        aw * bx + ax * bw + ay * bz - az * by,
-        aw * by - ax * bz + ay * bw + az * bx,
-        aw * bz + ax * by - ay * bx + az * bw,
-    ]
+/// Pitch is `atan2(R[0][2], R[2][2])` -- exactly
+/// `sim/scenarios/impulse_response.py::frame_pitch_rad`'s formula against the
+/// identical array, nose-up positive per ICD 10.1 -- and roll is the same
+/// atan2-of-a-tilted-axis derivation applied to the Y-Z plane (about local X)
+/// instead of the X-Z plane (about local Y). Both are exact only when the
+/// OTHER angle is near zero: 3D rotations do not commute and this is not a
+/// true Euler decomposition. Acceptable for the roll-shaped yaw limiter's
+/// "cheap stopgap" status (issue #161 W2 item 4); the real lean-steer
+/// controller needs a better one.
+///
+/// **`yaw_rad` must be removed FIRST, and that is why this function exists**
+/// (issue #163). Those formulas assume the world x/y axes still line up with
+/// the body's, which was true only while the board had no yaw freedom at all
+/// -- precisely what the kinematic in-plant yaw injection changed. `xmat` is
+/// now `Rz(yaw) * R_body`, whose third column mixes body pitch and body roll
+/// by the heading angle, so after a 90 deg turn the raw formulas would report
+/// the board's ROLL as its PITCH and `FALLEN` would fire on an upright board.
+/// Left-multiplying by `Rz(-yaw)` -- which is all the two `deyawed_*` lines
+/// are -- recovers the body-frame values the ICD and the roll gate both mean.
+///
+/// At `yaw_rad == 0` this reduces to `1.0 * xmat[k] + 0.0 * xmat[j]`, i.e.
+/// bit-identically the pre-#163 expressions; `deyaw_at_zero_yaw_is_a_no_op`
+/// pins that.
+fn body_pitch_roll_rad(xmat: &[f64; 9], yaw_rad: f32) -> (f32, f32) {
+    let (yaw_s, yaw_c) = yaw_rad.sin_cos();
+    let deyawed_02 = yaw_c * xmat[2] as f32 + yaw_s * xmat[5] as f32;
+    let deyawed_12 = -yaw_s * xmat[2] as f32 + yaw_c * xmat[5] as f32;
+    (
+        deyawed_02.atan2(xmat[8] as f32),
+        deyawed_12.atan2(xmat[8] as f32),
+    )
 }
 
 pub fn spawn(cfg: HostConfig) -> std::thread::JoinHandle<Result<RunSummary, HostError>> {
@@ -585,6 +682,14 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     // finished, so a later rising edge can retrigger it.
     let mut fall_kick_window_start_s: Option<f64> = None;
     let mut prev_outside_corridor = false;
+    // The heading this host has injected into the plant so far, radians,
+    // unbounded (it is a running total, not an angle in `[-pi, pi]`) -- the
+    // integral of the yaw law at the bottom of the loop body. Two readers:
+    // the state-out wire's `yaw_rad` field, whose contract is exactly this
+    // continuous running total (see `wire::StateOut::yaw_rad`), and the
+    // attitude de-rotation below, which needs to know how much world-frame
+    // yaw is currently baked into MuJoCo's own quaternion before it can read
+    // body pitch and roll back out of it.
     let mut yaw_rad: f32 = 0.0;
     let mut wheel_angle_rad: f32 = 0.0;
     // Previous tick's ground speed, m/s, signed (positive = forward) -- used
@@ -594,18 +699,12 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     // cycle old by construction, the same lag `last_amps` already has for the
     // command-feedforward estimator.
     let mut last_forward_speed_m_s: f32 = 0.0;
-    // Dead-reckoned game-ground path -- see the PARTIALLY SYNTHETIC POSITION
-    // block further down for why this exists and what it costs. f64: this
-    // accumulates every tick for the whole run, and f32 would visibly drift
-    // over a multi-minute session the way `wheel_angle_rad` (f32, but reset
-    // every run and never compared against a long-run reference) does not
-    // need to guard against.
-    let mut dr_pos_x_m: f64 = 0.0;
-    let mut dr_pos_y_m: f64 = 0.0;
-    // Latest TRUE MuJoCo x/y, kept for `write_stats` -- the out-of-band
-    // channel that keeps ground truth available now that `pos`'s x/y on the
-    // wire itself are dead-reckoned, not MuJoCo truth. See the PARTIALLY
-    // SYNTHETIC POSITION block below.
+    // Latest TRUE MuJoCo x/y -- now BOTH the wire's `pos` and the corridor
+    // check's input (issue #163), as well as `write_stats`'s. Kept in a
+    // variable across ticks because the corridor check runs at the top of the
+    // loop body, before this tick's own observation, and so reads the
+    // PREVIOUS tick's truth -- the same one-cycle lag `last_forward_speed_m_s`
+    // has, for the same reason.
     let mut truth_pos_x_m: f64 = 0.0;
     let mut truth_pos_y_m: f64 = 0.0;
 
@@ -750,18 +849,17 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         };
 
         // Corridor boundary (issue #161 follow-up, item 4) -- see
-        // CORRIDOR_X_MIN_M's doc comment for why this exists instead of
-        // MuJoCo collision geometry, and where the bounds come from.
-        // Checked against dr_pos_x_m/dr_pos_y_m as they stood at the END of
-        // the PREVIOUS tick (this tick's own dead-reckoning update runs
-        // later in this same loop body) -- the same one-cycle lag the speed
-        // cap above uses, and for the same reason.
-        let outside_corridor = !(CORRIDOR_X_MIN_M..=CORRIDOR_X_MAX_M).contains(&dr_pos_x_m)
-            || dr_pos_y_m.abs() > CORRIDOR_HALF_WIDTH_M;
+        // CORRIDOR_X_MIN_M's doc comment for the bounds and for why this is a
+        // soft lean rather than contact. Checked against MuJoCo TRUTH position
+        // as of the END of the PREVIOUS tick (issue #163: this used to read
+        // the dead-reckoned path, which no longer exists) -- the same
+        // one-cycle lag the speed cap above uses, and for the same reason.
+        let outside_corridor = !(CORRIDOR_X_MIN_M..=CORRIDOR_X_MAX_M).contains(&truth_pos_x_m)
+            || truth_pos_y_m.abs() > CORRIDOR_HALF_WIDTH_M;
         if outside_corridor && !prev_outside_corridor {
             eprintln!(
-                "sim-host: LEFT THE DRIVABLE CORRIDOR at ({dr_pos_x_m:.1}, {dr_pos_y_m:.1}) m \
-                 -- arresting forward lean"
+                "sim-host: LEFT THE DRIVABLE CORRIDOR at ({truth_pos_x_m:.1}, \
+                 {truth_pos_y_m:.1}) m -- arresting forward lean"
             );
         } else if prev_outside_corridor && !outside_corridor {
             eprintln!("sim-host: back inside the drivable corridor");
@@ -876,109 +974,50 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // `impulse-response-rust` / `sim/scenarios/impulse_response.py::
         // frame_pitch_rad` use, against the same underlying xmat.
         let xmat = backend.truth_frame_xmat();
-        let pitch_rad = (xmat[2] as f32).atan2(xmat[8] as f32);
-        // Roll (rotation about the frame's forward/-X axis) -- the same
-        // atan2-of-a-tilted-axis derivation `pitch_rad` uses, applied to the
-        // Y-Z plane (roll, about local X) instead of the X-Z plane (pitch,
-        // about local Y). Exact only when pitch is near zero, since 3D
-        // rotations don't commute and this is not a true Euler decomposition
-        // -- acceptable for the roll-shaped yaw limiter's "cheap stopgap"
-        // status (issue #161 W2 item 4); the real lean-steer controller
-        // (Tuesday) needs a better one.
-        let roll_rad = (xmat[5] as f32).atan2(xmat[8] as f32);
+        // ATTITUDE MUST BE DE-YAWED BEFORE PITCH/ROLL COME OUT OF IT (issue
+        // #163). Both readings below are `atan2` on the frame's world z-axis,
+        // and that derivation assumes the world x/y axes still line up with
+        // the body's -- true when the board had no yaw freedom at all, which
+        // is exactly what the kinematic injection changed. `xmat` is now
+        // `Rz(yaw) * R_body`; its third column mixes body pitch and body roll
+        // by the heading angle, so after a 90 deg turn the raw formula would
+        // report the board's ROLL as its PITCH, and `FALLEN` would fire on a
+        // board that is upright. Removing the heading first (`Rz(-yaw) *
+        // xmat`, applied to the two elements the formulas read) recovers the
+        // body-frame values the ICD and the roll gate both mean.
+        //
+        // `yaw_rad` here is the heading currently baked into the plant -- this
+        // tick's own increment is computed and injected at the BOTTOM of the
+        // loop body, after this. At `yaw_rad == 0` (zero steer, all run) this
+        // reduces to `1.0 * xmat[k] + 0.0 * xmat[j]`, i.e. bit-identically the
+        // pre-#163 expressions.
+        let (pitch_rad, roll_rad) = body_pitch_roll_rad(&xmat, yaw_rad);
         let pos_f64 = backend.truth_frame_xpos();
         truth_pos_x_m = pos_f64[0];
         truth_pos_y_m = pos_f64[1];
+        // MuJoCo's own attitude, sent to the wire UNMODIFIED (issue #163).
+        // The host used to compose a synthetic heading onto this quaternion
+        // on its way out, because the plant had no yaw of its own; the
+        // heading now lives inside the plant, so there is nothing left to
+        // bolt on and the wire carries plain MuJoCo truth.
         let quat_f64 = backend.truth_frame_xquat();
-        // MuJoCo's own attitude: pitch and roll, and NO yaw -- this plant has no yaw degree of
-        // freedom at all. The heading is bolted on below, after `yaw_rad` is updated.
-        let quat_truth = [
+        let quat = [
             quat_f64[0] as f32,
             quat_f64[1] as f32,
             quat_f64[2] as f32,
             quat_f64[3] as f32,
         ];
 
-        // yaw_rad: NON-PHYSICAL game channel (issue #161). `steer` supplies
-        // the sign/direction; `roll_authority` scales its magnitude between
-        // YAW_AUTHORITY_FLOOR (steer alone, however little the player is
-        // leaning) and 1.0 (at/above ROLL_FULL_YAW_AUTHORITY_RAD's measured,
-        // physically-achievable roll). Read BOTH constants' doc comments
-        // before touching this line -- on the current (widened) wheel
-        // geometry, achievable roll is ~0.03 deg, so `steer` is effectively
-        // the primary driver of yaw this weekend, NOT roll; the floor is
-        // what makes that honest instead of a limiter that reads as "off".
-        // Updated BEFORE the position dead-reckoning below, so that
-        // reckoning always projects against this tick's freshest heading.
-        let roll_authority = YAW_AUTHORITY_FLOOR
-            + (1.0 - YAW_AUTHORITY_FLOOR)
-                * (roll_rad.abs() / ROLL_FULL_YAW_AUTHORITY_RAD).clamp(0.0, 1.0);
-        // SIGN (issue #161 follow-up, CEO-reported bug: "turns me left when
-        // I turn right"): increasing yaw_rad is a positive rotation about
-        // +Z (see the quaternion composition further down), which in this
-        // Z-up right-handed frame is counter-clockwise viewed from above --
-        // LEFT, by this model's own "right = +y" convention (see the `imu`
-        // site comment in `overboard_rider.xml`) and confirmed directly by
-        // the dead-reckoning heading formula below (`heading_y = -sin
-        // (yaw_rad)`, which moves toward -Y, i.e. left, as yaw_rad
-        // increases). So positive `steer` (stick-right) must DECREASE
-        // yaw_rad, not increase it -- `-=`, not `+=`. See `wire.rs`'s
-        // `InputIn::steer` doc comment for the wire-level convention this
-        // fixes.
-        //
-        // SPEED-PROPORTIONAL (issue #161 follow-up, CEO's own diagnosis:
-        // "you can just straight up turn yourself around... too fast").
-        // `YAW_CURVATURE_PER_STEER_RAD_PER_M`'s own doc comment has the
-        // full reasoning; the short version is that yaw RATE now scales
-        // with `forward_speed_m_s`, so turn radius stops depending on speed
-        // (as a real vehicle's does) instead of yaw rate being a flat,
-        // speed-independent rad/s.
-        let yaw_rate_rad_s =
-            steer * YAW_CURVATURE_PER_STEER_RAD_PER_M * forward_speed_m_s.abs() * roll_authority;
-        yaw_rad -= yaw_rate_rad_s * DT_S as f32;
-
-        // --- PARTIALLY SYNTHETIC POSITION (issue #161/#163) -------------
-        //
-        // MuJoCo only ever translates this plant along its own -X axis
-        // (there is no lateral/carving force anywhere in this model --
-        // `yaw_rad` never touches the physics). Sending MuJoCo's own
-        // x/y straight through, the way W1/W2's first cut did, is
-        // therefore honest about the SIM but dishonest about the GAME: on
-        // screen the board would spin to face `yaw_rad` while sliding
-        // along its original straight line underneath -- a car spinning
-        // out, not a board carving -- and that reads as a physics bug to
-        // anyone watching, on the single artifact (Monday's footage) this
-        // whole channel exists to protect.
-        //
-        // So `pos`'s x/y are DEAD-RECKONED here, in the host (never in
-        // Unreal -- the renderer computes no board state, ADR-0009 and
-        // `overboard-game`'s own README are explicit about that boundary):
-        // REAL forward ground speed (`wheel_rate_rad_s * DEFAULT_R_EFF_M`,
-        // straight off `hal`, nothing invented) is projected along the
-        // SYNTHETIC heading (`yaw_rad`) and integrated every tick. The
-        // result is a curved path that matches where the board is
-        // pointing -- exactly as partially synthetic as the heading that
-        // drives it, no more and no less.
-        //
-        // z is untouched: vertical position stays real MuJoCo truth (the
-        // wheel's own rolling motion in the sagittal plane needs no
-        // reckoning -- MuJoCo already integrates that correctly, which is
-        // the entire property this block exists to compensate for the
-        // LACK of in the lateral plane).
-        //
-        // This is a NEW non-physical channel, same status as `yaw_rad`/
-        // `steer` -- it needs its own line in the `Playable Sim` channel
-        // declaration (issue #163), flagged in this PR's body rather than
-        // added to `docs/vocabulary/` directly (Archivist's path, not
-        // this crate's). True MuJoCo x/y is NOT deleted -- see
-        // `write_stats`'s `truth_pos_x_m`/`truth_pos_y_m` lines below,
-        // which keep it available out-of-band for anything downstream
-        // that needs ground truth rather than the game path.
-        let heading_x = -yaw_rad.cos();
-        let heading_y = -yaw_rad.sin();
-        dr_pos_x_m += (forward_speed_m_s * heading_x) as f64 * DT_S;
-        dr_pos_y_m += (forward_speed_m_s * heading_y) as f64 * DT_S;
-        let pos = [dr_pos_x_m as f32, dr_pos_y_m as f32, pos_f64[2] as f32];
+        // MuJoCo truth, straight through (issue #163). Nothing is
+        // dead-reckoned any more: the board's heading is injected into the
+        // plant before each step (see the bottom of this loop body), so
+        // MuJoCo integrates the ground path itself, against its own contacts
+        // and collision geometry, and this IS where the board is.
+        let pos = [
+            truth_pos_x_m as f32,
+            truth_pos_y_m as f32,
+            pos_f64[2] as f32,
+        ];
 
         // Wire v2 (issue #161 follow-up): the ACTUAL ballast joint
         // positions -- CEO feedback was "there is no rider, and the turn
@@ -992,32 +1031,6 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // NOT amplify it for legibility; that is the renderer's job, as its
         // own declared non-physical channel, not this crate's to fake.
         let (rider_fore_aft_m, rider_lateral_m) = backend.truth_ballast_positions();
-
-        // --- SYNTHETIC HEADING, APPLIED TO ATTITUDE TOO (issue #161/#163) ------------
-        //
-        // The dead reckoning above curves the PATH along `yaw_rad`. Sending MuJoCo's raw
-        // quaternion alongside it -- which is what the first cut of this block did -- makes the
-        // board travel that curve without ever turning to face it: it crabs sideways, nose fixed,
-        // which reads as a physics bug just as loudly as the failure the comment above describes.
-        // The two are the same mismatch with opposite signs, and fixing only one of them swaps
-        // which half is wrong.
-        //
-        // So the same synthetic heading that steers the path also rotates the body. Composed
-        // HERE, in MuJoCo's frame and before the wire, so `MuJoCoToUnreal`'s handedness flip
-        // applies to it exactly as it does to the truth attitude -- the renderer keeps computing
-        // nothing (ADR-0009), and there is one heading in the system rather than two that can
-        // disagree.
-        //
-        // Yaw is about +Z, applied on the LEFT: world-frame heading first, then the board's own
-        // pitch/roll within it. Right-multiplying would apply the heading in the board's tilted
-        // local frame, so a leaning board would yaw about its own tilted axis and drift out of
-        // the ground plane. The sign is fixed by the dead reckoning it must agree with: rotating
-        // about +Z by `yaw_rad` maps (-1, 0) to (-cos, -sin), which IS (heading_x, heading_y).
-        //
-        // `quat_truth` is not discarded -- write_stats still logs the unmodified MuJoCo attitude
-        // alongside truth_pos_x_m/truth_pos_y_m, so ground truth stays available out-of-band.
-        let (yaw_sin_half, yaw_cos_half) = (yaw_rad * 0.5).sin_cos();
-        let quat = quat_mul([yaw_cos_half, 0.0, 0.0, yaw_sin_half], quat_truth);
 
         let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;
         if pitch_rad.abs() > FALLEN_PITCH_RAD {
@@ -1041,6 +1054,94 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             rider_lateral_m,
         };
         out_socket.send_to(&state.to_bytes(), cfg.state_out_addr)?;
+
+        // --- KINEMATIC IN-PLANT YAW INJECTION (issue #163) --------------
+        //
+        // The steering law below is UNCHANGED -- same constants, same roll
+        // shaping, same sign, same speed-proportional curvature. What changed
+        // is where its output goes. It used to integrate a `yaw_rad` that the
+        // physics never saw, and the host then dead-reckoned the ground path
+        // and composed the heading onto the outgoing quaternion, because
+        // MuJoCo's own board only ever translated along one axis. Both of
+        // those are gone. The increment is now written straight into the
+        // plant's free joint, immediately below, so the very next physics step
+        // integrates the board's translation along the new heading itself.
+        //
+        // **The reframe that motivates it: the collision goal never needed yaw
+        // to be physically GENERATED, only MuJoCo's pose to be
+        // AUTHORITATIVE.** Those are different problems and the second is far
+        // smaller. Steering is still commanded rather than emergent -- no tire
+        // model produces this turn, and this file is still the only place the
+        // heading comes from -- but position, ground path and every contact
+        // downstream of it are now genuinely simulated at that heading, and
+        // collision geometry in the MJCF would finally be tested against the
+        // position the renderer actually draws. Nothing is dead-reckoned any
+        // more. The MJCF is untouched, which is the entire point of doing it
+        // this way.
+        //
+        // **REJECTED: making the wheel carve by geometry** (replacing the
+        // cylinder with a sphere, ellipsoid or torus so a lean migrates the
+        // contact patch and friction generates the turn). Recorded here
+        // because it is the obvious idea and it is a trap on this plant:
+        // the board is currently roll-stable ONLY because the wide cylinder
+        // rim physically cannot tip (measured full-stick roll is 0.03 deg --
+        // see ROLL_FULL_YAW_AUTHORITY_RAD). Any laterally-migrating contact
+        // profile converts the board into a roll-axis inverted pendulum about
+        // the contact point, and there is NO roll/lean controller in this
+        // repo yet, so it would simply fall over sideways. That option is
+        // gated on lean-steer; they are one epic, not two. Also, a torus mesh
+        // fails silently rather than loudly: MuJoCo convex-hulls meshes, and
+        // the convex hull of a torus is a rounded-rim disc.
+        //
+        // Placed here, at the END of the loop body, rather than at the top:
+        // this way everything already sent on the wire above describes the
+        // state as OBSERVED, and the injection is unambiguously the last
+        // thing that happens before the next `wait_observe()` steps the
+        // physics. `roll_rad` and `forward_speed_m_s` are this tick's own
+        // fresh values, exactly as the pre-#163 law used.
+        //
+        // `roll_authority` scales the law's magnitude between
+        // YAW_AUTHORITY_FLOOR (steer alone, however little the player is
+        // leaning) and 1.0 (at/above ROLL_FULL_YAW_AUTHORITY_RAD's measured,
+        // physically-achievable roll). Read BOTH constants' doc comments
+        // before touching it -- on the current (widened) wheel geometry,
+        // achievable roll is ~0.03 deg, so `steer` is effectively the primary
+        // driver of yaw, NOT roll; the floor is what makes that honest
+        // instead of a limiter that reads as "off".
+        let roll_authority = YAW_AUTHORITY_FLOOR
+            + (1.0 - YAW_AUTHORITY_FLOOR)
+                * (roll_rad.abs() / ROLL_FULL_YAW_AUTHORITY_RAD).clamp(0.0, 1.0);
+        // SIGN (issue #161 follow-up, CEO-reported bug: "turns me left when
+        // I turn right"): increasing yaw_rad is a positive rotation about +Z,
+        // which in this Z-up right-handed frame is counter-clockwise viewed
+        // from above -- LEFT, by this model's own "right = +y" convention
+        // (see the `imu` site comment in `overboard_rider.xml`). So positive
+        // `steer` (stick-right) must DECREASE yaw_rad -- `-`, not `+`. See
+        // `wire.rs`'s `InputIn::steer` doc comment for the wire-level
+        // convention this implies.
+        //
+        // SPEED-PROPORTIONAL (issue #161 follow-up, CEO's own diagnosis: "you
+        // can just straight up turn yourself around... too fast").
+        // `YAW_CURVATURE_PER_STEER_RAD_PER_M`'s own doc comment has the full
+        // reasoning; the short version is that yaw RATE scales with
+        // `forward_speed_m_s`, so turn radius stops depending on speed (as a
+        // real vehicle's does). At a standstill this is exactly zero, and the
+        // gate below then makes the whole injection a literal no-op.
+        let yaw_rate_rad_s =
+            steer * YAW_CURVATURE_PER_STEER_RAD_PER_M * forward_speed_m_s.abs() * roll_authority;
+        let dyaw_rad = -yaw_rate_rad_s * DT_S as f32;
+        // GATED ON EXACT ZERO, deliberately. With no steer (or no ground
+        // speed) the plant must evolve bit-identically to the pre-#163 code:
+        // this loop injects nothing, writes nothing, and the only remaining
+        // difference on the wire is that `pos` reports MuJoCo's own x/y
+        // instead of a reckoned one. `SimBackend::inject_kinematic_yaw`
+        // re-checks the same condition; the gate is repeated here so that
+        // `yaw_rad` and the plant can never disagree about whether a tick's
+        // increment was applied.
+        if dyaw_rad != 0.0 {
+            yaw_rad += dyaw_rad;
+            backend.inject_kinematic_yaw(dyaw_rad as f64);
+        }
 
         ticks += 1;
 
@@ -1091,10 +1192,10 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
 /// pick up. Never allowed to interrupt the control loop -- a failure here is
 /// silently swallowed ON PURPOSE (unlike a missed deadline or a malformed
 /// input packet, which issue #161 requires surfacing loudly): this file is
-/// internal tooling, not the wire. `truth_pos_x_m`/`truth_pos_y_m` exist
-/// because `pos`'s x/y on the wire are now dead-reckoned, not MuJoCo truth
-/// (see the PARTIALLY SYNTHETIC POSITION block in `run`) -- ground truth
-/// must stay reachable for anything downstream that needs it.
+/// internal tooling, not the wire. `truth_pos_x_m`/`truth_pos_y_m` are kept
+/// here for continuity with the tooling that already reads them -- as of
+/// issue #163 they are the SAME values the wire's `pos` now carries, since
+/// the dead-reckoned path is gone and MuJoCo's own position is authoritative.
 fn write_stats(
     path: &std::path::Path,
     ticks: u64,
@@ -1113,86 +1214,108 @@ fn write_stats(
 mod tests {
     use super::*;
 
-    /// Rotate `v` by quaternion `q` (`q v q*`).
-    fn rotate(q: [f32; 4], v: [f32; 3]) -> [f32; 3] {
-        let qv = [0.0, v[0], v[1], v[2]];
-        let qc = [q[0], -q[1], -q[2], -q[3]];
-        let r = quat_mul(quat_mul(q, qv), qc);
-        [r[1], r[2], r[3]]
-    }
-
-    fn yaw_quat(yaw_rad: f32) -> [f32; 4] {
-        let (s, c) = (yaw_rad * 0.5).sin_cos();
-        [c, 0.0, 0.0, s]
-    }
-
-    #[test]
-    fn quat_mul_identity_is_identity() {
-        // 90 deg about +Y. Spelled with the constant rather than 0.7071068, which clippy
-        // (correctly) flags as an approximation of it.
-        const H: f32 = std::f32::consts::FRAC_1_SQRT_2;
-        let q = [H, 0.0, H, 0.0];
-        let i = [1.0, 0.0, 0.0, 0.0];
-        for (a, b) in quat_mul(i, q).iter().zip(q.iter()) {
-            assert!((a - b).abs() < 1e-6, "identity * q != q");
-        }
-        for (a, b) in quat_mul(q, i).iter().zip(q.iter()) {
-            assert!((a - b).abs() < 1e-6, "q * identity != q");
-        }
-    }
-
-    /// THE invariant this whole fix exists for: the attitude on the wire must point the board
-    /// along the heading the position dead reckoning is steering it down. Before the fix, `quat`
-    /// was MuJoCo's raw attitude, which has no yaw at all -- so the board crabbed along a curved
-    /// path with its nose fixed. `yaw_rad` was transmitted and used by nobody.
+    /// Build `Rz(yaw) * Ry(pitch) * Rx(-roll)`, row-major, the same layout
+    /// MuJoCo's `xmat` uses. This is the composition [`body_pitch_roll_rad`]
+    /// has to invert.
     ///
-    /// The board's nose is its LOCAL -X (see `overboard_onewheel.xml`: "FORWARD IS -X"), and the
-    /// dead reckoning drives it along `(-cos yaw, -sin yaw)`. Those must be the same direction.
+    /// The `-roll` is not a typo. This crate's roll is measured about the
+    /// frame's FORWARD axis, which is its local **-X** (see
+    /// `overboard_onewheel.xml`: "FORWARD IS -X"), so a positive roll here is
+    /// a negative rotation about +X. Building the reference matrix in the same
+    /// convention the function under test reports keeps the sign flip in one
+    /// place instead of scattering `-` through every assertion.
+    fn xmat_from(yaw: f64, pitch: f64, roll: f64) -> [f64; 9] {
+        let (sy, cy) = yaw.sin_cos();
+        let (sp, cp) = pitch.sin_cos();
+        let (sr, cr) = (-roll).sin_cos();
+        [
+            cy * cp,
+            cy * sp * sr - sy * cr,
+            cy * sp * cr + sy * sr,
+            sy * cp,
+            sy * sp * sr + cy * cr,
+            sy * sp * cr - cy * sr,
+            -sp,
+            cp * sr,
+            cp * cr,
+        ]
+    }
+
+    /// Guard 1's unit-test half: with no heading injected, the de-yaw must be
+    /// a LITERAL no-op -- not "close to", but the identical bits the pre-#163
+    /// code produced. Zero steer has to leave every wire field it can reach
+    /// untouched, and `1.0 * x + 0.0 * y` is only bit-safe as long as nobody
+    /// "simplifies" the expression later.
     #[test]
-    fn synthetic_heading_rotates_the_body_it_steers() {
-        let level = [1.0f32, 0.0, 0.0, 0.0];
-        for &yaw in &[0.0f32, 0.3, -0.7, 1.9, -2.8, 3.0] {
-            let quat = quat_mul(yaw_quat(yaw), level);
-            let nose = rotate(quat, [-1.0, 0.0, 0.0]);
+    fn deyaw_at_zero_yaw_is_a_no_op() {
+        for &(p, r) in &[(0.0, 0.0), (0.12, -0.03), (-0.31, 0.007), (0.0, 0.4)] {
+            let xmat = xmat_from(0.0, p, r);
+            let (pitch, roll) = body_pitch_roll_rad(&xmat, 0.0);
+            // Bit-for-bit against the exact expressions this replaced.
+            assert_eq!(pitch, (xmat[2] as f32).atan2(xmat[8] as f32));
+            assert_eq!(roll, (xmat[5] as f32).atan2(xmat[8] as f32));
+        }
+    }
 
-            // Exactly the two lines the position integrator uses.
-            let heading_x = -yaw.cos();
-            let heading_y = -yaw.sin();
+    /// THE regression the in-plant injection introduces if de-yawing is
+    /// forgotten: a turned board reports its ROLL as its PITCH, so `FALLEN`
+    /// fires on a board that is perfectly upright.
+    ///
+    /// Concretely: 12 deg of body roll, no body pitch, yawed 90 deg. The raw
+    /// pre-#163 formula reads the frame's world z-axis in world x, which after
+    /// a quarter turn IS the roll -- it would report ~12 deg of pitch. The
+    /// de-yawed reading must report ~0.
+    #[test]
+    fn a_turned_board_does_not_report_its_roll_as_pitch() {
+        let yaw = std::f64::consts::FRAC_PI_2;
+        let roll = 12.0f64.to_radians();
+        let xmat = xmat_from(yaw, 0.0, roll);
 
+        let naive_pitch = (xmat[2] as f32).atan2(xmat[8] as f32);
+        assert!(
+            naive_pitch.abs() > 0.15,
+            "this test proves nothing unless the naive formula is badly wrong here \
+             (got {naive_pitch} rad)"
+        );
+
+        let (pitch, r) = body_pitch_roll_rad(&xmat, yaw as f32);
+        assert!(
+            pitch.abs() < 1e-5,
+            "de-yawed pitch should be ~0 on an unpitched board, got {pitch} rad"
+        );
+        assert!(
+            (r - roll as f32).abs() < 1e-5,
+            "de-yawed roll should be the body roll ({roll} rad), got {r}"
+        );
+    }
+
+    /// The de-yaw must recover both angles across a range of headings, not
+    /// just the one the previous test happens to pick.
+    #[test]
+    fn deyaw_recovers_body_pitch_and_roll_at_any_heading() {
+        let pitch = 0.09f64;
+        let roll = 0.02f64;
+        for &yaw in &[0.0f64, 0.4, -1.1, 2.6, -3.0, 5.9] {
+            let xmat = xmat_from(yaw, pitch, roll);
+            let (p, r) = body_pitch_roll_rad(&xmat, yaw as f32);
             assert!(
-                (nose[0] - heading_x).abs() < 1e-5 && (nose[1] - heading_y).abs() < 1e-5,
-                "yaw={yaw}: nose points ({}, {}) but the path is steered along ({heading_x}, {heading_y})",
-                nose[0],
-                nose[1]
+                (p - pitch as f32).abs() < 1e-4 && (r - roll as f32).abs() < 1e-4,
+                "yaw={yaw}: recovered ({p}, {r}), wanted ({pitch}, {roll})"
             );
         }
     }
 
-    /// The heading must be composed on the LEFT (world frame), not the right (body frame).
-    ///
-    /// With the board rolled, right-multiplying yaws it about its own tilted axis, which lifts the
-    /// nose out of the ground plane and makes the rendered heading disagree with the flat path the
-    /// dead reckoning integrates. Left-multiplying keeps the two consistent: whatever the board's
-    /// attitude, its nose still projects onto the heading the position is following.
+    /// The steering law's standstill property, which the speed-proportional
+    /// curvature formulation exists to give: full stick at zero ground speed
+    /// produces EXACTLY zero heading change, so the injection guarded by it is
+    /// a literal no-op. You cannot carve a stationary onewheel.
     #[test]
-    fn heading_is_applied_in_the_world_frame_not_the_body_frame() {
-        let roll = 0.35f32; // rolled board, as during a carve
-        let (s, c) = (roll * 0.5).sin_cos();
-        let rolled = [c, s, 0.0, 0.0]; // rotation about local X
-        let yaw = 0.9f32;
-
-        let correct = rotate(quat_mul(yaw_quat(yaw), rolled), [-1.0, 0.0, 0.0]);
-        let wrong = rotate(quat_mul(rolled, yaw_quat(yaw)), [-1.0, 0.0, 0.0]);
-
-        let (hx, hy) = (-yaw.cos(), -yaw.sin());
-        assert!(
-            (correct[0] - hx).abs() < 1e-5 && (correct[1] - hy).abs() < 1e-5,
-            "left-composed heading should match the dead-reckoned one"
-        );
-        // Guard against someone "simplifying" the order later: on a rolled board the two differ.
-        assert!(
-            (wrong[0] - hx).abs() > 1e-3 || (wrong[1] - hy).abs() > 1e-3,
-            "body-frame composition must NOT agree here, or this test proves nothing"
-        );
+    fn full_steer_at_a_standstill_injects_nothing() {
+        for &steer in &[1.0f32, -1.0, 0.6] {
+            let roll_authority = 1.0f32;
+            let yaw_rate = steer * YAW_CURVATURE_PER_STEER_RAD_PER_M * 0.0f32 * roll_authority;
+            let dyaw = -yaw_rate * DT_S as f32;
+            assert_eq!(dyaw, 0.0, "steer={steer} at rest must not turn the board");
+        }
     }
 }

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -79,36 +79,44 @@ pub struct StateOut {
     /// world frame. **Not** converted to Unreal's frame -- that conversion
     /// is deliberately the game side's job, not this host's (issue #161).
     ///
-    /// **`x`/`y` are PARTIALLY SYNTHETIC as of issue #161/#169's follow-up,
-    /// NOT raw MuJoCo truth** -- `crate::host` dead-reckons them from real
-    /// forward ground speed projected along the synthetic `yaw_rad` heading,
-    /// because MuJoCo itself never turns this plant (there is no lateral
-    /// force in the model; `yaw_rad` is a rendering-only overlay). Sending
-    /// literal MuJoCo x/y here would make the board spin in place while
-    /// sliding along its original straight line on screen -- a car spinning
-    /// out, not a board carving. See `crate::host::run`'s "PARTIALLY
-    /// SYNTHETIC POSITION" comment for the full reasoning; true MuJoCo x/y
-    /// stays reachable out-of-band via `crate::host::write_stats`'s
-    /// `truth_pos_x_m`/`truth_pos_y_m`. This deviates from this field's
-    /// original description in ADR-0010's wire table (which predates the
-    /// widened-wheel roll-authority finding that made it necessary); per
-    /// that ADR's own "Consequences" section, the code and this comment are
-    /// authoritative over the table when they disagree.
-    ///
-    /// `z` is untouched: vertical position is real MuJoCo truth throughout.
+    /// **Raw MuJoCo truth, all three components, as of issue #163.** Between
+    /// PR #172 and #163 `x`/`y` were dead-reckoned here -- projected from real
+    /// forward ground speed along a synthetic heading -- because MuJoCo never
+    /// turned this plant and sending its literal x/y would have shown a board
+    /// spinning in place while sliding down its original straight line.
+    /// `crate::host` now injects the heading into the plant's free joint
+    /// before each physics step instead, so MuJoCo integrates the ground path
+    /// itself and its own position IS the on-screen position. Nothing here is
+    /// reckoned, and this field is once again exactly what ADR-0010's wire
+    /// table describes.
     pub pos: [f32; 3],
-    /// Board body orientation, raw MuJoCo, **w, x, y, z**.
+    /// Board body orientation, raw MuJoCo, **w, x, y, z** -- and as of issue
+    /// #163 that is now literally true again. Between PR #172 and #163 the
+    /// host composed its synthetic heading onto this quaternion on the way
+    /// out, because the plant had no yaw of its own to report; the heading
+    /// now lives inside the plant, so there is nothing left to bolt on and
+    /// this carries MuJoCo's attitude unmodified. It already includes the
+    /// board's heading, so a renderer needs nothing but this.
     pub quat: [f32; 4],
     pub wheel_angle_rad: f32,
     /// Positive = forward.
     pub wheel_rate_rad_s: f32,
     /// Nose-up positive (ICD SS10.1).
     pub pitch_rad: f32,
-    /// NON-PHYSICAL game steering channel -- see
-    /// `crate::host::YAW_CURVATURE_PER_STEER_RAD_PER_M`'s doc comment for
-    /// the current rate model. The simulated wheel is a cylinder and cannot
-    /// physically carve; this is an integration of the `steer` input,
-    /// present so the game side has a heading to render with.
+    /// COMMANDED heading, radians, as a continuous running total (NOT wrapped
+    /// to `[-pi, pi]`) -- the integral of the `steer` input under
+    /// `crate::host::YAW_CURVATURE_PER_STEER_RAD_PER_M`'s rate model. The
+    /// simulated wheel is a cylinder and cannot physically carve: no tire
+    /// contact generates this turn, the host commands it.
+    ///
+    /// **What changed at issue #163: this is no longer an overlay the physics
+    /// never saw.** Each tick's increment is injected into MuJoCo's own free
+    /// joint before the step, so this value is the heading actually baked into
+    /// the plant, and `quat` above agrees with it by construction rather than
+    /// by a second composition. It is kept on the wire as a convenience (a
+    /// continuous, unwrapped scalar heading a renderer can interpolate
+    /// without unwrapping a quaternion), not as a separate source of truth --
+    /// `quat` is the authoritative attitude.
     ///
     /// **Sign (issue #161 follow-up): positive `yaw_rad` turns the board
     /// LEFT** (a positive rotation about MuJoCo's +Z, which is


### PR DESCRIPTION
## What and why

The board's heading now lives **inside the plant**. The same steering law — `YAW_CURVATURE_PER_STEER_RAD_PER_M`, the same roll shaping, the same sign, the same signed-off feel — writes its per-tick increment straight into MuJoCo's free joint before each physics step, instead of being carried alongside the physics and composed onto the output afterwards.

**The reframe:** the collision goal never required yaw to be physically *generated*, only MuJoCo's pose to be *authoritative*. Those are different problems, and the second is far smaller. **The MJCF is not touched** — that is the point of doing it this way.

Each tick, before the step, `dyaw = steer * k * v * roll_authority * dt`:

1. pre-multiply the freejoint quaternion by `quat_z(dyaw)` (world frame, about the vertical axis through the board's own x/y);
2. rotate the freejoint's **world-frame** linear velocity by the same angle;
3. leave the freejoint's **body-frame** angular velocity alone — rotating it too would double-count the injection as a spurious yaw rate.

MuJoCo then integrates the translation along the rotated heading itself.

### What this deletes

- The dead-reckoned ground path (`dr_pos_x_m`/`dr_pos_y_m`) entirely. `pos` on the wire is MuJoCo truth in all three components.
- The post-observe quaternion compose. `quat` is raw MuJoCo again, and it already carries the heading.
- The reason the drivable corridor could not use collision geometry. `CORRIDOR_*` now checks truth position, and geometry added to the MJCF would finally be tested against the position the renderer draws.

### What this adds

- `plant-mujoco`: `Plant::set_qpos_range` / `set_qvel_range` / `joint_dofadr`. The first write path into the state vector, deliberately **range-scoped** so a bug corrupts one joint rather than smearing the whole state. `jnt_dofadr` is separate from `jnt_qposadr` because a free joint is 7 `qpos` but 6 `qvel`.
- `sim-backend`: `SimBackend::inject_kinematic_yaw`, with the three-part contract above and a `dyaw == 0.0` early return.
- `sim-host`: `body_pitch_roll_rad`. **Not in the original scope, and required.** Pitch and roll are read out of `xmat` by an `atan2` that assumes the world x/y axes still line up with the body's — true only while the board had no yaw freedom. `xmat` is now `Rz(yaw) · R_body`, so without de-yawing, a board 90° into a turn reports its **roll as its pitch** and `FALLEN` fires on an upright board. Pinned by unit test.

## Guard 1 — zero-steer bit identity ✅

`dyaw != 0` gates the mutation, so zero steer is a literal no-op. Measured with a full-precision wire decoder (`wire-probe --csv` rounds to 6 decimals and cannot demonstrate bit identity):

| check | result |
|---|---|
| `sim-host --startup-kick`, no scenario/sender, 7,854 ticks, master vs branch | `pitch`, `quat`×4, `wheel_angle`, `wheel_rate`, `motor_current`, `rider_*`, `pos_z`, `sim_time`, `flags` — **all bit-identical** |
| `impulse-response-rust` (Rust-hosted, through the changed crates) | output file **byte-identical** to master |
| `sim/scenarios/impulse_response.py` full `qpos` trajectory | SHA-256 `bdc6a781…f9290d` on **both** trees |
| `pytest tests/` | **307 passed, 2 xfailed** — including the two bit-for-bit plant-equivalence gates |
| branch run-to-run determinism | bit-identical |

The **only** columns that differ are `pos_x`/`pos_y`, by design — and the gap *is* the error the old design was shipping: **14.7 mm over 7.37 m of travel (0.2%)** in x, and **8.2 µm** in y, where dead reckoning reported y as exactly `0.0` because it could not represent lateral motion at all.

## Guard 2 — steer-on equivalence ✅

Driven through `--scripted-scenario default` (PR #191's sim-time-indexed player: no socket, no wall clock, fully deterministic), 9,000 ticks, tick-for-tick against master:

| quantity | max delta |
|---|---|
| `pitch` | 2.1e-9 rad (1.2e-7 deg) |
| `wheel_rate` | 4.8e-7 rad/s |
| `motor_current` | 3.9e-7 A |
| largest `quat` component | 8.3e-5 |
| commanded heading | 1.7e-4 rad |
| **path, x** | **4.4 cm over 16 m (0.28%)** |
| **path, y** | **1.5 cm** |

- **Pitch envelope: `-5.842 .. +6.390°` — identical to master's on the same schedule**, and the same envelope the corridor-brake run recorded. Well inside the `|pitch| < 10°` carving limit.
- The dead-reckoning reconstruction the path comparison rests on is itself validated: replayed against **master's** own run it reproduces master's reported track to **0.0000 m**, so it is the deleted block, not an approximation of it.
- Truth attitude tracks the commanded heading to **0.19°** — and *master's* truth attitude differs from its own `yaw_rad` by the same **0.19°**. That residual is the plant's own contact-driven yaw, not the injection fighting the physics.

### The s-curve flip (#190) is untouched

Driven deterministically, master and branch cross 20°, 90° and 170° of pitch on the **identical tick** (seq 2933 / t = 5.868 s, seq 3070, seq 3216), and every physics column is bit-identical for the first **7,375 ticks** — the entire zero-steer portion, which is where the flip happens. The traces only separate once `steer` goes non-zero at t = 14.75 s, by which point both boards are tumbling. Not my change, not moved by my change.

### Corridor re-verified against truth position

Same tighten-to-−3 m method the constant's doc comment records. Log fired exactly once at `(-3.0, 0.0)`; truth `x` overshot to −7.6 m under residual momentum, then held at −7.3 m; pitch stayed `-4.7 .. +6.2°`. Bound reverted. (The overshoot differs from the −10.3 m recorded pre-#191 only because that run was wall-clock paced and crossed the line at a different speed.)

## Rejected, and recorded in the doc comment

Replacing the wheel cylinder with a **sphere / ellipsoid / torus** so carving emerges from friction. The board is roll-stable *only* because the wide cylinder rim physically cannot tip (measured full-stick roll: 0.03°). Any laterally-migrating contact profile turns it into a roll-axis inverted pendulum about the contact point, and there is no roll/lean controller yet — it would fall over sideways. Gated on lean-steer; they are one epic. A torus also fails **silently**: MuJoCo convex-hulls meshes, and the hull of a torus is a rounded-rim disc.

## ⚠️ Known stale-on-merge: the public provenance text

**From the moment this merges until the Archivist acts, the enforced `Playable Sim` declaration on `master` says something that is no longer true.** It claims the board's ground path is dead-reckoned. It is not — MuJoCo integrates it. This is stated here rather than discovered later. Open thread: **#163**, where the replacement wording and its three knock-on consequences are written up in full. No published asset should carry the old line from here on.

## Provenance — needs the Archivist, not this PR

The enforced `Playable Sim` declaration currently says *"The board's ground path is dead-reckoned, not simulated."* That clause is now **false** and must be **replaced, not deleted** — the invented-heading clause survives. Adjudicated wording:

> "Steering is commanded, not emergent: the host rotates the simulated board's heading (and velocity direction) from rider steer input; tire physics does not generate the turn. Position, ground path and collisions are then fully simulated at that heading — nothing is dead-reckoned."

`docs/vocabulary/provenance-marks.json` (`ground-path-dead-reckoned`) and `sweep_public.py` are **deliberately not edited here** — that set is the Archivist's, and unilateral edits to it are exactly what the sweep exists to prevent. Raised on #163.

## Acceptance criteria moved

- `pos` on the state-out wire is MuJoCo truth; nothing on the wire is dead-reckoned.
- Collision geometry in the MJCF would now be tested against the position the renderer draws — the blocker `CORRIDOR_X_MIN_M`'s doc comment described is gone.
- Steering feel unchanged: same constants, same law, pitch envelope identical to master's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
