### PR TITLE
feat(controls): command-envelope reserve + loss-of-authority warning -- (b) and (c) met, (f) is not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,13 @@ jobs:
       - name: Build the Rust-hosted impulse-response binary
         run: cargo build --release -p board-app-driverless --bin impulse-response-rust
 
+      # ADR-0011: tests/test_cmd_envelope_reserve.py shells out to this binary
+      # for the command-envelope-reserve acceptance matrix. Same "fail rather
+      # than skip" rule as above -- that file's first test asserts the binary
+      # exists, so a missing build is a red gate rather than a quiet one.
+      - name: Build the sim host
+        run: cargo build --release -p sim-host --bin sim-host
+
       - name: Scenario acceptance gate
         run: pytest tests/ -v
 
@@ -315,6 +322,13 @@ jobs:
       # because this job is not a required status check.
       - name: Build the Rust-hosted impulse-response binary
         run: cargo build --release -p board-app-driverless --bin impulse-response-rust
+
+      # ADR-0011: tests/test_cmd_envelope_reserve.py shells out to this binary
+      # for the command-envelope-reserve acceptance matrix. Same "fail rather
+      # than skip" rule as above -- that file's first test asserts the binary
+      # exists, so a missing build is a red gate rather than a quiet one.
+      - name: Build the sim host
+        run: cargo build --release -p sim-host --bin sim-host
 
       # Only tests that PASS contribute a claim (docs/design-claims-manifest.md,
       # issue #61). A red run here still writes a manifest of whatever passed,

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -318,6 +318,53 @@ impl SimBackend {
         (fore_aft, lateral)
     }
 
+    /// Ground-truth BODY-frame pitch rate of the `frame` body, rad/s, nose-up
+    /// positive -- the exact time derivative of the pitch angle
+    /// `sim-host::body_pitch_roll_rad` reads out of
+    /// [`SimBackend::truth_frame_xmat`], with no filter, no differencing and
+    /// no estimator in the path.
+    ///
+    /// Same non-`hal`, harness-only status as every other `truth_*` accessor
+    /// here (DR-OBS-1: `control-core` never sees this on a real board). It
+    /// exists for ADR-0011 criterion (f) -- "every pass must hold with the
+    /// estimator bias removed", which means an acceptance run has to be able
+    /// to feed the regulator MuJoCo truth instead of the complementary
+    /// filter's belief, and the regulator's D term needs a truth pitch RATE
+    /// as much as its P term needs a truth pitch.
+    ///
+    /// # Why `qvel[dof + 4]` is the pitch rate, and not something needing a
+    /// # de-yaw
+    ///
+    /// MuJoCo stores a free joint's velocity as 3D linear velocity in GLOBAL
+    /// coordinates followed by 3D angular velocity in the BODY frame -- the
+    /// same fact [`SimBackend::inject_kinematic_yaw`] relies on when it
+    /// rotates the linear half and deliberately leaves the angular half
+    /// alone. Body-frame angular velocity is therefore already heading-free:
+    /// unlike `xmat`, it needs no `Rz(-yaw)` applied to it.
+    ///
+    /// Component `+1` of that angular triple is rotation about the body's
+    /// **+Y**, and pitch (`atan2(xmat[2], xmat[8])`, ICD 10.1, nose-up
+    /// positive) is exactly the angle about that axis: for `R_y(theta)`,
+    /// `xmat[2] = sin(theta)` and `xmat[8] = cos(theta)`, so pitch `== theta`
+    /// and pitch rate `== omega_y`. No sign flip.
+    ///
+    /// `0.0` on a model that declares no `frame_free` joint -- the same
+    /// tolerance [`SimBackend::truth_ballast_positions`] has, for the same
+    /// reason.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_body_pitch_rate_rad_s(&self) -> f32 {
+        let plant = self
+            .plant
+            .as_ref()
+            .expect("truth_body_pitch_rate_rad_s: backend is not open");
+        match self.frame_free_dofadr {
+            Some(vadr) => plant.qvel()[vadr + 4] as f32,
+            None => 0.0,
+        }
+    }
+
     /// Rotates the board's free joint about the WORLD vertical axis through
     /// its own current x/y by `dyaw_rad`, so that the next
     /// [`BoardObserve::wait_observe`] integrates the board's translation along
@@ -721,6 +768,81 @@ mod tests {
         let mut b = opened();
         b.arm().unwrap();
         b
+    }
+
+    /// `truth_body_pitch_rate_rad_s` must be the actual time derivative of
+    /// the pitch angle every other consumer reads out of `truth_frame_xmat`,
+    /// in both magnitude AND sign -- it is the regulator's D-term input on an
+    /// ADR-0011 criterion (f) acceptance run, and a sign error there would
+    /// invert the damping term and be indistinguishable from a physics
+    /// finding.
+    ///
+    /// Checked by differencing, which needs no knowledge of MuJoCo's free
+    /// joint layout and therefore cannot make the same mistake the accessor
+    /// might: kick the board over with an external torque, then compare the
+    /// reported rate against `(pitch[n] - pitch[n-1]) / dt` over the swing.
+    #[test]
+    fn the_truth_pitch_rate_is_the_derivative_of_the_truth_pitch_angle() {
+        let mut b = armed();
+        let dt = CYCLE_NS as f64 * 1e-9;
+        let pitch = |b: &SimBackend| {
+            let m = b.truth_frame_xmat();
+            (m[2]).atan2(m[8])
+        };
+        // A torque big enough to produce a rate worth differencing, small
+        // enough that the board stays in the small-angle regime where
+        // `atan2(xmat[2], xmat[8])` IS the body rotation about +Y. Drive it
+        // to a full tumble instead and the two quantities stop being the same
+        // thing, which would make this a test of large-angle Euler
+        // bookkeeping rather than of the accessor.
+        b.apply_external_force([0.0; 3], [0.0, 20.0, 0.0]);
+        let mut prev = pitch(&b);
+        let mut prev_reported = b.truth_body_pitch_rate_rad_s() as f64;
+        let mut checked = 0;
+        let mut peak = 0.0f64;
+        for _ in 0..40 {
+            b.apply_external_force([0.0; 3], [0.0, 20.0, 0.0]);
+            b.wait_observe().unwrap();
+            let now = pitch(&b);
+            let numeric = (now - prev) / dt;
+            let reported = b.truth_body_pitch_rate_rad_s() as f64;
+            peak = peak.max(numeric.abs());
+            // Compared against the MEAN of the two endpoint rates, not
+            // against either one: a difference quotient is the average rate
+            // over the interval, and under a steady torque the instantaneous
+            // rate at the far end is twice the average at the very first step
+            // (from rest). Trapezoid removes that first-order term, so the
+            // tolerance can be tight enough for a sign or scale error to have
+            // nowhere to hide.
+            let trapezoid = 0.5 * (prev_reported + reported);
+            assert!(
+                (numeric - trapezoid).abs() < 1e-3 + 0.01 * numeric.abs(),
+                "reported pitch rate {reported} does not match the differenced \
+                 {numeric} rad/s (a sign error would show here first)"
+            );
+            prev = now;
+            prev_reported = reported;
+            checked += 1;
+        }
+        assert_eq!(checked, 40);
+        assert!(
+            peak > 0.1,
+            "this test proves nothing unless the board actually rotated; peak \
+             differenced rate was only {peak} rad/s"
+        );
+    }
+
+    /// A model with no free joint reports zero rather than panicking or
+    /// indexing out of bounds -- the same tolerance every other `truth_*`
+    /// accessor here has for a channel a model does not declare.
+    #[test]
+    fn the_truth_pitch_rate_is_zero_before_the_board_is_disturbed() {
+        let mut b = armed();
+        b.wait_observe().unwrap();
+        assert!(
+            b.truth_body_pitch_rate_rad_s().abs() < 1e-6,
+            "a settled board is not rotating"
+        );
     }
 
     #[test]

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -8,7 +8,12 @@
 //! ```text
 //! sim-host [--duration-secs SECONDS] [--startup-kick]
 //!          [--state-out-addr ADDR] [--input-in-addr ADDR]
-//!          [--scripted-scenario default|s-curve] [--stats-path PATH|none]
+//!          [--scripted-scenario default|s-curve|full-stick|stick-reversal]
+//!          [--stats-path PATH|none]
+//!          [--free-run] [--max-sim-secs SECONDS]
+//!          [--pitch-source estimator|truth] [--pitch-bias-deg DEGREES]
+//!          [--cmd-reserve FRACTION]
+//!          [--disturbance t0,dur,fx,fy,fz,tx,ty,tz] [--trace-csv PATH]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
 //! it, stops after that many seconds and exits -- used for verification runs
@@ -103,6 +108,120 @@ fn main() -> ExitCode {
                 } else {
                     Some(std::path::PathBuf::from(v))
                 };
