### PR TITLE
docs(cmo): re-base the marketing desk off dates and onto events (ADR-0011)

### DIFF
--- a/roles/cmo/CONTEXT.md
+++ b/roles/cmo/CONTEXT.md
@@ -1,27 +1,5 @@
 # CMO — working context
 
-> ## ⛔ STOP — THE LAUNCH IS HELD. The sub-goals below are STALE.
->
-> **Added by the COO on 2026-08-02 under `TURF-OVERRIDE`.** This file is CMO turf and the COO
-> has changed nothing else in it — your priorities are yours to set. This banner exists only
-> because the file was merged on 2026-08-01, the day *before*
-> [ADR-0011](../../docs/decisions/ADR-0011-hold-the-launch-until-the-board-stops-flipping.md)
-> was ratified, so it still issues launch orders for a launch that is not happening.
->
-> - **The 2026-08-03 launch is HELD.** There is **no new date** — the hold is gated on a
->   control fix, not a calendar. Do not set a date, do not let one be inferred, do not run a
->   readiness review. Everything below dated to Monday or Sunday night needs re-basing by you.
-> - **Why:** holding full forward stick from rest inverts the board in ~6.5 s. On the
->   straight, at `steer = 0`, reachable in the playable build. The CEO hit it on first contact.
-> - **The stability claim is WITHDRAWN, not softened.** "The board never became unstable at
->   any aggression level tested" is false and may not be restated in any form. The
->   measurements behind it were taken through a harness delivering stick input at 7–13 Hz
->   against a 100 ms staleness cutoff — the board was commanded at ~0.62 of the lean the tests
->   believed. They support nothing and may not be cited.
-> - **Full brief:** [`roles/coo/restart-briefs-2026-08-02-launch-hold.md`](../coo/restart-briefs-2026-08-02-launch-hold.md), section 0.
->
-> Delete this banner once you have re-based the sub-goals below it.
-
 - **Worktree:** `~/projects/overboard-cmo` (ADR-0006). Marketing work happens in
   `overboard-web`, `overboard-viz` and `overboard-metrics`.
 - **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md) · [`ROLES.md`](../../docs/decisions/ROLES.md)
@@ -29,34 +7,85 @@
 - In this repo I write **only** `roles/cmo/**` (ratified, CODEOWNERS:180). Everything else here is
   read-only to me.
 
-## Current sub-goals
+## Current sub-goals — re-based 2026-08-02 onto the launch hold
 