+                i += 2;
+            }
+            // --- ADR-0011 acceptance instrumentation -------------------
+            // All verification-only, all documented on HostConfig. Their
+            // reason for existing on the command line rather than in a test
+            // fixture is that an acceptance number nobody else can re-take
+            // is not a measurement, it is an assertion.
+            "--free-run" => {
+                cfg.free_run = true;
+                i += 1;
+            }
+            "--max-sim-secs" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --max-sim-secs needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(secs) = v.parse::<f64>() else {
+                    eprintln!("sim-host: --max-sim-secs value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                cfg.max_sim_time_s = Some(secs);
+                i += 2;
+            }
+            // ADR-0011 criterion (f): "every pass must hold with the
+            // estimator bias removed". `truth` is the measured-WORSE case on
+            // this plant, not the better one -- see HostConfig::pitch_source.
+            "--pitch-source" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --pitch-source needs a value");
+                    return ExitCode::FAILURE;
+                };
+                cfg.pitch_source = match v.as_str() {
+                    "estimator" => sim_host::host::PitchSource::Estimator,
+                    "truth" => sim_host::host::PitchSource::PlantTruth,
+                    other => {
+                        eprintln!(
+                            "sim-host: unknown --pitch-source '{other}' (want: estimator, truth)"
+                        );
+                        return ExitCode::FAILURE;
+                    }
+                };
+                i += 2;
+            }
+            // ADR-0011 criterion (f), the robustness form: a worst-case
+            // STATIC estimator error injected on top of the real signal
+            // path. See HostConfig::pitch_bias_deg for why this is a
+            // different question from --pitch-source truth.
+            "--pitch-bias-deg" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --pitch-bias-deg needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(deg) = v.parse::<f32>() else {
+                    eprintln!("sim-host: --pitch-bias-deg value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                cfg.pitch_bias_deg = deg;
+                i += 2;
+            }
+            // Overrides CMD_ENVELOPE_RESERVE. Sweeping this IS that
+            // constant's provenance measurement; see its doc comment.
+            "--cmd-reserve" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --cmd-reserve needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(scale) = v.parse::<f32>() else {
+                    eprintln!("sim-host: --cmd-reserve value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                if !(0.0..=1.0).contains(&scale) {
+                    eprintln!("sim-host: --cmd-reserve must be within [0, 1], got {scale}");
+                    return ExitCode::FAILURE;
+                }
+                cfg.cmd_envelope_reserve = Some(scale);
+                i += 2;
+            }
+            // `t0,duration,fx,fy,fz,tx,ty,tz` -- world frame, SI. The kerb
+            // strike of ADR-0011's criterion (a) matrix is fed in this way
+            // rather than derived here; see HostConfig::disturbance for why
+            // the derivation stays in `sim/scenarios/plant.py`.
+            "--disturbance" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --disturbance needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let parts: Result<Vec<f64>, _> =
+                    v.split(',').map(|p| p.trim().parse::<f64>()).collect();
+                let Ok(p) = parts else {
+                    eprintln!("sim-host: --disturbance '{v}' has a non-numeric field");
+                    return ExitCode::FAILURE;
+                };
+                if p.len() != 8 {
+                    eprintln!(
+                        "sim-host: --disturbance wants 8 comma-separated numbers \
+                         (t0,duration,fx,fy,fz,tx,ty,tz), got {}",
+                        p.len()
+                    );
+                    return ExitCode::FAILURE;
+                }
+                cfg.disturbance = Some(sim_host::host::Disturbance {
+                    t0_s: p[0],
+                    duration_s: p[1],
+                    force_n: [p[2], p[3], p[4]],
+                    torque_nm: [p[5], p[6], p[7]],
+                });
+                i += 2;
+            }
+            "--trace-csv" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --trace-csv needs a value");
+                    return ExitCode::FAILURE;
+                };
+                cfg.trace_path = Some(std::path::PathBuf::from(v));
                 i += 2;
             }
             "--input-in-addr" => {

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -98,9 +98,39 @@
 //! already tumbling and diverge chaotically. That flip is issue #190's, and
 //! nothing here moves it.
 
+//! # ADR-0011: the command-envelope reserve, and the warning that was being
+//! # thrown away
+//!
+//! Holding full forward stick from rest inverts this board (issue #190).
+//! [`CMD_ENVELOPE_RESERVE`] is the fix ADR-0011 specifies -- one multiply on
+//! the fore/aft stick, upstream of everything, derived from the actuator
+//! envelope rather than tuned to the measured cliff. [`AUTHORITY_
+//! UTILISATION_WARN`] is criterion (c): this file used to compute the safety
+//! envelope's saturation bit every cycle and discard it at the binding, while
+//! `FALLEN` -- which trips about a second after the outcome is decided -- was
+//! the only thing anyone was told.
+//!
+//! **Two of the ADR's criteria are NOT met and no value of the constant would
+//! meet them.** Fed MuJoCo truth (criterion (f)) the board inverts at every
+//! stick fraction down to 0.05; the reserve buys time-to-inversion, not
+//! survival. And during a full-stick hold the board cannot ride out much more
+//! than a 1 mm pavement lip (criterion (a), kerb entry). Both are measured in
+//! `tests/test_cmd_envelope_reserve.py` and recorded there as strict
+//! `xfail`s. Read [`CMD_ENVELOPE_RESERVE`] and [`PitchSource`] before quoting
+//! any margin out of this file.
+//!
+//! Everything under "verification only" on [`HostConfig`] exists to take
+//! those measurements -- free running, a trace CSV, a pitch source, a static
+//! pitch bias, a scheduled disturbance, and a reserve override. None of it is
+//! reachable on a deployed run, and all of it is on the command line rather
+//! than in a test fixture, because an acceptance number nobody else can
+//! re-take is not a measurement.
+
 use crate::pacer::Pacer;
 use crate::wire::{self, InputIn, StateOut};
-use board_types::{Command, Faults, ImuSample, Params, DEFAULT_R_EFF_M, RAD_S_PER_ERPM};
+use board_types::{
+    Command, Faults, ImuSample, Params, Saturation, DEFAULT_R_EFF_M, RAD_S_PER_ERPM,
+};
 use control_core::{CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator};
 use hal::BoardObserve;
 use hal_actuate::BoardActuate;
@@ -244,6 +274,221 @@ const MAX_GROUND_SPEED_M_S: f32 = 9.34;
 /// tighter cap is wanted; a smaller margin trades a harder-edged feel for
 /// less overshoot.
 const SPEED_CAP_MARGIN_M_S: f32 = 1.0;
+
+/// The speed at which [`SPEED_CAP_MARGIN_M_S`]'s authority ramp starts
+/// withdrawing accelerating fore/aft authority -- 8.34 m/s. Named because
+/// ADR-0011's loss-of-authority warning discriminates on it (see
+/// [`AUTHORITY_UTILISATION_WARN`]), not merely because the speed cap
+/// arithmetic uses it.
+const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
+
+/// Fraction of full fore/aft stick the command map actually delivers --
+/// ADR-0011 exit criterion (b), "cap commanded lean, changing nothing else".
+/// Applied to `weight_shift_fore_aft` UPSTREAM of the estimator, the
+/// regulator and the safety envelope, so it is pure input shaping: no gain
+/// moves, `MAX_CURRENT_A` does not move (that would be a claim about
+/// hardware), `MAX_GROUND_SPEED_M_S` does not move (rejected as dominated --
+/// it costs top speed and this does not).
+///
+/// # DERIVED, NOT TUNED -- and specifically NOT tuned to the measured cliff
+///
+/// Holding full forward stick from rest inverts this board in ~6.5 s
+/// (issue #190). The flip boundary was measured between 0.95 and 0.97 of
+/// full stick, and **tuning to that boundary is forbidden**: it rests
+/// partly on an accidental ~1 deg nose-down estimator bias that happens to
+/// act as nose-up trim, and partly on `wheel_hinge`'s undocumented
+/// `damping="0.08"`. A constant sitting on either is a constant that moves
+/// when somebody fixes a bug.
+///
+/// The derivation instead runs off the actuator envelope, per the
+/// command-map rule ADR-0011 propagates to the hardware spec -- *the
+/// stick->setpoint map SHALL be derived from the actuator envelope minus a
+/// stated disturbance reserve*:
+///
+/// 1. **Measured** -- peak fore/aft current demand is linear in stick at
+///    [`PEAK_DEMAND_A_PER_UNIT_STICK`] = **42.03 A per unit**. Full stick
+///    therefore demands 42.03 A against a 40 A envelope: the present map
+///    **over-commands by 5%**, which is a normalisation defect, not a sizing
+///    gap.
+/// 2. **Stated reserve** -- hold peak demand to
+///    [`STATED_ENVELOPE_RESERVE_FRACTION`] = 84% of [`MAX_CURRENT_A`], a
+///    policy input rather than a measurement, and labelled as one.
+/// 3. **Derived:** `0.84 * 40 A / 42.03 A per unit = 0.799`, to two figures
+///    **0.80**. Pinned as executable arithmetic by
+///    `the_command_envelope_reserve_is_the_stated_reserve_divided_by_the_
+///    measured_slope`, not merely written down here.
+///
+/// # What it buys, measured
+///
+/// Against the highest stick fraction that survived unshaped (0.95 -- 1.00
+/// inverts, so it cannot be the baseline), over a 60 s full-stick hold on the
+/// deployed estimator path:
+///
+/// | | 0.95 (unshaped baseline) | 0.80 (shipped) |
+/// |---|---|---|
+/// | peak demand | 40.25 A -- envelope reached | **33.41 A (83.5%)** |
+/// | peak lean | 9.94 deg | **7.96 deg** |
+/// | pitch reserve vs the 11.46 deg ceiling | 13% | **31%** |
+///
+/// The ceiling is `MAX_CURRENT_A * KT / KP` = 28/140 = 0.2 rad = 11.46 deg.
+///
+/// # What it costs, measured
+///
+/// Top speed is **unchanged**: the board settles at 9.150 m/s against the
+/// baseline's 9.176 m/s (-0.3%), because `MAX_GROUND_SPEED_M_S` governs it
+/// and a shaped full stick still reaches the cap. Time to 8 m/s from rest
+/// rises 5.910 s -> 6.832 s (**+0.92 s**) and distance over the first 15 s
+/// falls 108.83 m -> 100.23 m (**-7.9%**).
+///
+/// # What it does NOT buy -- read this before quoting the numbers above
+///
+/// The reserve satisfies criterion (b) and two of criterion (a)'s three
+/// matrix entries **on the deployed estimator path**. It does not satisfy
+/// the other two, and no value of it would:
+///
+/// - **Criterion (f) -- fed MuJoCo truth -- fails at every value.** Sweeping
+///   this constant from 1.00 down to 0.05 moves time-to-inversion from 4.42 s
+///   to 28.67 s and never removes it; only exactly zero stick survives. With
+///   the estimator bias removed a sustained forward lean has no equilibrium,
+///   so the reserve buys TIME, not survival.
+/// - **Criterion (a)'s kerb-strike entry fails** above roughly a 1 mm lip
+///   struck at the worst point of a full-stick hold.
+///
+/// Both are measured in `tests/test_cmd_envelope_reserve.py`, which records
+/// them as strict `xfail`s -- the criteria are written there as they should
+/// read, and they will turn red the day somebody fixes the underlying
+/// problem, which is the only way a known failure stays known.
+const CMD_ENVELOPE_RESERVE: f32 = 0.80;
+
+/// The measurement [`CMD_ENVELOPE_RESERVE`] is derived FROM, in amps of peak
+/// fore/aft current demand per unit of fore/aft stick.
+///
+/// A named constant rather than a number in a sentence, so the derivation is
+/// arithmetic a test can check rather than prose a reader has to trust --
+/// see `the_command_envelope_reserve_is_the_stated_reserve_divided_by_the_
+/// measured_slope`.
+///
+/// **Re-measured for ADR-0011, not inherited.** Nine runs of
+/// `--scripted-scenario full-stick --pitch-source estimator` at stick
+/// fractions 0.20 through 0.95, peak `|proposed_amps|` taken PRE-envelope
+/// (the clamp cannot hide demand); least squares through the origin gives
+/// 42.03 A/unit at R^2 = 0.99936, and the per-point ratio never leaves
+/// 41.6-43.5 A/unit. The ADR quoted 42 A/unit from an independent
+/// measurement; these agree to 0.1%.
+///
+/// Measured on the ESTIMATOR path deliberately, even though ADR-0011
+/// criterion (f) runs acceptance against MuJoCo truth. A command map is a
+/// property of the command path, and the estimator is the only signal path a
+/// real board has; more decisively, the truth-fed runs have no steady state
+/// to take a peak demand FROM (see the criterion (f) results in
+/// `tests/test_cmd_envelope_reserve.py`), so the slope is not measurable
+/// there at all.
+const PEAK_DEMAND_A_PER_UNIT_STICK: f32 = 42.03;
+
+/// The stated disturbance reserve [`CMD_ENVELOPE_RESERVE`] is derived
+/// against: peak fore/aft demand is held to this fraction of
+/// [`MAX_CURRENT_A`], leaving the rest for disturbance rejection.
+///
+/// **A stated policy input, not a measurement** -- inherited from ADR-0011,
+/// and labelled as such rather than dressed up as derived. What is derived
+/// is the stick scale that delivers it. 0.84 leaves 16% (6.4 A) of the
+/// envelope.
+///
+/// It is worth saying plainly what 6.4 A does and does not cover: it is
+/// about 0.2 rad/s of pitch-rate rejection through `KD`, which is a small
+/// disturbance. The reserve is sized against the envelope because that is
+/// the number this repo can defend; it is NOT sized against the repo's own
+/// reference disturbance, which is far larger than the envelope can answer
+/// at any stick setting (issue #142, and criterion (a)'s kerb-strike entry).
+const STATED_ENVELOPE_RESERVE_FRACTION: f32 = 0.84;
+
+/// The derivation, enforced by the COMPILER rather than by a reader.
+///
+/// [`CMD_ENVELOPE_RESERVE`] is not an independent number: it is the stated
+/// reserve fraction times the envelope, divided by the measured slope,
+/// rounded to two figures. Editing any one of those four in isolation is a
+/// build error, which is the point -- ADR-0011 forbids moving the constant to
+/// make a scenario pass, and a rule enforced at compile time cannot be
+/// forgotten by a session that never read the ADR.
+///
+/// The tolerance is half a rounding step. Two figures is what the
+/// measurement supports; see [`PEAK_DEMAND_A_PER_UNIT_STICK`]'s spread.
+const _: () = {
+    let derived = STATED_ENVELOPE_RESERVE_FRACTION * MAX_CURRENT_A / PEAK_DEMAND_A_PER_UNIT_STICK;
+    let err = CMD_ENVELOPE_RESERVE - derived;
+    assert!(
+        err < 0.005 && err > -0.005,
+        "CMD_ENVELOPE_RESERVE is no longer STATED_ENVELOPE_RESERVE_FRACTION * \
+         MAX_CURRENT_A / PEAK_DEMAND_A_PER_UNIT_STICK rounded to two figures. \
+         Re-derive the constant from the measurement; do not adjust the \
+         measurement to fit the constant."
+    );
+};
+
+/// Time constant of the low-pass filter on authority utilisation, seconds --
+/// the loss-of-authority warning's detector (ADR-0011 exit criterion (c)).
+///
+/// Not bench-tuned, and bounded rather than picked: it has to be long
+/// relative to the 2 ms control period (or the warning chatters on a single
+/// noisy cycle) and short relative to the lead time it exists to preserve
+/// (or the filter eats the warning it is supposed to give). 0.1 s is 50
+/// control cycles and 4% of the measured lead -- comfortably inside both
+/// bounds, which is the whole requirement on it.
+const AUTHORITY_UTILISATION_TAU_S: f32 = 0.1;
+
+/// Filtered `|proposed current| / MAX_CURRENT_A` above which the host warns
+/// that it is running out of pitch authority -- ADR-0011 exit criterion (c).
+///
+/// # The discriminator is the SPEED, not the saturation
+///
+/// Saturation alone is not a fault on this board. ADR-0011's measured
+/// finding: **every run that saturated above [`SPEED_CAP_ONSET_M_S`]
+/// survived, and every run that saturated below it flipped.** Once torque
+/// is clamped `tau = -kp*theta` no longer holds and pitch is open-loop
+/// unstable, so saturation is survivable if and only if something is
+/// already unloading the board when it happens -- above the onset the speed
+/// cap is doing exactly that. A warning that fired on saturation above the
+/// onset would be noise, and noise is how a warning gets ignored.
+///
+/// # Why filtered utilisation rather than the raw saturation bit
+///
+/// The raw bit (`Saturation::Yes` out of `safety::Envelope::apply`, which
+/// this host used to discard at the `let (bounded_cmd, _sat)` binding) fires
+/// only once the envelope has ALREADY bound. Filtered utilisation crosses
+/// 0.85 while the controller still has authority left, which is the
+/// difference between a warning and a post-mortem.
+///
+/// # Measured lead, against the reference ADR-0011 uses
+///
+/// `--scripted-scenario full-stick --cmd-reserve 1.0`, estimator path. The
+/// reference event is the FIRST ENVELOPE SATURATION -- the ADR's table puts
+/// it at 4.92 s and quotes `FALLEN` at -0.95 s, which is exactly `FALLEN`
+/// minus that:
+///
+/// | event | sim time | lead over the committed point |
+/// |---|---|---|
+/// | this warning | 3.000 s | **+1.92 s** |
+/// | first saturation (the reference) | 4.920 s | 0 |
+/// | `FALLEN` (20 deg) | 5.868 s | **-0.95 s** |
+/// | inverted past 90 deg | 6.142 s | -1.22 s |
+///
+/// So the warning leads `FALLEN` by **2.87 s**. ADR-0011 predicted 2.69 s of
+/// lead over the committed point; the measurement is **1.92 s** with this
+/// filter and threshold, and 2.02 s unfiltered. Recorded as measured rather
+/// than reconciled -- the ADR's figure is not reproducible from the
+/// definition it states, and quoting it anyway would be exactly the habit
+/// that ADR exists to break.
+///
+/// # What this warning is NOT
+///
+/// It is a diagnostic, not a safety control. The board it warns about cannot
+/// ride out a 2 mm pavement lip during a full-stick hold (criterion (a)'s
+/// kerb entry, `tests/test_cmd_envelope_reserve.py`), and 1.92 s of notice
+/// does not change that. It also does not reach the game: the state-out wire
+/// is fixed by ADR-0010 until it expires, so this goes to the host's log and
+/// to the acceptance trace and nowhere else. Putting it on the wire is a
+/// schema change and needs that ADR's expiry or the COO's sign-off.
+const AUTHORITY_UTILISATION_WARN: f32 = 0.85;
 
 /// Roll magnitude, radians, at which the roll-shaped yaw limiter reaches
 /// full authority (issue #161 W2 item 4).
@@ -494,6 +739,119 @@ pub struct HostConfig {
     /// `send-input`: the UDP path is the one Unreal actually uses, and only
     /// `send-input` exercises it.
     pub scripted_scenario: Option<crate::scenario::Schedule>,
+
+    /// **Verification only.** Stops the run after this much SIMULATED time,
+    /// independently of `duration`'s wall clock. A free-running acceptance
+    /// sweep has no wall clock worth bounding, and a scripted run's own
+    /// schedule length is not always the window a measurement wants.
+    pub max_sim_time_s: Option<f64>,
+
+    /// **Verification only.** Where the regulator's pitch and pitch rate come
+    /// from. See [`PitchSource`]; ADR-0011 exit criterion (f) is why this
+    /// exists.
+    pub pitch_source: PitchSource,
+
+    /// **Verification only.** A static pitch offset, DEGREES, added to
+    /// whatever [`HostConfig::pitch_source`] hands the regulator. Positive is
+    /// nose-up, matching ICD 10.1.
+    ///
+    /// This is the robustness test ADR-0011 criterion (f) was reaching for.
+    /// The ADR asks for acceptance "with the estimator bias removed" and
+    /// implements that as "feed the regulator MuJoCo truth" -- but the
+    /// measured `est - truth` residual is not a static bias at all: it
+    /// regresses on unaided specific force at 5.7-6.1 deg per m/s^2, which is
+    /// 1 radian per g, i.e. it is the complementary filter reading the
+    /// APPARENT VERTICAL. Replacing it with truth therefore does not remove
+    /// an error, it deletes an acceleration reference and leaves a
+    /// pitch-only regulator (see `PitchSource::PlantTruth`).
+    ///
+    /// Injecting a worst-case STATIC bias on top of the real signal path is
+    /// the test that actually asks "does this margin survive an estimator
+    /// that is wrong?" without silently changing which controller is under
+    /// test. Both are run and both are reported;
+    /// `tests/test_cmd_envelope_reserve.py` has the results.
+    pub pitch_bias_deg: f32,
+
+    /// **Verification only.** Runs the loop as fast as the CPU allows,
+    /// skipping the [`Pacer`] entirely.
+    ///
+    /// The plant is a fixed-timestep RK4 integrator with no stochastic terms
+    /// and the scripted schedule is indexed on simulated time, so a scripted
+    /// free run produces bit-identically the same trajectory as a paced one
+    /// -- it just produces it in a fraction of a second instead of in real
+    /// time, which is what makes an acceptance SWEEP (stick fraction x
+    /// scenario x pitch source) a thing that fits in a test rather than in an
+    /// afternoon. Missed deadlines are not counted in this mode: there are no
+    /// deadlines.
+    ///
+    /// NOT how a deployed host runs. The UDP state-out is still sent every
+    /// tick, so a listener would see the whole run arrive at once.
+    pub free_run: bool,
+
+    /// **Verification only.** Fraction of full fore/aft stick to deliver,
+    /// overriding [`CMD_ENVELOPE_RESERVE`].
+    ///
+    /// Exists so that constant's own provenance is re-measurable rather than
+    /// merely asserted: sweeping this IS the "peak demand is linear at N amps
+    /// per unit stick" measurement its doc comment cites. `None` uses the
+    /// shipped constant.
+    pub cmd_envelope_reserve: Option<f32>,
+
+    /// **Verification only.** A scheduled external disturbance -- see
+    /// [`Disturbance`]. `None` applies none, which is the deployed
+    /// behaviour.
+    pub disturbance: Option<Disturbance>,
+
+    /// **Verification only.** Writes one CSV row per control cycle to this
+    /// path when the run ends. Buffered in memory and written once, never
+    /// during the loop: a 500 Hz control thread does not do file I/O per
+    /// tick, and the trace exists to measure the loop, not to perturb it.
+    pub trace_path: Option<PathBuf>,
+}
+
+/// Where the regulator's attitude comes from -- ADR-0011 exit criterion (f).
+///
+/// The default is the only one a deployed host may use. `PlantTruth` exists
+/// because the ADR requires every acceptance pass to hold **with the
+/// estimator bias removed**, and on this plant that is the measured-WORSE
+/// case, not the better one: the complementary filter's ~1 deg nose-down
+/// error acts as nose-up trim, so feeding the controller MuJoCo truth makes
+/// the board flip EARLIER. That is accidental model error, not a designed
+/// safety property, and criterion (f) exists precisely so no acceptance
+/// number is allowed to rest on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PitchSource {
+    /// The `ComplementaryFilter`, fed raw IMU through `hal` -- the real
+    /// signal path, and the only one a real board has.
+    #[default]
+    Estimator,
+    /// MuJoCo's own body-frame pitch and pitch rate, straight from the
+    /// plant. Physically unavailable on hardware; an acceptance-run
+    /// instrument only.
+    PlantTruth,
+}
+
+/// A scheduled external force/torque disturbance, world frame, applied to the
+/// `frame` body over a fixed window of SIMULATED time.
+///
+/// Generic on purpose. The disturbance ADR-0011's test matrix needs is a kerb
+/// strike, and the kerb derivation this repo trusts lives in ONE place --
+/// `sim/scenarios/plant.py::kerb_strike_impulse` (issue #142/#147, Sr.
+/// Mechanical & Systems' call, not Controls'). Re-implementing that geometry
+/// in Rust would give this repo two kerb models that could disagree, so this
+/// host takes the derived impulse as a parameter and stays dumb about where
+/// it came from; `tests/test_cmd_envelope_reserve.py` calls the Python
+/// derivation and passes the result in.
+#[derive(Debug, Clone, Copy)]
+pub struct Disturbance {
+    /// Simulated time the force window opens, seconds.
+    pub t0_s: f64,
+    /// How long it stays open, seconds. Impulse delivered is `force * this`.
+    pub duration_s: f64,
+    /// World-frame force, newtons.
+    pub force_n: [f64; 3],
+    /// World-frame torque about the frame body's own origin, N*m.
+    pub torque_nm: [f64; 3],
 }
 
 impl Default for HostConfig {
@@ -505,8 +863,58 @@ impl Default for HostConfig {
             stats_path: Some(PathBuf::from(DEFAULT_STATS_PATH)),
             startup_kick: false,
             scripted_scenario: None,
+            max_sim_time_s: None,
+            pitch_source: PitchSource::Estimator,
+            pitch_bias_deg: 0.0,
+            free_run: false,
+            cmd_envelope_reserve: None,
+            disturbance: None,
+            trace_path: None,
         }
     }
+}
+
+/// One control cycle's worth of acceptance-run instrumentation. See
+/// [`HostConfig::trace_path`]; the column list and its order are the CSV
+/// header written by [`write_trace`].
+#[derive(Debug, Clone, Copy)]
+struct TraceRow {
+    seq: u64,
+    sim_time_s: f64,
+    /// Fore/aft stick as the schedule (or the socket) supplied it, before
+    /// [`CMD_ENVELOPE_RESERVE`].
+    stick_fore_aft: f32,
+    /// After the reserve, before the speed cap and the corridor brake.
+    shaped_fore_aft: f32,
+    /// What actually reached `set_ballast_targets`, after everything.
+    applied_fore_aft: f32,
+    /// MuJoCo truth, de-yawed, degrees, nose-up positive.
+    truth_pitch_deg: f32,
+    /// The complementary filter's belief, degrees -- recorded even on a
+    /// `PitchSource::PlantTruth` run (the estimator still runs; it is simply
+    /// not the regulator's input) so the bias itself stays visible.
+    est_pitch_deg: f32,
+    /// ... and the rate it believes, which is the regulator's D-term input on
+    /// a deployed run. Recorded alongside the truth rate because the two are
+    /// the pair criterion (f) swaps, and a swap nobody can see the size of is
+    /// not a measurement.
+    est_pitch_rate_deg_s: f32,
+    truth_pitch_rate_deg_s: f32,
+    forward_speed_m_s: f32,
+    /// PRE-envelope demand, amps. The number the reserve is derived from.
+    proposed_amps: f32,
+    /// POST-envelope command, amps.
+    applied_amps: f32,
+    /// `safety::Envelope` reported the clamp bound this cycle.
+    saturated: bool,
+    /// `|proposed_amps| / MAX_CURRENT_A`, unfiltered.
+    utilisation: f32,
+    /// ... and low-passed at [`AUTHORITY_UTILISATION_TAU_S`].
+    utilisation_filtered: f32,
+    /// The loss-of-authority warning is asserted this cycle.
+    authority_warning: bool,
+    /// The wire's `FALLEN` bit, for the lead-time comparison.
+    fallen: bool,
 }
 
 /// What a finished (or interrupted-by-error) run produced.
@@ -605,6 +1013,52 @@ fn body_pitch_roll_rad(xmat: &[f64; 9], yaw_rad: f32) -> (f32, f32) {
         deyawed_02.atan2(xmat[8] as f32),
         deyawed_12.atan2(xmat[8] as f32),
     )