-- **LAUNCH IS MONDAY 2026-08-03 MORNING**, readiness review Sunday night. Everything else is
-  subordinate until it ships. Both of the CEO decisions that blocked this desk for three boards
-  were answered on 08-01; nothing is waiting on him except the two rows below.
-- 🔄 **The launch artefact is a playable Unreal game, not a page of simulation results.** It
-  changed late on 08-01, after I had already written a board section against the old one.
-  **If a marketing doc still says "simulation results", it predates the change and is wrong.**
+- 🛑 **THE LAUNCH IS HELD and there is NO DATE.**
+  [ADR-0011](../../docs/decisions/ADR-0011-hold-the-launch-until-the-board-stops-flipping.md).
+  Holding full forward stick from rest inverts the board in ~6.5 s — on the straight, at
+  `steer = 0`, reachable in the playable build; the CEO hit it on first contact. **The hold is
+  gated on an engineering bar, not on a calendar.** I do not set a date, I do not let one be
+  inferred from a deadline of mine, and I do not run a readiness review. Every date this file
+  used to carry is gone; **triggers below are events, never days of the week.**
+- **What clears it is observable, so go and look rather than ask.** ADR-0011's second
+  ratification respecified the exit bar; four criteria are met by
+  [#205](https://github.com/MikePaNtZ/overboard/pull/205). Outstanding:
+  [#207](https://github.com/MikePaNtZ/overboard/issues/207) (pin the estimator trim and the
+  reserve's derivation), [#208](https://github.com/MikePaNtZ/overboard/issues/208) (encode the
+  authored-world constraint as a check), and **surfacing the loss-of-authority warning to the
+  player** — condition 3 of the criterion move.
+- **The stability claim is WITHDRAWN, not softened.** *"The board never became unstable at any
+  aggression level tested"* is **false** and may not be restated in any form, however hedged.
+  The measurements behind it came through a harness delivering stick at 7–13 Hz against a
+  100 ms staleness cutoff — the board was commanded at **~0.62** of the lean the tests
+  believed. **Those numbers support nothing and may not be cited.** Anything I publish that
+  needs them needs a re-measurement instead.
+- 🔄 **The launch artefact is a playable Unreal game, not a page of simulation results.** Still
+  true, and now with a caveat: the build that eventually ships is the *fixed* one, with a
+  saturation warning and a constrained world. **Copy written against the pre-hold build
+  describes a machine that will not ship.**
   Plan: [M3 Implementation Plan § Revision 3](https://app.notion.com/p/3af472a5fb6981f5b6e4ec038293ad6f).
+- **What this desk does during the hold — three things, in order.**
+  1. **Make sure nothing goes out.** Zero announced is now a *deliberate* number, not a
+     backlog. It stays zero until the bar clears and the CEO signs the claims.
+  2. **Spend the recovered capacity on the two real calendar deadlines** — the assembly
+     capture runbook (hardware Aug 15–28) and funding materials (Aug 24). Both are dated by
+     the physical world, not by the launch, so the hold does not move them; it just handed me
+     the time to do them. **These are the active work.**
+  3. **Keep the launch kit one revision behind the build**, so the desk can fire within a day
+     of the bar clearing without anyone feeling schedule pressure to skip the claims gate.
 - Answer the two big unknowns with data: do strangers care, and is *how we build it* more
-  interesting than the onewheel. **We can now measure the first one.**
+  interesting than the onewheel. **We can measure the first one** — the instrument is live and
+  the hold does not touch it.
 - **Produced vs. seen by a stranger is still the whole game.** Six produced, five published on a
-  live page, **zero announced anywhere**. Monday is the first time that last number can move.
+  live page, **zero announced anywhere**. The hold means that last number cannot move yet, and
+  moving it early would spend the one first impression on a board that flips.
 
-## What is live (re-verified 2026-08-01 ~21:00)
+## What is live (re-verified 2026-08-02 ~08:00)
 
 - `overboardproject.com`, HTTPS enforced, HTTP 200 in 0.19 s. Apex is DNS-only/grey-cloud so GitHub
   Pages holds its certificate; only `e.` is Cloudflare-proxied. **Do not flip the apex to orange —
   it takes the site's TLS down.**
 - Collector at `e.overboardproject.com/e` → D1. `/health` reports events, last event, reject count
   and last reject reason, and is **unauthenticated** — it is the one number provable without a token.
-  1,973 events, last at 13:18 UTC; 4 rejected all time, all "missing required field `site`".
+  2,371 events, last at 07:51 UTC; 4 rejected all time, all "missing required field `site`",
+  the most recent on 08-01. **No announcement spike — the growth since 08-01 is the daily
+  synthetic job.**
 - Dashboard at `/dashboard?k=…`, token-gated, fails closed, **404s on a bad token** (deliberate — a
   403 would confirm the route exists). Real vs. synthetic is `&site=synthetic-overboard`.
 - Daily jobs: synthetic traffic, and a GitHub traffic snapshot into `overboard-metrics` (private).
+- **Nothing launch-shaped is on the public surface, checked rather than assumed (08-02).** The
+  live page carries no date, no "launch", no "playable", and not one word of the withdrawn
+  stability claim; `overboard-web` `master` is unchanged since the policy-gate port; no
+  marketing branch of mine is pushed; the three open web PRs (#41/#42/#43) are copy, not
+  announcements. **No scheduled job can publish on its own** — web CI is deploy-on-push plus a
+  private daily metrics snapshot, so nothing fires on a calendar.
+  - The one sentence worth re-reading each time: the build-log entry *"the real board is
+    stable at rest, because the battery and motor sit below the axle"*. It is a **static**
+    claim about mass placement, not a balance-controller claim, so ADR-0011 does not withdraw
+    it — but it is the nearest neighbour to a withdrawn claim on the live page, and it is the
+    one a hostile reader would quote back. Reviewed 08-02 and kept.
 
 ## Rules this role owns
 
+- 🛑 **No public artefact asserts stability of the balance controller** until the ADR-0011 exit
+  bar is met (ADR-0011, registered with the `policy` gate). This is stronger than the existing
+  Playable Sim rule and outranks it: Playable Sim forbids behavioural numbers *from a game run*;
+  this forbids stability language **from any source**, including a clean scripted run, until the
+  bar clears. When it does clear, the replacement is **a measured margin with its method**, never
+  the word "stable".
+- **A withdrawn claim is withdrawn at the measurement, not at the sentence.** Rewording around
+  it is the failure mode. The 7–13 Hz harness data is unusable **as data** — a softer sentence
+  built on it is the same false claim in a better mood.
 - **Category on every published asset** — Footage · Sim Replay · Hardware Replay · Concept, plus
   **Playable Sim**, a fifth category proposed 08-01 for live/interactive artefacts and **not yet
   landed** ([#163](https://github.com/MikePaNtZ/overboard/issues/163)). **Until it lands the game
@@ -90,6 +119,30 @@
 
 ## Decisions made
 
+- **Every deadline on this desk is now anchored to an EVENT, not a date** (2026-08-02). Named
+  as a decision because it changes how this file is written, not just what it says. A
+  day-of-the-week deadline in a role context file survives the thing it was written for and
+  then issues orders — which is exactly the trap ADR-0011 caught here, and
+  [#203](https://github.com/MikePaNtZ/overboard/issues/203) generalises. The events I use:
+  *bar clears* · *build nominated* · *claims signed* · *first announcement*.
+- **The claims doc is revised now and routed to the CEO later** (2026-08-02). Its content
+  survives the hold almost intact — it already forbids "stable", "rock solid" and "balances
+  confidently" — so it is not wasted work. But it is titled a **gate** with a Sunday deadline,
+  and a gate arriving with a deadline implies a date behind it. **Trigger re-based to: the exit
+  bar is met AND a specific build is nominated.** Sending it early would buy a day of CEO
+  reading time at the cost of implying a schedule, and its premise (the pre-hold build) has
+  moved anyway.
+- **The subscribe-form deadline moves from a date to the announcement** (2026-08-02). The old
+  rule was *"not green by Saturday night → I cut the form."* Saturday night was a proxy for
+  *before strangers arrive*; the launch was the thing bringing strangers, and it is held. The
+  harm the rule exists to prevent — a stranger typing an address into a control that discards
+  it — cannot occur while nothing is announced. **New trigger: green or cut before the first
+  announcement, whichever comes first. Still mine, still no need to ask.** Recorded so it reads
+  as a call rather than a deadline I let slide.
+- **Portfolio direction is unparked** (2026-08-02). It was parked on *"Tue/Wed after launch"* —
+  a date derived from a launch that no longer exists, which would have parked it indefinitely.
+  It was parked for capacity, and the hold returned the capacity. It queues behind the two
+  hard-dated items rather than behind a launch.
 - **Build log: gone for launch, not for good.** The CEO ruled on the removal; only "for good?" was
   open and that half is mine. Entries keep being written into Notion so the planned content is not
   lost, and the section returns with conditional approval. Disposes of
@@ -117,6 +170,13 @@
 
 ## Known dead ends
 
+- 🔴 **A day-of-the-week deadline in this file is a live trap.** *"LAUNCH IS MONDAY"* sat at the
+  top of this file on `master` while ADR-0011 held the launch, so **any** CMO restart booted
+  into orders for a launch that was not happening — armed, not merely uninformed. The COO had
+  to bolt a banner on someone else's turf to defuse it. Nothing in the org notices this class of
+  contradiction ([#203](https://github.com/MikePaNtZ/overboard/issues/203)). **Anchor every
+  trigger in here to an event.** An event-anchored line that goes stale is inert; a
+  date-anchored one gives instructions.
 - 🔴 **Never send a Notion `update_content` edit whose `new_str` opens a `<table>` that the `old_str`
   did not close.** I did this to the 08-01 board at ~21:35 and it swallowed every section after
   mine — the COO's and Archivist's prose were destroyed and three metric tables merged into one.
@@ -144,34 +204,75 @@
 
 ## In flight / owed
 
-- 🔴 **Blocked on the CEO — does a stranger PLAY the game Monday, or only WATCH it?** Neither build
-  brief has packaging or QA in it, so my default is *watch*. **It decides the headline verb**, so
-  the page copy cannot be finished without it.
-- 🔴 **Blocked on the CEO — the claims gate.** He owns public claims personally and has not seen the
-  words. Due in front of him **Sunday evening, before the readiness review**, not during it.
-  [🔒 Launch claims](https://app.notion.com/p/3af472a5fb6981cfb496e2444aff610e).
-- 🔴 **Blocked on the Archivist — [#163](https://github.com/MikePaNtZ/overboard/issues/163)**,
-  `Playable Sim` into the canonical vocabulary, `docs/vocabulary/`, the sweep, **and the Digital
-  Content Production session-start prompt** — that prompt enumerates the four categories and is what
-  DCP actually reads when labelling Monday's footage. Needed **before footage exists**.
-- 🔴 **Blocked on Senior Controls — [#161](https://github.com/MikePaNtZ/overboard/issues/161).** If
-  the real control law is not in the loop, the claims doc is **void, not weakened**. I am not
-  writing a second set of copy for the fake-physics case; there is no version of it I would sign.
-- **Mine, Saturday night —** [`overboard-web#53`](https://github.com/MikePaNtZ/overboard-web/issues/53),
-  the subscribe form. `signupEndpoint` is `''` (`analytics.js:27`) and the handler discards the
-  address (`index.html:1216`). **Not green by Saturday night → I cut the form** rather than ship a
-  decoy. I do not need to ask.
-- **Mine, Sunday midday —** review the actual playable build and rewrite everything marked
-  CONFIRM SUNDAY in [🚀 Monday launch content](https://app.notion.com/p/3af472a5fb6981f59d3dd2cfe5320ce8)
-  against what exists rather than what was promised.
-- **SDM owes the adversarial fit-and-finish UI review** before the page reaches the CEO —
-  [`overboard-web#54`](https://github.com/MikePaNtZ/overboard-web/issues/54). A CEO-named gate that
-  had no ticket until 08-01.
-- 🔴 **Purge synthetic data before L1 publishes.** It lives in Cloudflare; the local `--purge` will
-  not reach it. Use the collector's purge job. **Gated by the CEO** — he sets the date at conditional
-  approval, and until then he wants synthetic folded into the board highlights.
-- 🔴 **Assembly capture runbook** — hardware Aug 15–28, happens once, still not written.
-- **Parked with a date, not a risk:** portfolio direction with the CEO, Tue/Wed after launch.
-- Funding materials (Aug 24, P0, not started) — **unblocked as of 08-01**; the hardware-evidence
-  decision was answered (simulation content, best available).
+**Two things are dated by the physical world and are therefore the active work. Everything
+under "waiting on the hold" is genuinely waiting — it is not parked, because nobody is blocked
+on me for it.**
+
+### Active — real calendar, untouched by the hold
+
+- 🔴 **Assembly capture runbook** — hardware arrives **Aug 15–28**, the assembly happens **once**,
+  and it is still not written. The hold has no bearing on this and just handed me the time.
+  **This is the top item on the desk.**
+- **Funding materials — Aug 24, P0, not started.** Unblocked since 08-01 (the hardware-evidence
+  question was answered: simulation content, best available). One re-base: the materials must
+  not lean on the withdrawn stability claim or on anything measured through the old harness.
+  **The hold is not a hole in the story** — a project that caught its own defect before shipping
+  and held a launch over it reads better to an investor than one that shipped it.
+- **Portfolio direction with the CEO** — unparked, queued behind the two above.
+
+### Waiting on the hold — no dates, event triggers only
+
+- **Mine, when the bar clears AND a build is nominated —** revise
+  [🔒 Launch claims](https://app.notion.com/p/3af472a5fb6981cfb496e2444aff610e) and route it to
+  the CEO. Revision needed before it goes anywhere: strip the Sunday/Monday framing, add the
+  **full-stick inversion** to the say / do-not-say table as its own row, and replace the
+  "what has to be true by Sunday midday" list with the ADR-0011 exit criteria. It still reads
+  DRAFT and the CEO has never seen it — **which is the correct state, not a slip.**
+- **Mine, when a build is nominated —** review the build and rewrite the `[CONFIRM SUNDAY]`
+  lines in [🚀 Monday launch content](https://app.notion.com/p/3af472a5fb6981f59d3dd2cfe5320ce8)
+  against what exists. The doc needs re-titling off "Monday" and the `[CONFIRM SUNDAY]` markers
+  re-anchoring to *the nominated build*; §7 (Follow along) picks up the re-based form trigger.
+- **Mine, before the first announcement —**
+  [`overboard-web#53`](https://github.com/MikePaNtZ/overboard-web/issues/53), the subscribe form.
+  Still a decoy: `signupEndpoint` is `''` (`analytics.js:27`), the handler reads it, finds
+  nothing and shows *"The list opens with the first build log"* while discarding the address
+  (`index.html:1214`). **Green or cut before anything is announced.** I do not need to ask.
+- **Archivist — [#163](https://github.com/MikePaNtZ/overboard/issues/163)**, `Playable Sim` into
+  the canonical vocabulary, `docs/vocabulary/`, the sweep, **and the Digital Content Production
+  session-start prompt**. Re-based from 🔴 to a **prerequisite with slack**: ADR-0011 supersedes
+  the existing capture and holds the re-shoot, so no footage exists to mislabel. Trigger is
+  unchanged and unmissable — **before any footage exists**, which is now before the re-shoot
+  rather than before Monday.
+- **Senior Controls — [#161](https://github.com/MikePaNtZ/overboard/issues/161).** Unchanged in
+  substance: real control law in the loop, or the claims doc is **void, not weakened**. Nothing
+  ships that fakes the physics.
+- **SDM owes the adversarial fit-and-finish UI review** —
+  [`overboard-web#54`](https://github.com/MikePaNtZ/overboard-web/issues/54). Trigger re-based
+  from "before the page reaches the CEO on Sunday" to **before the page reaches the CEO**.
+- 🔴 **Purge synthetic data before L1 publishes.** Cloudflare-resident; the local `--purge` will
+  not reach it — use the collector's purge job. Already event-triggered, so the hold changes
+  nothing. Gated by the CEO at conditional approval; until then he wants synthetic folded into
+  the board highlights.
+
+### Closed out by the hold
+
+- ~~**Blocked on the CEO — does a stranger PLAY the game or only WATCH it?**~~ **Unblocked by
+  standing default: watch.** It was urgent only because it decided a headline verb for a page
+  going out on Monday. There is no Monday, the packaging work still does not exist in any brief,
+  and a build that inverts at full stick is not one to hand a stranger. **Revisit only if a
+  nominated build ships with packaging.** One fewer thing waiting on the CEO.
+- ~~`feat/marketing/board-0801-relaunch`~~ — ADR-0011 assigns "the branch carrying the dead
+  date" to the Senior Digital Marketer, but the `feat/marketing/` prefix is **mine**. Checked
+  08-02: it is a local-only branch in my worktree, never pushed, and its single commit is
+  already squashed onto `master`. Nothing to strip and nothing to publish. **The SDM's exposure
+  is under `feat/web/` and is a separate check.**
+
+### Background
+
 - web#25 alarm · web#29 publish-race regression test · Experiments database.
+- **No ticket anywhere for ADR-0011 condition 3** — surfacing the loss-of-authority warning to
+  the player. #205 landed the signal (2.868 s of lead over `FALLEN`); the ADR says it "still
+  needs to actually surface". Filed 08-02 as
+  [`overboard-game#19`](https://github.com/MikePaNtZ/overboard-game/issues/19) so the last
+  hold-clearing condition is observable rather than remembered. **The ask, not the design** —
+  how it surfaces is the Game Engineer's.

--- a/roles/cmo/log/2026-08-02-rebase-on-the-launch-hold.md
+++ b/roles/cmo/log/2026-08-02-rebase-on-the-launch-hold.md
@@ -1,0 +1,82 @@
+# 2026-08-02 — re-based the marketing desk onto the launch hold, and confirmed nothing went out
+
+**Role:** CMO · **Session outcome:** `CONTEXT.md` re-based off dates and onto events, banner
+deleted, publication surface audited clean, one untracked hold-clearing condition ticketed.
+
+## The one thing to know
+
+**Nothing went out, and nothing can go out on its own.** Checked rather than assumed — the
+audit is in the "What is live" section of `CONTEXT.md`. The live page carries no date, no
+"launch", no "playable", and not one word of the withdrawn stability claim. No marketing branch
+of mine is pushed. `overboard-web` CI is deploy-on-push plus a private daily metrics snapshot,
+so **no scheduled job can publish**. The collector shows 2,371 events with no announcement
+spike; the growth since 08-01 is the synthetic job.
+
+The two launch documents in Notion — 🔒 Launch claims and 🚀 Monday launch content — are both
+still `DRAFT`, unreviewed, and have never reached the CEO. **That is the correct state, not a
+slip.** The claims doc was due in front of him "Sunday evening"; it did not go, and it should
+not now.
+
+## The trap, and why the banner was warranted
+
+`roles/cmo/CONTEXT.md` was merged on `master` on 08-01 with **"LAUNCH IS MONDAY 2026-08-03
+MORNING"** as its first sub-goal, one day before ADR-0011 held that launch. It is the first
+file a CMO session reads. Any restart — for any reason — booted this desk into launch orders.
+It was **armed, not merely uninformed**, and the COO was right to bolt a `TURF-OVERRIDE` banner
+on it rather than wait for a session to notice.
+
+The durable fix is not the banner. **Every trigger on this desk is now anchored to an event**
+— *bar clears* · *build nominated* · *claims signed* · *first announcement* — never to a day of
+the week. An event-anchored line that goes stale is inert. A date-anchored one gives
+instructions. Recorded as a dead end because [#203](https://github.com/MikePaNtZ/overboard/issues/203)
+says nothing in the org catches this class of contradiction.
+
+## What re-based, and the calls behind it
+
+| Was | Now | Why it is a re-base and not a slide |
+|---|---|---|
+| Claims gate to the CEO, **Sunday evening** | When the bar clears **and** a build is nominated | A doc titled *gate* arriving with a deadline implies a date behind it. Its premise — the pre-hold build — has moved anyway |
+| Subscribe form green or cut, **Saturday night** | Green or cut **before the first announcement** | Saturday was a proxy for *before strangers arrive*. The launch was what brought strangers; the harm cannot occur while nothing is announced |
+| Review the build, **Sunday midday** | When a build is nominated | Same review, no date to infer from |
+| `Playable Sim` before **Monday's footage** | Before **any footage exists** | ADR-0011 supersedes the capture and holds the re-shoot. Prerequisite with slack, not an emergency |
+| Portfolio direction, **Tue/Wed after launch** | Unparked | It was parked for capacity against a launch that no longer exists — that parks it indefinitely. The hold returned the capacity |
+| Play-or-watch, **blocked on the CEO** | Closed on the standing default: **watch** | It was urgent only because it decided a headline verb for Monday. One fewer thing waiting on the CEO |
+
+**Unchanged by the hold, and therefore now the active work:** the assembly capture runbook
+(hardware Aug 15–28, happens once, still not written) and funding materials (Aug 24, P0). Both
+are dated by the physical world. The hold did not move them — it handed me the time to do them.
+
+## The claim, and the sentence next to it
+
+*"The board never became unstable at any aggression level tested"* is **withdrawn at the
+measurement, not at the sentence.** The harness delivered stick at 7–13 Hz against a 100 ms
+staleness cutoff, so the board was commanded at ~0.62 of the lean the tests believed. Rewording
+around that data is the same false claim in a better mood. Added to "Rules this role owns" as a
+rule that **outranks** the Playable Sim numbers split: that one forbids behavioural numbers from
+a game run, this one forbids stability language from any source until the bar clears.
+
+One live sentence sits next to it and was reviewed and **kept**: the build-log entry *"the real
+board is stable at rest, because the battery and motor sit below the axle."* That is a static
+claim about mass placement, not a balance-controller claim. It is the nearest neighbour to a
+withdrawn claim on the public surface and the one a hostile reader would quote back, so it is
+recorded rather than left to be rediscovered.
+
+## Filed
+
+[`overboard-game#19`](https://github.com/MikePaNtZ/overboard-game/issues/19) — surfacing the
+loss-of-authority warning to the player, **ADR-0011 condition 3.** Conditions 1 and 2 have
+tickets (#207, #208); condition 3 existed only in prose, in no repo. The ADR says the criterion
+split is honest only under all three. Filed as the **ask, not the design** — how it surfaces is
+the Game Engineer's.
+
+## For my successor
+
+- **Do not set a date and do not accept one inferred from a deadline of mine.** If a document of
+  mine acquires a day of the week, that is the regression.
+- `feat/marketing/board-0801-relaunch` is a local-only branch in my worktree, never pushed, its
+  single commit already squashed onto `master`. ADR-0011 attributes it to the SDM; the
+  `feat/marketing/` prefix is mine. **Nothing to strip.** The SDM's exposure is under
+  `feat/web/` and is a separate check I did not run.
+- The launch kit is one revision behind whatever build eventually ships. Keep it there, so the
+  desk can fire within a day of the bar clearing and nobody feels pressure to skip the claims
+  gate to make up time.


### PR DESCRIPTION
## What changed

`roles/cmo/CONTEXT.md` is re-based onto the launch hold, and the COO's `TURF-OVERRIDE` banner is **deleted** — because the thing it warned about is fixed rather than merely acknowledged. Plus a session log.

## Why the banner was warranted

This file was merged on `master` on 08-01 with **"LAUNCH IS MONDAY 2026-08-03 MORNING"** as its first sub-goal, one day before [ADR-0011](docs/decisions/ADR-0011-hold-the-launch-until-the-board-stops-flipping.md) held that launch. It is the first file a CMO session reads under the session-start protocol, so **any** restart booted this desk into launch orders — armed, not merely uninformed. Exactly the class of contradiction #203 says nothing in the org notices.

## The fix is not a banner

**Every trigger on this desk is now anchored to an event** — *bar clears* · *build nominated* · *claims signed* · *first announcement* — never to a day of the week. An event-anchored line that goes stale is inert; a date-anchored one gives instructions. Recorded as a dead end so the next session does not reintroduce it.

| Was | Now |
|---|---|
| Claims gate to the CEO, **Sunday evening** | When the bar clears **and** a build is nominated |
| Subscribe form green-or-cut, **Saturday night** | Before the **first announcement** |
| Review the build, **Sunday midday** | When a build is nominated |
| `Playable Sim` before **Monday's footage** | Before **any** footage exists — prerequisite with slack, not an emergency |
| Portfolio direction, **Tue/Wed after launch** | Unparked; it was parked for capacity against a launch that no longer exists |
| Play-or-watch, **blocked on the CEO** | Closed on the standing default: **watch** |

**No new date is set and none is inferable.** The two items dated by the physical world — the assembly capture runbook (hardware Aug 15–28) and funding materials (Aug 24) — are untouched by the hold and are now the active work.

## Acceptance criteria that moved

- **ADR-0011, public-claim half.** Added as a rule that **outranks** the existing Playable Sim numbers split: no public artefact asserts stability of the balance controller **from any source** — not just from a game run — until the exit bar is met. And the withdrawn claim is withdrawn **at the measurement**: the 7–13 Hz harness data is unusable as data, so a softer sentence built on it is the same false claim in a better mood.
- **`SR-WEB-4` lock-step:** verified rather than assumed — nothing on the public surface asserts a launch, so nothing needs to move.

## Nothing went out — audited, not assumed

The live page carries no date, no "launch", no "playable", and not one word of the withdrawn claim. No marketing branch of mine is pushed. `overboard-web` CI is deploy-on-push plus a private daily metrics snapshot, so **no scheduled job can publish on its own**. Collector shows 2,371 events with no announcement spike. Both Notion launch docs are still `DRAFT` and have never reached the CEO — the correct state, not a slip.

One live sentence was reviewed and **kept**, and is recorded so it is not rediscovered: the build-log entry *"the real board is stable at rest, because the battery and motor sit below the axle"* is a **static** claim about mass placement, not a balance-controller claim.

## Related

- Filed [`overboard-game#19`](https://github.com/MikePaNtZ/overboard-game/issues/19) — surfacing the loss-of-authority warning to the player, **ADR-0011 condition 3**. Conditions 1 and 2 have tickets (#207, #208); condition 3 existed only in prose, in no repo, and the ADR says the criterion split is honest only under all three. Filed as the ask, not the design.
- Note for the COO: ADR-0011 attributes `feat/marketing/board-0801-relaunch` to the SDM, but `feat/marketing/` is the **CMO** prefix. That branch is local-only, never pushed, and its one commit is already squashed onto `master` — nothing to strip. The SDM's exposure is under `feat/web/`.

## Scope

`roles/cmo/**` only (CODEOWNERS:180, verified with `policy_check.py --who`).