+}
+
+/// The command-envelope reserve, as a function (ADR-0011 criterion (b)).
+///
+/// One multiply, extracted from the loop body only so the property that
+/// matters can be stated as a test rather than as a comment: this is a
+/// LINEAR scaling of the stick, symmetric about zero, and it changes nothing
+/// else. In particular it is not a clamp -- a clamp would leave full stick
+/// untouched right up to a limit and then bite, which is a different feel and
+/// a different failure mode.
+fn shape_fore_aft_command(stick: f32, reserve: f32) -> f32 {
+    stick * reserve
+}
+
+/// The speed cap's authority ramp, as a function -- unchanged in behaviour,
+/// extracted so ADR-0011 criterion (a)'s reversal entry can be stated as a
+/// unit test as well as a sim run.
+///
+/// The property worth pinning: a REVERSAL is never attenuated. The cap only
+/// withdraws authority when the stick and the current motion share a sign,
+/// so a stick slammed from one rail to the other at speed passes through at
+/// FULL authority, at any speed, including above the onset where the cap is
+/// the only thing unloading the board. That is why the reversal is the
+/// matrix's worst case and not merely another entry in it.
+fn speed_capped_fore_aft(stick: f32, last_forward_speed_m_s: f32) -> f32 {
+    let speed_headroom_m_s = MAX_GROUND_SPEED_M_S - last_forward_speed_m_s.abs();
+    let accel_authority = (speed_headroom_m_s / SPEED_CAP_MARGIN_M_S).clamp(0.0, 1.0);
+    if stick * last_forward_speed_m_s >= 0.0 {
+        stick * accel_authority
+    } else {
+        stick
+    }
+}
+
+/// The loss-of-authority warning's trigger (ADR-0011 criterion (c)):
+/// filtered authority utilisation over threshold, AND below the speed cap's
+/// onset.
+///
+/// Both halves are load-bearing and the second is the one that is easy to
+/// drop. Saturation above [`SPEED_CAP_ONSET_M_S`] is survivable -- the cap is
+/// already unloading the board when it happens -- and every run in ADR-0011's
+/// data that saturated above the onset survived. A warning without the speed
+/// term would fire on all of those, which is a warning nobody reads.
+fn authority_warning_active(utilisation_filtered: f32, forward_speed_m_s: f32) -> bool {
+    utilisation_filtered > AUTHORITY_UTILISATION_WARN
+        && forward_speed_m_s.abs() < SPEED_CAP_ONSET_M_S
 }
 
 pub fn spawn(cfg: HostConfig) -> std::thread::JoinHandle<Result<RunSummary, HostError>> {
@@ -708,6 +1162,30 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     let mut truth_pos_x_m: f64 = 0.0;
     let mut truth_pos_y_m: f64 = 0.0;
 
+    // --- ADR-0011 (b) and (c) state ------------------------------------
+    // The fore/aft command scale actually in force this run. Normally the
+    // shipped constant; a verification sweep overrides it (see
+    // HostConfig::cmd_envelope_reserve, which is how the constant's own
+    // provenance measurement is taken).
+    let cmd_envelope_reserve = cfg.cmd_envelope_reserve.unwrap_or(CMD_ENVELOPE_RESERVE);
+    let pitch_bias_rad = cfg.pitch_bias_deg.to_radians();
+    // Low-passed |proposed current| / MAX_CURRENT_A. Starts at zero, which is
+    // true: an unarmed board at rest is asking for nothing.
+    let mut utilisation_filtered: f32 = 0.0;
+    // One-pole coefficient for AUTHORITY_UTILISATION_TAU_S at this cycle
+    // rate, precomputed rather than recomputed 500 times a second.
+    let utilisation_alpha = DT_S as f32 / (AUTHORITY_UTILISATION_TAU_S + DT_S as f32);
+    // Edge state for the loss-of-authority warning, so it announces itself
+    // once per episode rather than 500 times a second -- the same
+    // rising-edge discipline the corridor warning above uses.
+    let mut prev_authority_warning = false;
+    let mut trace: Vec<TraceRow> = Vec::new();
+    if cfg.trace_path.is_some() {
+        // A 30 s scripted run at 500 Hz is 15,000 rows; reserving avoids
+        // reallocating inside the control loop.
+        trace.reserve(16_384);
+    }
+
     let start = Instant::now();
     let mut pacer = Pacer::new(Duration::from_nanos(CYCLE_NS), start);
     // Headroom over InputIn::WIRE_SIZE so an oversized datagram is caught as
@@ -735,6 +1213,11 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // wall-clock backstop.
         if let Some(sched) = cfg.scripted_scenario {
             if t_known_s > crate::scenario::total_duration_s(sched) + SCRIPTED_RUN_TAIL_S {
+                break;
+            }
+        }
+        if let Some(limit) = cfg.max_sim_time_s {
+            if t_known_s > limit {
                 break;
             }
         }
@@ -779,7 +1262,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // SIMULATED time and the socket's stick values are ignored entirely.
         // The flag bits (arm/reset/kick) still come from the wire either way,
         // so an on-demand kick can still be injected into a scripted run.
-        let (steer, weight_shift_fore_aft, weight_shift_lateral) = match cfg.scripted_scenario {
+        let (steer, stick_fore_aft, weight_shift_lateral) = match cfg.scripted_scenario {
             Some(sched) => {
                 let (fa, lat, st, label) = crate::scenario::value_at(sched, t_known_s);
                 if label != scripted_label {
@@ -798,6 +1281,24 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
                 latest_input.weight_shift_lateral,
             ),
         };
+
+        // --- COMMAND-ENVELOPE RESERVE (ADR-0011 exit criterion (b)) ------
+        //
+        // The whole fix, in one multiply. Deliberately placed HERE, at the
+        // point where a stick value enters the host and before anything else
+        // touches it: upstream of the speed cap, the corridor brake, the
+        // ballast actuator, the plant, the estimator, the regulator and the
+        // safety envelope. That ordering is the reason this is a zero-risk
+        // change rather than a retune -- every downstream block sees a
+        // smaller stick and is otherwise bit-identical, no gain moves, and
+        // nothing in the control law learns that a limit exists.
+        //
+        // Fore/aft only. The failure ADR-0011 is about is a fore/aft pitch
+        // authority failure; lateral stick moves `ballast_lat`, whose
+        // measured full-stick effect on this geometry is 0.03 deg of roll
+        // (see ROLL_FULL_YAW_AUTHORITY_RAD) and which consumes no wheel
+        // torque at all. Scaling it would cost steering feel to buy nothing.
+        let weight_shift_fore_aft = shape_fore_aft_command(stick_fore_aft, cmd_envelope_reserve);
 
         // `arm`/`reset` bits: accepted and tracked, logged on change rather
         // than every tick. Neither gates anything yet -- the host self-arms
@@ -839,14 +1340,8 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // reversing (opposite sign to current motion) is never touched.
         // Gated on last_forward_speed_m_s -- one cycle old, since this
         // tick's fresh speed is not known until wait_observe() below.
-        let speed_headroom_m_s = MAX_GROUND_SPEED_M_S - last_forward_speed_m_s.abs();
-        let accel_authority = (speed_headroom_m_s / SPEED_CAP_MARGIN_M_S).clamp(0.0, 1.0);
-        let accelerating_same_direction = weight_shift_fore_aft * last_forward_speed_m_s >= 0.0;
-        let capped_weight_shift_fore_aft = if accelerating_same_direction {
-            weight_shift_fore_aft * accel_authority
-        } else {
-            weight_shift_fore_aft
-        };
+        let capped_weight_shift_fore_aft =
+            speed_capped_fore_aft(weight_shift_fore_aft, last_forward_speed_m_s);
 
         // Corridor boundary (issue #161 follow-up, item 4) -- see
         // CORRIDOR_X_MIN_M's doc comment for the bounds and for why this is a
@@ -913,14 +1408,27 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
                 fall_kick_window_start_s = None;
             }
         }
-        let force = if in_kick_window {
-            STARTUP_KICK_FORCE_N
+        // A scheduled acceptance-run disturbance (ADR-0011 criterion (a),
+        // "full stick during a kerb strike"), on the same pre-step-time
+        // window rule as the two kicks above. Unlike them it carries a
+        // TORQUE as well as a force: a kerb acts at the wheel, well below the
+        // CoM, and the angular channel is the one that topples the board --
+        // see `Disturbance` and issue #142's finding that quoting a kerb in
+        // N*s alone understates it silently.
+        let in_disturbance_window = cfg
+            .disturbance
+            .is_some_and(|d| (d.t0_s..d.t0_s + d.duration_s).contains(&t_known_s));
+        let (force, torque) = if in_disturbance_window {
+            let d = cfg.disturbance.expect("checked by is_some_and above");
+            (d.force_n, d.torque_nm)
+        } else if in_kick_window {
+            (STARTUP_KICK_FORCE_N, [0.0; 3])
         } else if in_fall_kick_window {
-            FALL_KICK_FORCE_N
+            (FALL_KICK_FORCE_N, [0.0; 3])
         } else {
-            [0.0; 3]
+            ([0.0; 3], [0.0; 3])
         };
-        backend.apply_external_force(force, [0.0; 3]);
+        backend.apply_external_force(force, torque);
 
         let obs = backend.wait_observe().map_err(HostError::Backend)?;
         t_known_s = obs.t_recv_ns as f64 * 1e-9;
@@ -940,39 +1448,27 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let forward_speed_m_s = wheel_rate_rad_s * DEFAULT_R_EFF_M;
         last_forward_speed_m_s = forward_speed_m_s;
         let aiding = accel_ff.predict(last_amps);
+        // The estimator runs on EVERY run, including a `PitchSource::
+        // PlantTruth` acceptance run where the regulator is not listening to
+        // it -- it is the only signal path a real board has, and an
+        // acceptance trace that stopped recording it would stop being able to
+        // show how big the bias criterion (f) is neutralising actually is.
         let attitude = estimator.update(std::slice::from_ref(&sample), aiding);
-        let proposed_torque_nm =
-            regulator.update(attitude.pitch_rad, attitude.pitch_rate_rad_s, 0.0);
-        // The single kt division -- the actuation boundary (issue #137).
-        let proposed_amps = proposed_torque_nm / KT_NM_PER_A;
-        let (bounded_cmd, _sat) = envelope.apply(
-            Command::MotorCurrent {
-                amps: proposed_amps,
-            },
-            Faults::NONE,
-        );
-        backend.apply(&bounded_cmd).map_err(HostError::Backend)?;
-        // POST-envelope current, not the proposal -- the plant only ever
-        // sees the clamped value (same reasoning `control-ffi`'s own
-        // `ctl.last_amps` update carries).
-        last_amps = match bounded_cmd {
-            Command::MotorCurrent { amps } => amps,
-            Command::RemoteSpeed { .. } => 0.0,
-        };
 
-        // wheel_angle_rad: there is no absolute wheel-angle channel on `hal`
-        // (ICD carries ERPM/tacho, the same as real VESC telemetry) -- this
-        // dead-reckons it from the rate `hal` already reports, exactly the
-        // way a real host would have to. Not a fabricated value: it is an
-        // honest integral of an actually-measured rate.
-        wheel_angle_rad += wheel_rate_rad_s * DT_S as f32;
-
-        // Ground truth, never fed to the controller above (DR-OBS-1) --
-        // reported because "the board is actually up" is what the state-out
-        // wire needs to prove, and truth proves it more directly than the
-        // controller's own (estimator-mediated) belief. Same formula
-        // `impulse-response-rust` / `sim/scenarios/impulse_response.py::
-        // frame_pitch_rad` use, against the same underlying xmat.
+        // Ground truth, never fed to the controller on a DEPLOYED run
+        // (DR-OBS-1) -- reported because "the board is actually up" is what
+        // the state-out wire needs to prove, and truth proves it more
+        // directly than the controller's own (estimator-mediated) belief.
+        // Same formula `impulse-response-rust` / `sim/scenarios/
+        // impulse_response.py::frame_pitch_rad` use, against the same
+        // underlying xmat.
+        //
+        // **Read here rather than after the wire block, where it used to
+        // live** (ADR-0011 criterion (f)): a `PitchSource::PlantTruth`
+        // acceptance run needs it BEFORE the regulator, not after. Nothing
+        // between the old and new positions touched the plant or `yaw_rad`
+        // -- `backend.apply` only buffers a current for the next step -- so
+        // the values are bit-identical to the ones the old ordering read.
         let xmat = backend.truth_frame_xmat();
         // ATTITUDE MUST BE DE-YAWED BEFORE PITCH/ROLL COME OUT OF IT (issue
         // #163). Both readings below are `atan2` on the frame's world z-axis,
@@ -992,6 +1488,87 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // reduces to `1.0 * xmat[k] + 0.0 * xmat[j]`, i.e. bit-identically the
         // pre-#163 expressions.
         let (pitch_rad, roll_rad) = body_pitch_roll_rad(&xmat, yaw_rad);
+        let truth_pitch_rate_rad_s = backend.truth_body_pitch_rate_rad_s();
+
+        // --- ADR-0011 criterion (f): the estimator bias, removed ---------
+        //
+        // On a deployed run this is the `Estimator` arm and the regulator
+        // sees exactly what it always saw. On an acceptance run it is
+        // `PlantTruth`, and the regulator sees MuJoCo -- which on this plant
+        // is the measured-WORSE case, because the filter's ~1 deg nose-down
+        // error acts as nose-up trim. See `PitchSource`.
+        let (source_pitch_rad, regulated_pitch_rate_rad_s) = match cfg.pitch_source {
+            PitchSource::Estimator => (attitude.pitch_rad, attitude.pitch_rate_rad_s),
+            PitchSource::PlantTruth => (pitch_rad, truth_pitch_rate_rad_s),
+        };
+        // Zero on any deployed run, so this whole line is a no-op there --
+        // see HostConfig::pitch_bias_deg.
+        let regulated_pitch_rad = source_pitch_rad + pitch_bias_rad;
+        let proposed_torque_nm =
+            regulator.update(regulated_pitch_rad, regulated_pitch_rate_rad_s, 0.0);
+        // The single kt division -- the actuation boundary (issue #137).
+        let proposed_amps = proposed_torque_nm / KT_NM_PER_A;
+        // --- ADR-0011 criterion (c): the saturation bit STOPS being thrown
+        // --- away here ---------------------------------------------------
+        //
+        // This binding used to read `let (bounded_cmd, _sat) = ...`. The
+        // ADR names that discard by line number: the board's own "I have run
+        // out of authority" signal existed, was computed every cycle, and was
+        // dropped on the floor, while `FALLEN` -- which trips about a second
+        // AFTER the outcome is decided -- was the only thing anyone was told.
+        let (bounded_cmd, saturation) = envelope.apply(
+            Command::MotorCurrent {
+                amps: proposed_amps,
+            },
+            Faults::NONE,
+        );
+        let saturated = saturation == Saturation::Yes;
+        backend.apply(&bounded_cmd).map_err(HostError::Backend)?;
+        // POST-envelope current, not the proposal -- the plant only ever
+        // sees the clamped value (same reasoning `control-ffi`'s own
+        // `ctl.last_amps` update carries).
+        last_amps = match bounded_cmd {
+            Command::MotorCurrent { amps } => amps,
+            Command::RemoteSpeed { .. } => 0.0,
+        };
+
+        // Authority utilisation: how much of the actuator envelope the
+        // controller is ASKING for, which is the pre-envelope demand and not
+        // the post-envelope command -- the clamped value can never exceed
+        // 1.0 and so can never warn about anything. Low-passed at
+        // AUTHORITY_UTILISATION_TAU_S.
+        let utilisation = proposed_amps.abs() / MAX_CURRENT_A;
+        utilisation_filtered += (utilisation - utilisation_filtered) * utilisation_alpha;
+        // The discriminator is the SPEED (see AUTHORITY_UTILISATION_WARN):
+        // saturation above the speed cap's onset is survivable, because the
+        // cap is already unloading the board when it happens. Below it,
+        // nothing is.
+        let authority_warning = authority_warning_active(utilisation_filtered, forward_speed_m_s);
+        if authority_warning && !prev_authority_warning {
+            eprintln!(
+                "sim-host: LOSS OF PITCH AUTHORITY IMMINENT at sim_t={t_known_s:.3}s -- \
+                 filtered authority utilisation {:.0}% (demand {proposed_amps:+.1} A of \
+                 {MAX_CURRENT_A:.0} A) at {forward_speed_m_s:+.2} m/s, below the \
+                 {SPEED_CAP_ONSET_M_S:.2} m/s speed-cap onset. Pitch {:+.1} deg.",
+                utilisation_filtered * 100.0,
+                pitch_rad.to_degrees(),
+            );
+        } else if prev_authority_warning && !authority_warning {
+            eprintln!(
+                "sim-host: pitch authority recovered at sim_t={t_known_s:.3}s \
+                 (filtered utilisation {:.0}%)",
+                utilisation_filtered * 100.0,
+            );
+        }
+        prev_authority_warning = authority_warning;
+
+        // wheel_angle_rad: there is no absolute wheel-angle channel on `hal`
+        // (ICD carries ERPM/tacho, the same as real VESC telemetry) -- this
+        // dead-reckons it from the rate `hal` already reports, exactly the
+        // way a real host would have to. Not a fabricated value: it is an
+        // honest integral of an actually-measured rate.
+        wheel_angle_rad += wheel_rate_rad_s * DT_S as f32;
+
         let pos_f64 = backend.truth_frame_xpos();
         truth_pos_x_m = pos_f64[0];
         truth_pos_y_m = pos_f64[1];
@@ -1033,8 +1610,31 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let (rider_fore_aft_m, rider_lateral_m) = backend.truth_ballast_positions();
 
         let mut flags = wire::STATE_FLAG_ARMED | wire::STATE_FLAG_VALID;
-        if pitch_rad.abs() > FALLEN_PITCH_RAD {
+        let fallen = pitch_rad.abs() > FALLEN_PITCH_RAD;
+        if fallen {
             flags |= wire::STATE_FLAG_FALLEN;
+        }
+
+        if cfg.trace_path.is_some() {
+            trace.push(TraceRow {
+                seq: ticks,
+                sim_time_s: t_known_s,
+                stick_fore_aft,
+                shaped_fore_aft: weight_shift_fore_aft,
+                applied_fore_aft: corridor_enforced_fore_aft,
+                truth_pitch_deg: pitch_rad.to_degrees(),
+                est_pitch_deg: attitude.pitch_rad.to_degrees(),
+                est_pitch_rate_deg_s: attitude.pitch_rate_rad_s.to_degrees(),
+                truth_pitch_rate_deg_s: truth_pitch_rate_rad_s.to_degrees(),
+                forward_speed_m_s,
+                proposed_amps,
+                applied_amps: last_amps,
+                saturated,
+                utilisation,
+                utilisation_filtered,
+                authority_warning,
+                fallen,
+            });
         }
 
         let state = StateOut {
@@ -1158,14 +1758,21 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             }
         }
 
-        let sleep_for = pacer.wait_for_next(Instant::now());
-        if sleep_for.is_zero() {
-            eprintln!(
-                "sim-host: missed deadline at tick {ticks} (total missed so far: {})",
-                pacer.missed_deadlines()
-            );
-        } else {
-            std::thread::sleep(sleep_for);
+        // A free run has no deadlines to miss: the pacer is skipped entirely
+        // rather than consulted and ignored, so its missed-deadline counter
+        // stays at the truthful zero instead of reporting one miss per tick
+        // for a mode in which "late" is not defined. See
+        // `HostConfig::free_run`.
+        if !cfg.free_run {
+            let sleep_for = pacer.wait_for_next(Instant::now());
+            if sleep_for.is_zero() {
+                eprintln!(
+                    "sim-host: missed deadline at tick {ticks} (total missed so far: {})",
+                    pacer.missed_deadlines()
+                );
+            } else {
+                std::thread::sleep(sleep_for);
+            }
         }
     }
 
@@ -1179,12 +1786,68 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         );
     }
 
+    if let Some(path) = &cfg.trace_path {
+        write_trace(path, &trace)?;
+        eprintln!(
+            "sim-host: wrote {} trace rows to {}",
+            trace.len(),
+            path.display()
+        );
+    }
+
     let _ = backend.close();
 
     Ok(RunSummary {
         ticks,
         missed_deadlines: pacer.missed_deadlines(),
     })
+}
+
+/// Writes the acceptance-run trace ([`HostConfig::trace_path`]) as CSV, once,
+/// after the loop has stopped.
+///
+/// Unlike [`write_stats`] this one is NOT best-effort: a trace is the
+/// evidence an ADR-0011 acceptance number is quoted from, and a measurement
+/// whose output silently failed to be written is worse than no measurement.
+/// The error propagates.
+///
+/// Full `f32` precision (`{:?}`) on every physical column on purpose:
+/// `wire-probe --csv`'s 6-decimal rounding is enough to draw a graph and not
+/// enough to demonstrate that two runs are bit-identical, and this crate has
+/// already been caught out once by exactly that difference (issue #163's own
+/// equivalence work).
+fn write_trace(path: &std::path::Path, rows: &[TraceRow]) -> Result<(), HostError> {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(rows.len() * 160 + 256);
+    out.push_str(
+        "seq,sim_time_s,stick_fore_aft,shaped_fore_aft,applied_fore_aft,truth_pitch_deg,\
+         est_pitch_deg,est_pitch_rate_deg_s,truth_pitch_rate_deg_s,forward_speed_m_s,proposed_amps,applied_amps,\
+         saturated,utilisation,utilisation_filtered,authority_warning,fallen\n",
+    );
+    for r in rows {
+        let _ = writeln!(
+            out,
+            "{},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{},{:?},{:?},{},{}",
+            r.seq,
+            r.sim_time_s,
+            r.stick_fore_aft,
+            r.shaped_fore_aft,
+            r.applied_fore_aft,
+            r.truth_pitch_deg,
+            r.est_pitch_deg,
+            r.est_pitch_rate_deg_s,
+            r.truth_pitch_rate_deg_s,
+            r.forward_speed_m_s,
+            r.proposed_amps,
+            r.applied_amps,
+            r.saturated as u8,
+            r.utilisation,
+            r.utilisation_filtered,
+            r.authority_warning as u8,
+            r.fallen as u8,
+        );
+    }
+    std::fs::write(path, out).map_err(HostError::Io)
 }
 
 /// Best-effort, atomic (write-then-rename) write of the host's own counters
@@ -1303,6 +1966,214 @@ mod tests {
                 "yaw={yaw}: recovered ({p}, {r}), wanted ({pitch}, {roll})"
             );
         }
+    }
+
+    // --- ADR-0011 criterion (b): the command-envelope reserve -----------
+
+    /// The constant is DERIVED. This test is the derivation, executable:
+    /// stated reserve fraction x envelope / measured slope. If somebody
+    /// re-measures the slope and forgets to move the constant -- or moves the
+    /// constant to make a scenario pass, which is the failure ADR-0011
+    /// explicitly forbids -- this goes red.
+    ///
+    /// The shipped constant is the derived value rounded to two figures, and
+    /// the tolerance here is half a rounding step. Two figures is not
+    /// laziness: the measured slope's own per-run spread is 41.6-43.5 A/unit
+    /// (see [`PEAK_DEMAND_A_PER_UNIT_STICK`]), so a constant quoted to three
+    /// figures would be claiming a precision the measurement does not have.
+    #[test]
+    fn the_command_envelope_reserve_is_the_stated_reserve_divided_by_the_measured_slope() {
+        let derived =
+            STATED_ENVELOPE_RESERVE_FRACTION * MAX_CURRENT_A / PEAK_DEMAND_A_PER_UNIT_STICK;
+        assert!(
+            (CMD_ENVELOPE_RESERVE - derived).abs() <= 0.005,
+            "the shipped constant ({CMD_ENVELOPE_RESERVE}) is not the derived value \
+             ({derived}) rounded to two figures. It is DERIVED -- \
+             {STATED_ENVELOPE_RESERVE_FRACTION} x {MAX_CURRENT_A} A / \
+             {PEAK_DEMAND_A_PER_UNIT_STICK} A-per-unit -- and ADR-0011 forbids moving it \
+             to make a scenario pass. Re-measure the slope and the constant follows; \
+             the reverse is not allowed."
+        );
+    }
+
+    /// The defect the reserve exists to remove, stated as arithmetic: at full
+    /// stick the UNSHAPED command map asks for more current than the actuator
+    /// has. ADR-0011 calls this a normalisation defect rather than a sizing
+    /// gap, and this is what that sentence means numerically.
+    #[test]
+    fn full_stick_over_commands_the_envelope_without_the_reserve_and_fits_inside_it_with() {
+        let unshaped = shape_fore_aft_command(1.0, 1.0) * PEAK_DEMAND_A_PER_UNIT_STICK;
+        assert!(
+            unshaped > MAX_CURRENT_A,
+            "the premise of this whole change is that full stick over-commands: \
+             {unshaped} A demanded of a {MAX_CURRENT_A} A envelope"
+        );
+
+        let shaped =
+            shape_fore_aft_command(1.0, CMD_ENVELOPE_RESERVE) * PEAK_DEMAND_A_PER_UNIT_STICK;
+        // The stated reserve plus the two-figure rounding step the constant
+        // carries -- 33.62 A predicted here, 33.41 A actually measured in
+        // sim. Asserting against the exact stated fraction would be asserting
+        // that a rounded constant is unrounded.
+        let bound = (STATED_ENVELOPE_RESERVE_FRACTION + 0.01) * MAX_CURRENT_A;
+        assert!(
+            shaped <= bound,
+            "shaped full-stick demand {shaped} A exceeds the stated \
+             {STATED_ENVELOPE_RESERVE_FRACTION} of the {MAX_CURRENT_A} A envelope \
+             by more than the rounding step"
+        );
+        assert!(
+            shaped < MAX_CURRENT_A,
+            "the reserve has to leave SOME headroom at full stick, or it is not a reserve"
+        );
+    }
+
+    /// The reserve is a linear scaling and NOT a clamp. A clamp would leave
+    /// small stick inputs untouched and bite only near the rails, which is a
+    /// different control feel and a different failure mode -- and it is the
+    /// shape somebody reaches for when "cap the lean" is read casually.
+    #[test]
+    fn the_reserve_scales_the_whole_stick_range_and_is_symmetric() {
+        for &u in &[0.0f32, 0.1, 0.25, 0.5, 0.75, 1.0] {
+            let shaped = shape_fore_aft_command(u, CMD_ENVELOPE_RESERVE);
+            assert_eq!(
+                shaped,
+                u * CMD_ENVELOPE_RESERVE,
+                "u={u} is not scaled linearly"
+            );
+            assert_eq!(
+                shape_fore_aft_command(-u, CMD_ENVELOPE_RESERVE),
+                -shaped,
+                "u={u}: braking authority must be shaped exactly like driving authority; \
+                 a one-sided cap is an asymmetric-authority bug that only shows up under a \
+                 hard recovery in one direction"
+            );
+        }
+    }
+
+    /// Full stick still reaches the speed cap, so the reserve costs no top
+    /// speed -- which is the entire reason ADR-0011 rejected lowering
+    /// `MAX_GROUND_SPEED_M_S` as dominated. Stated here as the property that
+    /// makes it true: a shaped full stick is still far enough above zero that
+    /// the cap, not the command map, is what stops the board.
+    #[test]
+    fn a_shaped_full_stick_is_still_governed_by_the_speed_cap_not_by_the_command_map() {
+        let shaped = shape_fore_aft_command(1.0, CMD_ENVELOPE_RESERVE);
+        // Well below the cap, the cap does not touch it: the command map is
+        // the only thing acting.
+        assert_eq!(speed_capped_fore_aft(shaped, 0.0), shaped);
+        // At the cap, the cap takes all of it, whatever the command map left.
+        assert_eq!(speed_capped_fore_aft(shaped, MAX_GROUND_SPEED_M_S), 0.0);
+    }
+
+    // --- ADR-0011 criterion (a): why the reversal is the worst case ------
+
+    /// The reversal entry of the matrix, as a property rather than a run:
+    /// the speed cap NEVER attenuates a reversal, at any speed. This is what
+    /// makes "full reverse-to-forward stick reversal at speed" the worst
+    /// case -- the board is above the onset, where every surviving run in
+    /// ADR-0011's data was being unloaded by the cap, and the cap is not
+    /// acting.
+    #[test]
+    fn the_speed_cap_never_attenuates_a_stick_reversal() {
+        for &v in &[1.0f32, 5.0, 8.34, 9.34, 12.0] {
+            // Travelling forward, stick slammed back: full authority.
+            assert_eq!(
+                speed_capped_fore_aft(-1.0, v),
+                -1.0,
+                "braking from +{v} m/s was attenuated"
+            );
+            // ... and the mirror image.
+            assert_eq!(
+                speed_capped_fore_aft(1.0, -v),
+                1.0,
+                "braking from -{v} m/s was attenuated"
+            );
+        }
+    }
+
+    /// ... whereas an input that would accelerate the board further IS
+    /// attenuated, all the way to zero at the cap. Pinned alongside the test
+    /// above so the pair reads as the asymmetry it is.
+    #[test]
+    fn the_speed_cap_withdraws_accelerating_authority_over_the_last_margin() {
+        assert_eq!(speed_capped_fore_aft(1.0, 0.0), 1.0);
+        assert_eq!(speed_capped_fore_aft(1.0, SPEED_CAP_ONSET_M_S), 1.0);
+        let half = speed_capped_fore_aft(1.0, SPEED_CAP_ONSET_M_S + 0.5 * SPEED_CAP_MARGIN_M_S);
+        assert!(
+            (half - 0.5).abs() < 1e-6,
+            "the ramp should be linear across the margin, got {half}"
+        );
+        assert_eq!(speed_capped_fore_aft(1.0, MAX_GROUND_SPEED_M_S), 0.0);
+        assert_eq!(speed_capped_fore_aft(1.0, MAX_GROUND_SPEED_M_S + 5.0), 0.0);
+    }
+
+    // --- ADR-0011 criterion (c): the loss-of-authority warning -----------
+
+    /// The discriminator, both halves. Utilisation alone is not the trigger
+    /// and speed alone is not the trigger; the warning is the conjunction,
+    /// and dropping the speed half turns it into noise on every survivable
+    /// high-speed saturation.
+    #[test]
+    fn the_authority_warning_fires_only_on_high_utilisation_below_the_speed_cap_onset() {
+        let hot = AUTHORITY_UTILISATION_WARN + 0.05;
+        let cold = AUTHORITY_UTILISATION_WARN - 0.05;
+        assert!(authority_warning_active(hot, 2.0), "hot and slow must warn");
+        assert!(
+            authority_warning_active(hot, -2.0),
+            "the discriminator is speed MAGNITUDE -- a board reversing at 2 m/s is as \
+             unloaded as one driving at 2 m/s, which is to say not at all"
+        );
+        assert!(
+            !authority_warning_active(hot, SPEED_CAP_ONSET_M_S + 0.1),
+            "saturation above the onset is survivable and warning on it is noise"
+        );
+        assert!(
+            !authority_warning_active(cold, 2.0),
+            "utilisation below the threshold must not warn"
+        );
+        assert!(
+            !authority_warning_active(AUTHORITY_UTILISATION_WARN, 2.0),
+            "the trigger is strictly greater than the threshold"
+        );
+    }
+
+    /// The filter has to be fast enough to preserve the lead time it exists
+    /// to give and slow enough not to chatter on one noisy cycle. Both bounds
+    /// asserted, because the constant is chosen by them rather than tuned.
+    #[test]
+    fn the_authority_filter_is_bounded_by_the_cycle_below_and_the_lead_time_above() {
+        let cycle_s = DT_S as f32;
+        assert!(
+            AUTHORITY_UTILISATION_TAU_S > 10.0 * cycle_s,
+            "a filter shorter than ~10 control cycles is not a filter"
+        );
+        // The lead this warning is quoted at, measured on the estimator path
+        // with the reserve disabled -- see AUTHORITY_UTILISATION_WARN's doc
+        // comment and `tests/test_cmd_envelope_reserve.py`.
+        let measured_lead_s = 1.92_f32;
+        assert!(
+            AUTHORITY_UTILISATION_TAU_S < 0.2 * measured_lead_s,
+            "a filter comparable to the lead time eats the warning it is meant to give"
+        );
+    }
+
+    /// A first-order filter cannot overshoot its input, so the warning can
+    /// never fire on a utilisation the controller never asked for. Cheap, and
+    /// it is the property that makes the filtered signal safe to quote.
+    #[test]
+    fn the_filtered_utilisation_never_exceeds_a_constant_input() {
+        let alpha = DT_S as f32 / (AUTHORITY_UTILISATION_TAU_S + DT_S as f32);
+        let input = 0.9_f32;
+        let mut y = 0.0_f32;
+        for _ in 0..10_000 {
+            y += (input - y) * alpha;
+            assert!(y <= input, "filter overshot: {y} > {input}");
+        }
+        assert!(
+            (y - input).abs() < 1e-3,
+            "the filter must actually converge to its input, got {y}"
+        );
     }
 
     /// The steering law's standstill property, which the speed-proportional

--- a/crates/sim-host/src/scenario.rs
+++ b/crates/sim-host/src/scenario.rs
@@ -171,9 +171,104 @@ pub const S_CURVE_SCHEDULE: Schedule = &[
     (E2, E2 + 1.5, 0.0, 0.0, 0.0, "release (coast)"),
 ];
 
+// --- ADR-0011 exit criterion (a): the named acceptance matrix ------------
+//
+// "The board does not invert across a named test matrix" -- the ADR names
+// three entries, because "from any starting state" was untestable as
+// written. Two of the three are below; the third (full stick during a kerb
+// strike) is `FULL_STICK_SCHEDULE` plus a `HostConfig::disturbance`, since a
+// kerb is a disturbance and not an input schedule.
+//
+// All three are STRAIGHT-LINE, `steer = 0`, `lateral = 0`. That is not a
+// simplification: the flip these exist to catch happens on the straight, and
+// carving into them would add a yaw channel this crate's own header calls
+// non-physical to a measurement that has to stand up.
+
+/// Settle time before any acceptance schedule starts driving. Matches
+/// [`SCURVE4_SETTLE_S`] so the two are comparable tick for tick.
+pub const ACCEPTANCE_SETTLE_S: f64 = 0.5;
+
+/// Criterion (a) entry 1: **full stick from rest**, held. The defect issue
+/// #190 root-caused, reduced to the shortest schedule that reproduces it --
+/// no carve, no lateral, nothing to argue about.
+///
+/// 15 s of hold, matching [`SCURVE4_BUILD_S`]: the measured divergence is
+/// ~5.4 s in, and a hold that outlasts it by 3x leaves no room for "it was
+/// about to recover".
+pub const FULL_STICK_SCHEDULE: Schedule = &[
+    (0.0, ACCEPTANCE_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
+    (
+        ACCEPTANCE_SETTLE_S,
+        ACCEPTANCE_SETTLE_S + 15.0,
+        1.0,
+        0.0,
+        0.0,
+        "full stick from rest (hold)",
+    ),
+];
+
+/// Criterion (a) entry 2: **full stick reversal at speed** -- the ADR's
+/// worst case, and the one it records as NEVER TESTED.
+///
+/// Why it is the worst case, in the ADR's words: *commanded deceleration and
+/// gravity load the same side*. Two further mechanisms make it worse than
+/// that summary suggests, both visible in this host's own code:
+///
+/// 1. **The speed cap does not attenuate it.** The cap only withdraws
+///    authority when the stick and the current motion have the SAME sign
+///    (`accelerating_same_direction`). A reversal is by definition
+///    opposite-signed, so it passes through at full authority at any speed
+///    -- including above the 8.34 m/s onset where every surviving run in the
+///    ADR's data was being unloaded by that cap.
+/// 2. **It is a step, not a ramp.** The ballast actuator's `timeconst` is
+///    0.15 s and the stick goes from one rail to the other in one tick.
+///
+/// The schedule runs the reversal in BOTH directions, in one deterministic
+/// run, because the ADR names the reverse-to-forward one and the
+/// forward-to-reverse one is the entry condition for it:
+///
+/// - build forward at full stick to the speed cap,
+/// - slam to full reverse (forward-to-reverse, at speed),
+/// - hold through zero and back up to speed in reverse,
+/// - slam to full forward (**reverse-to-forward, at speed** -- the ADR's
+///   named case),
+/// - release.
+pub const STICK_REVERSAL_SCHEDULE: Schedule = &[
+    (0.0, ACCEPTANCE_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
+    (
+        ACCEPTANCE_SETTLE_S,
+        10.5,
+        1.0,
+        0.0,
+        0.0,
+        "full stick forward (build to the cap)",
+    ),
+    (
+        10.5,
+        20.5,
+        -1.0,
+        0.0,
+        0.0,
+        "SLAM full reverse (forward-to-reverse reversal at speed)",
+    ),
+    (
+        20.5,
+        30.5,
+        1.0,
+        0.0,
+        0.0,
+        "SLAM full forward (reverse-to-forward reversal at speed)",
+    ),
+    (30.5, 32.5, 0.0, 0.0, 0.0, "release"),
+];
+
 /// Every schedule a `--scenario`/`--scripted-scenario` flag accepts, by name.
-pub const BY_NAME: &[(&str, Schedule)] =
-    &[("default", DEFAULT_SCHEDULE), ("s-curve", S_CURVE_SCHEDULE)];
+pub const BY_NAME: &[(&str, Schedule)] = &[
+    ("default", DEFAULT_SCHEDULE),
+    ("s-curve", S_CURVE_SCHEDULE),
+    ("full-stick", FULL_STICK_SCHEDULE),
+    ("stick-reversal", STICK_REVERSAL_SCHEDULE),
+];
 
 /// Looks up a schedule by its command-line name.
 pub fn by_name(name: &str) -> Option<Schedule> {

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -1,0 +1,532 @@
+"""ADR-0011's acceptance matrix, measured -- including the two entries it fails.
+
+`docs/decisions/ADR-0011-hold-the-launch-until-the-board-stops-flipping.md`
+holds the launch until the board stops inverting at full stick, and specifies
+the fix as a **command-envelope reserve**: scale fore/aft stick by a derived
+constant upstream of the estimator, the regulator and the safety envelope,
+changing nothing else. This file is the evidence for that fix and, more
+importantly, the evidence for where it stops working.
+
+WHAT THIS FILE ASSERTS, AND WHAT IT DELIBERATELY MARKS xfail
+------------------------------------------------------------
+Three of ADR-0011's criteria pass on the DEPLOYED signal path and are asserted
+here as ordinary tests: (b) the constant is derived and the margin is a
+measured number, (a)-entry-1 full stick from rest, (a)-entry-2 the full stick
+reversal at speed -- which the ADR records as never having been tested and
+names as the worst case.
+
+Two do not pass, at any value of the constant, and are written here as
+`xfail(strict=True)`:
+
+* **(a)-entry-3, the kerb strike.** During a full-stick hold the board cannot
+  ride out a strike much above a 1 mm lip.
+* **(f), "every pass must hold with the estimator bias removed".**
+
+They are written as the criteria SHOULD read, and marked expected-to-fail,
+rather than being softened into something that passes or left out. `strict=True`
+matters: the day somebody fixes the underlying problem these turn RED as
+XPASS, which is the only mechanism that reliably tells a future session a known
+failure has stopped being one. A green suite that quietly stopped covering the
+thing it was written for is the failure mode this repo keeps hitting.
+
+WHY CRITERION (f) IS ALSO FLAGGED AS MIS-SPECIFIED
+---------------------------------------------------
+The ADR implements "with the estimator bias removed" as "feed the regulator
+MuJoCo truth". Measured here (`test_the_estimator_residual_is_specific_force_
+not_a_static_bias`), the `est - truth` residual is NOT a static bias: it
+regresses on the specific force the accel aiding failed to remove at ~5.8 deg
+per m/s^2, which is one radian per g -- the signature of a complementary
+filter reading the APPARENT VERTICAL rather than pitch. So `--pitch-source
+truth` does not remove an error; it deletes an acceleration reference and
+leaves a pitch-only regulator. Both readings of the criterion are therefore
+run: the ADR's literal one, and the robustness one it was reaching for (a
+worst-case STATIC bias injected on top of the real signal path). Both fail,
+so the conclusion does not depend on which reading is right.
+
+DETERMINISM
+------------
+Every run is `--scripted-scenario ... --free-run`: the schedule is indexed on
+simulated time (no wall clock, no socket, no staleness gate -- issue #190) and
+the plant is a fixed-timestep RK4 integrator with no stochastic terms, so
+these numbers are reproducible bit for bit and the whole matrix costs seconds
+rather than minutes of real time.
+
+THE BINARY MUST BE BUILT. If it is missing this FAILS, not skips -- same rule
+`test_closed_loop.py` and `test_rust_hosted_impulse_response.py` carry, for
+the same reason: a green gate that quietly did nothing is worse than no gate.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from sim.scenarios.plant import kerb_strike_impulse  # noqa: E402
+
+HOST_RS = REPO / "crates" / "sim-host" / "src" / "host.rs"
+
+#: Ports well away from the documented 9601/9602, so a verification run can
+#: never collide with a live capture session -- the same reason `sim-host`
+#: grew `--state-out-addr`/`--input-in-addr` in the first place.
+STATE_OUT = "127.0.0.1:19601"
+INPUT_IN = "127.0.0.1:19602"
+
+#: Pitch beyond which the board is unambiguously going over. Not the wire's
+#: own `FALLEN` threshold (20 deg) -- that one is a proxy this file measures
+#: the lateness OF, so it cannot also be the definition of failure.
+INVERTED_DEG = 90.0
+
+#: ICD 10.1 / the host's own constants. Duplicated here rather than imported
+#: because this file has no Rust binding; `test_the_shipped_constants_are_the_
+#: ones_this_file_measured` pins every one of them against `host.rs` so the
+#: duplication cannot drift silently.
+MAX_CURRENT_A = 40.0
+KT_NM_PER_A = 0.7
+KP_NM_PER_RAD = 140.0
+
+#: Total pitch authority, degrees: `MAX_CURRENT_A * KT / KP` = 0.2 rad. Every
+#: "pitch headroom" number in this file is measured against this.
+PITCH_CEILING_DEG = math.degrees(MAX_CURRENT_A * KT_NM_PER_A / KP_NM_PER_RAD)
+
+#: The frictionless-normal strike enters the frame at the axle, this far below
+#: the vehicle CoM -- `sim/scenarios/plant.py`'s own model parameters
+#: (`com_height_m` 0.77885, `wheel_radius_m` 0.1454), not numbers invented
+#: here. Sr. Mechanical & Systems owns that derivation (issue #142 AC2).
+KERB_MOMENT_ARM_M = 0.77885 - 0.1454
+
+#: One control cycle, which is also one physics step (`overboard_rider.xml`
+#: declares `timestep="0.002"` and `sim-backend` asserts the ratio is exactly
+#: 1), so an impulse delivered over this window is exact.
+DISTURBANCE_WINDOW_S = 0.002
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _rust_constant(name: str) -> float:
+    """Read a `const NAME: f32 = value;` straight out of `host.rs`.
+
+    So the numbers this file asserts against are the SHIPPED ones rather than
+    a copy of them. A constant edited in Rust and not here would otherwise
+    leave this suite green while measuring a controller that no longer exists.
+    """
+    m = re.search(rf"^const {name}: f32 = ([0-9.]+);", HOST_RS.read_text(), re.M)
+    assert m is not None, f"{name} is not a plain f32 const in {HOST_RS}"
+    return float(m.group(1))
+
+
+def test_the_sim_host_binary_is_actually_built():
+    assert (REPO / "target" / "release" / "sim-host").exists(), (
+        "sim-host is not built, so this whole gate would be vacuous. Run:\n"
+        "    cargo build --release -p sim-host --bin sim-host"
+    )
+
+
+def _run(tmp_path: Path, name: str, scenario: str, **kw) -> list[dict]:
+    """One deterministic free run; returns the per-cycle trace.
+
+    Invoked through `cargo run` rather than the raw binary path for the same
+    reason `test_rust_hosted_impulse_response.py` does: Cargo puts the linked
+    libmujoco's `OUT_DIR` on the dynamic loader path, so this resolves on
+    macOS without hand-set environment variables.
+    """
+    out = tmp_path / f"{name}.csv"
+    argv = [
+        "cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+        "--scripted-scenario", scenario,
+        "--free-run",
+        "--stats-path", "none",
+        "--state-out-addr", STATE_OUT,
+        "--input-in-addr", INPUT_IN,
+        "--trace-csv", str(out),
+    ]
+    for flag, value in kw.items():
+        if value is None:
+            continue
+        argv += [f"--{flag.replace('_', '-')}", str(value)]
+    proc = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert proc.returncode == 0, f"sim-host failed:\n{proc.stderr[-4000:]}"
+    with out.open() as f:
+        return [{k: float(v) for k, v in row.items()} for row in csv.DictReader(f)]
+
+
+def _first(rows, pred):
+    return next((r["sim_time_s"] for r in rows if pred(r)), None)
+
+
+def _inversion_time(rows):
+    return _first(rows, lambda r: abs(r["truth_pitch_deg"]) > INVERTED_DEG)
+
+
+def _healthy(rows):
+    """Rows up to the moment the board is committed, or all of them.
+
+    Peak statistics taken after an inversion describe a tumbling board, not a
+    controller, and quoting them would be meaningless in both directions.
+    """
+    t = _inversion_time(rows)
+    return [r for r in rows if t is None or r["sim_time_s"] < t]
+
+
+def _peak_demand_a(rows):
+    return max(abs(r["proposed_amps"]) for r in _healthy(rows))
+
+
+def _peak_pitch_deg(rows):
+    return max(abs(r["truth_pitch_deg"]) for r in _healthy(rows))
+
+
+def _margin(rows) -> str:
+    """The measured margin, in BOTH currencies ADR-0011 criterion (b) demands.
+
+    Never the word "stable" -- that claim is withdrawn and gated (ADR-0003).
+    """
+    a, p = _peak_demand_a(rows), _peak_pitch_deg(rows)
+    return (
+        f"peak demand {a:.2f} A of {MAX_CURRENT_A:.0f} A "
+        f"(current headroom {MAX_CURRENT_A - a:.2f} A, {100 * (1 - a / MAX_CURRENT_A):.1f}%); "
+        f"peak lean {p:.2f} deg of {PITCH_CEILING_DEG:.2f} deg "
+        f"(pitch headroom {PITCH_CEILING_DEG - p:.2f} deg, "
+        f"{100 * (1 - p / PITCH_CEILING_DEG):.1f}%)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion (b): the constant is DERIVED
+# ---------------------------------------------------------------------------
+
+
+def test_the_shipped_constants_are_the_ones_this_file_measured():
+    """Guard against the duplication above drifting from `host.rs`."""
+    assert _rust_constant("MAX_CURRENT_A") == MAX_CURRENT_A
+    assert _rust_constant("KT_NM_PER_A") == KT_NM_PER_A
+    assert _rust_constant("KP_NM_PER_RAD") == KP_NM_PER_RAD
+
+
+def test_peak_current_demand_is_linear_in_stick_at_the_documented_slope(tmp_path):
+    """`PEAK_DEMAND_A_PER_UNIT_STICK` is a MEASUREMENT, re-taken here.
+
+    It is the whole provenance of `CMD_ENVELOPE_RESERVE`: the constant is
+    `STATED_ENVELOPE_RESERVE_FRACTION * MAX_CURRENT_A / slope`, so a slope
+    that has moved means a constant that has to move with it. ADR-0011 forbids
+    the reverse -- tuning the constant to make a scenario pass.
+
+    Demand is taken PRE-envelope (`proposed_amps`), because the clamp cannot
+    reveal a demand it has already removed, and on the ESTIMATOR path, because
+    a command map is a property of the command path and the truth-fed runs
+    have no steady state to take a peak FROM (see criterion (f) below).
+
+    The 5% band is stated before the comparison: the per-run ratio across this
+    sweep spans 41.6-43.5 A/unit, so a tighter band would be asserting a
+    precision the measurement does not have.
+    """
+    fractions = (0.30, 0.50, 0.70, 0.90)
+    peaks = [
+        _peak_demand_a(_run(tmp_path, f"slope{u}", "full-stick", cmd_reserve=u, pitch_source="estimator"))
+        for u in fractions
+    ]
+    slope = sum(u * a for u, a in zip(fractions, peaks)) / sum(u * u for u in fractions)
+    documented = _rust_constant("PEAK_DEMAND_A_PER_UNIT_STICK")
+    print(f"\nmeasured peak-demand slope: {slope:.2f} A/unit (host.rs: {documented})")
+    assert abs(slope - documented) / documented < 0.05, (
+        f"peak demand is now {slope:.2f} A per unit stick, not the documented "
+        f"{documented}. CMD_ENVELOPE_RESERVE is derived from this number -- "
+        f"re-derive it ({_rust_constant('STATED_ENVELOPE_RESERVE_FRACTION')} * "
+        f"{MAX_CURRENT_A} / {slope:.2f} = "
+        f"{_rust_constant('STATED_ENVELOPE_RESERVE_FRACTION') * MAX_CURRENT_A / slope:.3f}) "
+        "rather than adjusting this tolerance."
+    )
+    assert slope > MAX_CURRENT_A, (
+        "the premise of the whole change is that full stick over-commands the "
+        f"envelope; measured {slope:.2f} A/unit against {MAX_CURRENT_A} A"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion (a): the named matrix, on the deployed signal path
+# ---------------------------------------------------------------------------
+
+
+def test_the_unshaped_command_map_still_inverts_the_board(tmp_path):
+    """The positive control, and it has to run FIRST in spirit.
+
+    Every "the board did not invert" assertion below is worthless unless this
+    harness can still see the defect ADR-0011 is about. With the reserve
+    disabled (`--cmd-reserve 1.0`) the board must still go over, at the time
+    the ADR measured.
+    """
+    rows = _run(tmp_path, "unshaped", "full-stick", cmd_reserve=1.0, pitch_source="estimator")
+    t = _inversion_time(rows)
+    assert t is not None, (
+        "full stick with the reserve disabled did NOT invert the board. Either "
+        "the plant, the gains or the harness has changed, and every acceptance "
+        "number in this file is measuring something else."
+    )
+    print(f"\nunshaped full stick inverts at {t:.3f} s")
+
+
+def test_criterion_a1_full_stick_from_rest_does_not_invert(tmp_path):
+    rows = _run(tmp_path, "a1", "full-stick", pitch_source="estimator")
+    assert _inversion_time(rows) is None, "full stick from rest inverted the board"
+    print(f"\n(a)1 full stick from rest -- {_margin(rows)}")
+
+    peak = _peak_demand_a(rows)
+    bound = (_rust_constant("STATED_ENVELOPE_RESERVE_FRACTION") + 0.01) * MAX_CURRENT_A
+    assert peak <= bound, (
+        f"peak demand {peak:.2f} A exceeds the stated reserve's {bound:.2f} A -- "
+        "the reserve is not delivering the headroom it is derived to deliver"
+    )
+    assert _peak_pitch_deg(rows) < PITCH_CEILING_DEG
+
+
+def test_criterion_a2_a_full_stick_reversal_at_speed_does_not_invert(tmp_path):
+    """The entry ADR-0011 records as NEVER TESTED, and names as the worst case.
+
+    It is the worst case for a reason the speed cap makes structural: the cap
+    only withdraws authority when stick and motion share a sign, so a reversal
+    passes through at FULL authority at any speed -- including above the
+    8.34 m/s onset, where the cap is the only thing that was unloading the
+    board. Commanded deceleration and gravity then load the same side.
+
+    The schedule runs it in both directions in one deterministic run; the
+    ADR names the reverse-to-forward one and the forward-to-reverse one is
+    its entry condition.
+    """
+    rows = _run(tmp_path, "a2", "stick-reversal", pitch_source="estimator")
+    assert _inversion_time(rows) is None, "a full stick reversal at speed inverted the board"
+    print(f"\n(a)2 full stick reversal at speed -- {_margin(rows)}")
+    assert _peak_pitch_deg(rows) < PITCH_CEILING_DEG
+
+
+def test_the_worst_point_in_the_matrix_is_quoted_in_both_currencies(tmp_path):
+    """Criterion (b): margin as a measured number, at the worst matrix point.
+
+    Deliberately re-derived across the matrix rather than asserted from one
+    scenario, so "the worst point" cannot quietly become "the point somebody
+    happened to measure". No threshold beyond "there is some headroom left" --
+    the number is the deliverable; a pass/fail bound on it would be a target,
+    and ADR-0011 forbids tuning to targets.
+    """
+    matrix = {
+        "full stick from rest": _run(tmp_path, "w1", "full-stick", pitch_source="estimator"),
+        "full stick reversal at speed": _run(tmp_path, "w2", "stick-reversal", pitch_source="estimator"),
+    }
+    worst = min(matrix, key=lambda k: MAX_CURRENT_A - _peak_demand_a(matrix[k]))
+    print(f"\nWORST POINT IN THE MATRIX: {worst} -- {_margin(matrix[worst])}")
+    assert _peak_demand_a(matrix[worst]) < MAX_CURRENT_A
+    assert _peak_pitch_deg(matrix[worst]) < PITCH_CEILING_DEG
+
+
+# ---------------------------------------------------------------------------
+# Criterion (c): the loss-of-authority warning
+# ---------------------------------------------------------------------------
+
+
+def test_criterion_c_the_warning_leads_the_outcome_where_fallen_trails_it(tmp_path):
+    """The warning must fire BEFORE the board is committed. `FALLEN` does not.
+
+    The reference event is the FIRST ENVELOPE SATURATION, which is what
+    ADR-0011's own lead times are quoted against -- its table puts it at
+    4.92 s, and its `FALLEN` figure of -0.95 s is exactly `FALLEN` minus that.
+    Lead is asserted against a floor rather than pinned to a value, because
+    the number is a measurement and pinning it would make an improvement look
+    like a regression; the measured value is printed either way.
+    """
+    rows = _run(tmp_path, "warn", "full-stick", cmd_reserve=1.0, pitch_source="estimator")
+    t_sat = _first(rows, lambda r: r["saturated"] > 0.5)
+    t_warn = _first(rows, lambda r: r["authority_warning"] > 0.5)
+    t_fallen = _first(rows, lambda r: r["fallen"] > 0.5)
+    assert t_sat is not None and t_warn is not None and t_fallen is not None
+
+    print(
+        f"\n(c) warning {t_warn:.3f} s | saturation {t_sat:.3f} s | FALLEN {t_fallen:.3f} s"
+        f"\n    warning lead over saturation: {t_sat - t_warn:+.3f} s"
+        f"\n    FALLEN  lead over saturation: {t_sat - t_fallen:+.3f} s"
+        f"\n    warning lead over FALLEN:     {t_fallen - t_warn:+.3f} s"
+    )
+    assert t_sat - t_warn > 1.5, "the warning no longer leads the committed point"
+    assert t_sat - t_fallen < 0.0, (
+        "FALLEN now leads saturation, which would mean the premise of this "
+        "criterion has changed"
+    )
+    assert t_fallen - t_warn > 2.5
+
+
+def test_the_warning_stays_quiet_on_a_survivable_run(tmp_path):
+    """A warning that fires on the shipped configuration's ordinary full-stick
+    acceleration is noise, and noise is how a warning gets ignored."""
+    rows = _run(tmp_path, "quiet", "full-stick", pitch_source="estimator")
+    assert _first(rows, lambda r: r["authority_warning"] > 0.5) is None
+
+
+# ---------------------------------------------------------------------------
+# The instrument criterion (f) depends on
+# ---------------------------------------------------------------------------
+
+
+def test_the_truth_pitch_rate_is_the_derivative_of_the_truth_pitch(tmp_path):
+    """Criterion (f) feeds truth pitch AND truth pitch rate to the regulator's
+    D term. A wrong rate there would invert the damping and be indistinguishable
+    from a physics finding, so it is checked against a signal that shares none
+    of its machinery: the numerical derivative of the reported pitch."""
+    rows = _run(tmp_path, "rate", "full-stick", pitch_source="estimator")
+    dt = rows[1]["sim_time_s"] - rows[0]["sim_time_s"]
+    worst = 0.0
+    for a, b in zip(rows[:-1], rows[1:]):
+        numeric = (b["truth_pitch_deg"] - a["truth_pitch_deg"]) / dt
+        worst = max(worst, abs(numeric - b["truth_pitch_rate_deg_s"]))
+    print(f"\ntruth pitch rate vs differenced pitch: worst {worst:.4f} deg/s")
+    assert worst < 1.0
+
+
+def test_the_estimator_residual_is_specific_force_not_a_static_bias(tmp_path):
+    """WHY CRITERION (f) IS MIS-SPECIFIED, as a measurement.
+
+    ADR-0011 describes the `est - truth` gap as a "~1 deg nose-down estimator
+    bias" and implements "remove the bias" as "feed the regulator truth". It
+    is not a bias. Regressed against the specific force the command feedforward
+    failed to remove (`a_x - ACCEL_FF_GAIN * I`), it comes out at ~5.8 deg per
+    m/s^2 -- and 1 radian per g is 57.2958/9.81 = 5.84 deg per m/s^2. That is
+    a complementary filter reporting the APPARENT VERTICAL, which is what an
+    accelerometer measures on a vehicle that accelerates.
+
+    The consequence is structural, not cosmetic: the estimate carries an
+    acceleration reference, so replacing it with truth does not correct an
+    error, it removes a feedback path and leaves a pitch-only regulator. That
+    is why the criterion (f) result below is a continuum in time-to-inversion
+    rather than a threshold in stick.
+    """
+    rows = _run(tmp_path, "resid", "full-stick", cmd_reserve=0.6, pitch_source="estimator")
+    accel_ff_gain = 0.0584  # ACCEL_FF_GAIN_M_S2_PER_A, host.rs
+    half = 50  # +-0.1 s central difference, to see through per-cycle noise
+    xs, ys = [], []
+    for i in range(half, len(rows) - half):
+        if not 1.0 <= rows[i]["sim_time_s"] <= 15.0:
+            continue
+        a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
+            rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
+        )
+        xs.append(a_x - accel_ff_gain * rows[i]["applied_amps"])
+        ys.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
+    n = len(xs)
+    sx, sy = sum(xs), sum(ys)
+    slope = (n * sum(x * y for x, y in zip(xs, ys)) - sx * sy) / (n * sum(x * x for x in xs) - sx * sx)
+    intercept = (sy - slope * sx) / n
+    one_rad_per_g = math.degrees(1.0) / 9.81
+    print(
+        f"\nest-truth residual vs unaided specific force: {slope:.2f} deg per m/s^2 "
+        f"(1 rad/g = {one_rad_per_g:.2f}), intercept {intercept:+.3f} deg"
+    )
+    assert abs(abs(slope) - one_rad_per_g) / one_rad_per_g < 0.25, (
+        "the est-truth residual no longer looks like an apparent-vertical "
+        "reading. If that is real, ADR-0011 criterion (f)'s framing needs "
+        "revisiting again, in the other direction."
+    )
+    assert abs(intercept) < 0.5, (
+        "a large intercept would mean there IS a static bias component after "
+        "all, which would make the ADR's framing partly right"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The criteria that do NOT pass. Written as they should read; xfail(strict).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ADR-0011 criterion (f), literal reading: fed MuJoCo truth the board "
+        "inverts at EVERY value of CMD_ENVELOPE_RESERVE down to 0.05 -- 4.42 s "
+        "at 1.00, 5.95 s at the shipped 0.80, 28.67 s at 0.05, and only exactly "
+        "zero stick survives. The constant buys TIME, not survival, so no "
+        "input-shaping value can satisfy this. See "
+        "test_the_estimator_residual_is_specific_force_not_a_static_bias for "
+        "why the truth-fed loop is a different controller rather than a "
+        "de-biased one. NOT a harness defect: the same harness reproduces the "
+        "ADR's own saturation (4.92 s), FALLEN (5.87 s) and truth-fed delta "
+        "(-1.74 s) figures."
+    ),
+)
+def test_criterion_f_full_stick_holds_with_the_estimator_bias_removed(tmp_path):
+    rows = _run(tmp_path, "f1", "full-stick", pitch_source="truth")
+    t = _inversion_time(rows)
+    assert t is None, f"fed MuJoCo truth, full stick from rest inverted at {t:.3f} s"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ADR-0011 criterion (f), robustness reading -- the question the ADR "
+        "was reaching for. A worst-case STATIC pitch-estimate error injected "
+        "on top of the real signal path inverts the board at +-0.5 deg "
+        "(survives +-0.25 deg). The tolerance band on the pitch estimate is "
+        "therefore about a quarter of a degree, which is the number that "
+        "matters most for hardware: an IMU mounted half a degree out flips "
+        "this board. Both readings of criterion (f) fail, so the conclusion "
+        "does not depend on which one is right."
+    ),
+)
+@pytest.mark.parametrize("bias_deg", [-0.5, 0.5])
+def test_criterion_f_the_matrix_holds_under_a_worst_case_static_pitch_bias(tmp_path, bias_deg):
+    rows = _run(tmp_path, f"f2{bias_deg}", "stick-reversal", pitch_source="estimator", pitch_bias_deg=bias_deg)
+    t = _inversion_time(rows)
+    assert t is None, f"a {bias_deg:+} deg static pitch bias inverted the board at {t:.3f} s"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ADR-0011 criterion (a) entry 3: full stick during a kerb strike. The "
+        "board rides out roughly a 1 mm lip at a calm point of the hold and "
+        "nothing at its worst point; a 20 mm lip -- brick edge, root heave, "
+        "the kind of thing a pavement has every few metres (issue #142) -- is "
+        "201 deg/s of imparted pitch rate against a KD channel that can afford "
+        "about 76 deg/s at zero lean. This is NOT fixable by input shaping and "
+        "is not what CMD_ENVELOPE_RESERVE was specified to fix; it is the "
+        "measurement behind ADR-0011's own note that the BALLAST STROKE and "
+        "CoM height, not the motor, are the undersized elements."
+    ),
+)
+def test_criterion_a3_full_stick_during_a_kerb_strike_does_not_invert(tmp_path):
+    """The strike magnitude comes from `sim/scenarios/plant.py`, not from here.
+
+    `kerb_strike_impulse` is Sr. Mechanical & Systems' derivation (issue #142
+    AC2) and stays the single source: this test reads the horizontal impulse
+    and the pitch rate it imparts, and injects force and torque that deliver
+    them. The moment arm is the axle-to-CoM distance the same function uses,
+    so the injected angular impulse is `J * l` by construction rather than by
+    coincidence.
+    """
+    # Struck mid-hold, at the speed the un-struck run is doing there.
+    t0, height_m = 6.0, 0.020
+    baseline = _run(tmp_path, "a3base", "full-stick", pitch_source="estimator")
+    speed = next(
+        abs(r["forward_speed_m_s"]) for r in baseline if abs(r["sim_time_s"] - t0) < 1e-3
+    )
+    strike = kerb_strike_impulse(height_m, speed)
+    impulse_ns = strike["impulse_ns"][0]  # frictionless-normal LOWER bound
+    force_n = impulse_ns / DISTURBANCE_WINDOW_S
+    torque_nm = -(KERB_MOMENT_ARM_M * force_n)  # below the CoM => nose-down
+    print(
+        f"\n(a)3 kerb {height_m * 1000:.0f} mm at {speed:.2f} m/s: {impulse_ns:.1f} N*s, "
+        f"{strike['pitch_rate_deg_s'][0]:.0f} deg/s imparted"
+    )
+    rows = _run(
+        tmp_path, "a3", "full-stick", pitch_source="estimator",
+        # forward is -X, so a retarding strike is +X
+        disturbance=f"{t0},{DISTURBANCE_WINDOW_S},{force_n},0,0,0,{torque_nm},0",
+    )
+    t = _inversion_time(rows)
+    assert t is None, f"a {height_m * 1000:.0f} mm lip at {speed:.1f} m/s inverted the board at {t:.3f} s"


### PR DESCRIPTION
## What

ADR-0011 exit criteria **(b)** and **(c)**: a derived command-envelope reserve on the fore/aft stick, and the loss-of-authority warning that this file was computing every cycle and throwing away.

**This does not clear the hold.** It is a strict improvement that is honest about its limit. Read the "does not pass" section before quoting any margin out of it.

## Provenance — read this before reviewing

The authoring agent **died on a spend limit** with all ~1,277 lines uncommitted. The first commit on this branch is a COO snapshot that says plainly it is unvalidated and must not be trusted. Every claim it flagged has since been run first-hand; the second commit is the validation record.

This matters because this repo has been burned by exactly this artefact once already — `feat/controls/turn-radius-and-reset` was snapshotted the same way, looked plausible for a day, and delivered one of its two features while its CI was green.

## Gate

| | |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets` | clean, zero warnings |
| `cargo test --workspace` | **194 passed, 0 failed** |
| `pytest tests/` | **318 passed, 6 xfailed, 0 failed** |
| `pytest tests/test_cmd_envelope_reserve.py` | **11 passed, 4 xfailed, no XPASS** |

No XPASS matters: the four are `xfail(strict=True)`, so an XPASS would mean a known failure had silently stopped being one.

## What passes — measured, in both currencies

- **(b) The constant is DERIVED, not tuned** to the forbidden 0.96/0.97 cliff. Re-measured peak-demand slope **41.97 A/unit** against the 42.03 documented; 0.80 × 41.97 = 33.6 A = 84% of envelope.
- **(b) Worst point in the matrix** is the full stick reversal at speed: peak demand **35.40 A of 40 A** → current headroom **4.60 A (11.5%)**; peak lean **9.74° of 11.46°** → pitch headroom **1.72° (15.0%)**. Never quoted as "stable".
- **(a)-1 full stick from rest** — holds.
- **(a)-2 full reverse-to-forward reversal at speed** — holds. The ADR records this as **never having been tested** and names it the worst case. It is now tested.
- **(c)** Warning at **3.000 s**, saturation **4.920 s**, `FALLEN` **5.868 s**. Warning leads `FALLEN` by **2.868 s**; `FALLEN` trails saturation by **−0.948 s**. Triggered on saturation *while below speed-cap onset* — the discriminator the ADR specifies, not saturation generally.

## What does not pass

- **(f), literal reading.** Fed MuJoCo truth the board inverts at **every** reserve value down to **0.05** — 4.42 s at 1.00, 5.95 s at the shipped 0.80, 28.67 s at 0.05. Only exactly zero stick survives. The constant buys **time, not survival**; no input-shaping value can satisfy this.
- **(f), robustness reading.** A worst-case *static* pitch error injected on the real signal path inverts at **±0.5°** and survives **±0.25°**. Both readings fail, so the conclusion does not depend on which is right. That quarter-degree band is probably the most important hardware number here: **an IMU mounted half a degree out flips this board.**
- **(a)-3, kerb strike.** Rides out roughly a **1 mm** lip at a calm point of the hold and nothing at its worst. A 20 mm lip is **201 °/s** of imparted pitch rate against a KD channel affording about **76 °/s** at zero lean. Not fixable by input shaping — this is the measurement behind the ADR's own note that **ballast stroke and CoM height, not the motor, are the undersized elements.**

## Is this real, or a miswired harness?

Real. The harness reproduces the ADR's independently-established figures — saturation **4.920 s** vs 4.92 s, `FALLEN` **5.868 s** vs 5.87 s. That is the check that separates a finding from a wiring bug.

## Criterion (f) now looks mis-specified, not merely unmet

The `est − truth` residual is **not a static bias**. It regresses on specific force at **~5.8°/m/s² — one radian per g**, the signature of a complementary filter reading *apparent vertical* rather than pitch. So `--pitch-source truth` does not remove an error; it **deletes an acceleration reference** and leaves a pitch-only regulator.

Escalated, not decided here. This PR claims nothing about (f) — it records the failure as a strict xfail so the day it is fixed, the suite turns red rather than quietly green.

## Acceptance criteria moved

**(b) met. (c) met. (a) two of three entries met. (f) not met and under review. (a)-3 not met.**
