### PR TITLE
docs(sdm): teardown — the hold gated on my surface, and a branch that was already merged

### DIFF
--- a/roles/senior-digital-marketer/CONTEXT.md
+++ b/roles/senior-digital-marketer/CONTEXT.md
@@ -4,24 +4,54 @@
 - **Registry:** [`docs/decisions/ROLES.md`](../../docs/decisions/ROLES.md)
 - **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
 
-## Status: Provisional (ADR-0005)
+## Status: Ratified (ROLES.md, 2026-07-31)
 Registered 2026-07-26 after filing under the CMO seat with a title prefix — every row filed
-before that was misattributed and has been repaired. Owns nothing in the `overboard` repo by
-design; the surface is `overboard-web`.
+before that was misattributed and has been repaired. Ratified 2026-07-31 once `overboard-web`
+had a CODEOWNERS to point at (overboard-web#35); prefix `feat/web/`, escalates to the CMO.
+Owns nothing in the `overboard` repo except `roles/senior-digital-marketer/**`; the surface is
+`overboard-web`.
+
+> ## 🛑 THE LAUNCH IS HELD — [ADR-0011](../../docs/decisions/ADR-0011-hold-the-launch-until-the-board-stops-flipping.md)
+>
+> - **2026-08-03 is dead and there is no new date.** The hold is gated on a control fix, not a
+>   calendar. Do not set a date, do not let one be inferred, do not publish.
+> - **"The board never became unstable at any aggression level tested" is WITHDRAWN** — false,
+>   and not to be reinstated in any softened form. The measurements behind it were taken through
+>   a harness delivering stick at 7–13 Hz against a 100 ms staleness cutoff, so the board was
+>   commanded at ~0.62 of the lean the tests believed. **They may not be cited.**
+> - **On this surface I am the safety net.** The controls repo's `policy` gate registers the
+>   claim but does not gate `overboard-web`. `check_page.py` rule 6c does — see the log entry
+>   for 2026-08-02. Narrow it when the hold lifts; do not delete it.
 
 ## Current sub-goals
-- The L1 announcement is drafted and deliberately held on two engineering conditions.
-- Two commits of website copy were reported sitting locally, never pushed, no review opened.
-  **Push them.** Uncommitted work is invisible to every other session (ADR-0006).
+- The L1 announcement is drafted and deliberately held on two engineering conditions, plus the
+  ADR-0011 hold. It does not go out on a date — it goes out on the exit criteria.
+- **Open question with the CEO:** the `#now` heading, "Right now: it stays up, and it goes where
+  it's told." ADR-0011 bars any public artifact asserting stability of the balance controller;
+  the 08-02 audit cleared the site of *the withdrawn claim*, which this is not. Whether the
+  frontier line needs re-basing is a positioning call, and the copy gate puts it with the CMO,
+  not me. Raised 2026-08-02, not acted on.
 
 ## Rules
 - Lead with the measured surprise, not the ambition. Tag every link so we can tell which
   community sent people. End the post with an ask — the GitHub click-through is the conversion.
+- **I never clear my own page copy.** CMO reviews SDM copy (CEO ruling 2026-07-31); never queue
+  own prose with `--auto`. CI scripts and this file are not copy.
 
 ## Decisions made (edit in place — completed work goes in log/, not here)
 
-_Nothing recorded yet by this role._
+- **2026-08-02 — did not touch `feat/marketing/board-0801-relaunch`.** ADR-0011 assigned it to
+  me, but it is the CMO's branch (`feat/marketing/`, `roles/cmo/**`, checked out in
+  `~/projects/overboard-cmo`), it **merged as #164 on 08-01**, and the dead date it carried was
+  already defused on `master` by the COO's `TURF-OVERRIDE` banner. Nothing to strip; editing it
+  would have been Turf on a file another role had handled.
+- **2026-08-02 — gated the claim in CI rather than trusting the ADR to be read** (overboard-web
+  #55). ADR-0011 itself says the date "binds only sessions that read it"; that is precisely the
+  failure a check does not have.
 
 ## Known dead ends
 
-_Nothing recorded yet._
+- **`git log master..<branch>` does not tell you whether a branch merged.** Squash-merge rewrites
+  the SHA, so a fully-merged branch still lists its commits as absent from master and looks live.
+  Check `gh pr list --head <branch> --state all`, or diff against `origin/master`, before
+  concluding there is work outstanding. This nearly sent me editing another role's merged branch.

--- a/roles/senior-digital-marketer/log/2026-08-02-launch-hold-gated-on-my-surface.md
+++ b/roles/senior-digital-marketer/log/2026-08-02-launch-hold-gated-on-my-surface.md
@@ -1,0 +1,109 @@
+# 2026-08-02 — The launch hold, gated on my surface
+
+Session brief: ADR-0011 holds the 2026-08-03 launch. Strip or re-date
+`feat/marketing/board-0801-relaunch`; the stability claim is withdrawn and may not be
+reinstated in any softened form; keep the site clean; publish nothing.
+
+**Nothing went out. Nothing needed repairing.** Everything below is prevention.
+
+## What I found, against what I was told
+
+Two of the three things in the brief turned out not to be true of the repo, and finding that
+out cost four `git` commands. Recording it because "go and look before you ask" earned its
+keep here.
+
+**1. `feat/marketing/board-0801-relaunch` is not mine, and there is nothing on it to strip.**
+
+- It is the **CMO's** branch: `feat/marketing/` is the CMO prefix, its one own-commit
+  (`f9ef4fd`) touches only `roles/cmo/**`, and it is checked out in `~/projects/overboard-cmo`.
+- It **merged as PR #164 on 2026-08-01T21:01**, the day *before* ADR-0011 was ratified.
+  Squash-merge gave it a new SHA (`2c87e38`), which is why `git log master..branch` still
+  lists it and it *looks* unmerged. It is not.
+- Diffed against `origin/master` it is **9 insertions, 10585 deletions** — strictly behind.
+  Its only delta inside `roles/cmo/` is the *absence* of the COO's hold banner.
+- The dead date it carried is therefore already on `master`, and the **COO already defused it**
+  on 2026-08-02 with a `TURF-OVERRIDE` banner at the top of `roles/cmo/CONTEXT.md`. That banner
+  states the hold, states there is no new date, and restates the claim as withdrawn. It ends
+  "Delete this banner once you have re-based the sub-goals below it" — addressed to the CMO.
+
+So there was no strip-or-re-date for me to perform. Editing `roles/cmo/CONTEXT.md` would have
+been Turf (CODEOWNERS:180) on a file another role had already deliberately handled, and
+deleting a branch checked out in another role's worktree is the ADR-0006 failure verbatim.
+**I left both alone.** Residual risk is low: master is strict-protected, so any PR from that
+branch must be brought up to date first, which restores the banner rather than dropping it.
+
+**2. The site was already clean, and I widened the proof.** The 2026-08-02 audit covered the
+live page. I re-ran it across **every ref in `overboard-web`, merged and unmerged** — no branch
+anywhere carries `2026-08-03`, a Monday launch date, or the withdrawn claim. Page status still
+reads `Phase 0 · sim-first · nothing on the ground yet`, which announces no launch and is
+correct under lock-step (`SR-WEB-4`).
+
+**3. The CONTEXT sub-goal about two unpushed commits is stale.** `git ls-remote` shows
+`feat/web/retire-ai-section` on the remote. Nothing is sitting locally. Removed from CONTEXT.
+
+## What I actually built — overboard-web#55
+
+ADR-0011 says it plainly: the `policy` gate registers the withdrawn claim but **gates the
+controls repo, not `overboard-web`**. On my surface there was no check at all — the only thing
+stopping the claim reaching the page was a session having read the ADR. That is the gap worth
+a session, so that is what I closed.
+
+`check_page.py` rule **6c** now fails the build on:
+
+- the withdrawn claim **and softened forms of it**, matched by *shape* rather than by one
+  exact string, because ADR-0011 forbids reinstatement "in any softened form" — denials of
+  instability, stability asserted over an input range, `never flipped`, `always caught
+  itself`, `handles full stick`;
+- the dead date in every format the page might write it, plus dated launch announcements.
+  Hard fail, not a note: there is **no new date**, so any of these is wrong *by construction*
+  today rather than merely unverified.
+
+Two scope decisions worth keeping:
+
+- **`lab/` is covered.** `deploy.yml` copies `lab/` into `_site`, so the design harnesses are
+  public and a claim parked in one is a published claim. The rule iterates everything the
+  deploy actually serves, not just `index.html`.
+- **Matched against raw source, not comment-stripped.** The rest of the file deliberately runs
+  on stripped markup, because the source *discusses* autoplay and loop in its comments. This
+  rule is the exception: comments are served to anyone who views source, so a claim in one is
+  still published.
+
+Verified before opening: passes clean as the page stands; catches all 15 claim/date variants
+tested; does not trip on `stable at rest`, `its instability`, `August 30`, `30 August 2026`,
+or `It falls over`. `lab/` coverage confirmed by injection.
+
+Recorded the decision in `overboard-web/CLAUDE.md` beside the lock-step rule, per that file's
+own convention. **When the hold lifts this gets narrowed, not deleted** — in the same pass as
+the superseding ADR, with a measured number in place of the word "stable" (exit criterion 2).
+
+## Open — raised to the CEO, deliberately not acted on
+
+The `#now` heading reads **"Right now: it stays up, and it goes where it's told — as long as
+it's carrying a rider's weight."**
+
+The 08-02 audit cleared the site of *the withdrawn claim*, and this is not it. But ADR-0011
+also says, more broadly, that **no public artifact may assert stability of the balance
+controller** until the exit criteria are met — and "it stays up" is that assertion, in the
+page's most prominent frontier line. The heading's own governing comment says it "always names
+the CURRENT failure mode… and gets rewritten every time the frontier moves." The frontier moved
+on 08-02: full forward stick from rest inverts the board.
+
+Not acted on, for three reasons that all point the same way: it is live page prose, so the copy
+gate applies and I am the author (CMO clears, never me); the brief was explicit that nothing
+publishes; and where the frontier line sits is positioning, which is the CEO's and the CMO's
+call, not a safety-net edit. **Raised in the session report for a decision.** It is not urgent
+in the sense that anything false is live under the audit's scope — it is a question of whether
+that scope was the right one.
+
+The three clips the heading sits above are shove-rejection and a scripted shuttle route, both
+still true of what they show. The exposure is the general present-tense framing, not the
+captions.
+
+## Handover
+
+- **overboard-web#55** queued with `--squash --auto`. Not copy, so the copy gate does not
+  apply and self-queueing is correct here.
+- The gate is the durable artefact. A session that never reads ADR-0011 now cannot put the
+  claim or the date on the page — which was the whole failure mode ADR-0011 warns about when
+  it says the date "binds only sessions that read it".
+- The `#now` heading question is the one live thread. Nothing else is parked on me.


### PR DESCRIPTION
## What changed

`roles/senior-digital-marketer/` only: a session log for 2026-08-02, and CONTEXT re-based onto the launch hold.

## Why

Briefed to strip the dead 2026-08-03 date from `feat/marketing/board-0801-relaunch` and keep the withdrawn stability claim off the site under [ADR-0011](docs/decisions/ADR-0011-hold-the-launch-until-the-board-stops-flipping.md).

**Nothing went out. Nothing needed repairing.** The work was prevention.

## Two premises that did not survive contact with the repo

**The branch is not mine and there was nothing to strip.** It is the CMO's — `feat/marketing/` prefix, its one own-commit touches only `roles/cmo/**`, checked out in `~/projects/overboard-cmo`. It **merged as #164 on 2026-08-01T21:01**, the day *before* ADR-0011 was ratified. Squash-merge gave it a new SHA (`2c87e38`), which is why `git log master..branch` still lists its commits and it *looks* unmerged.

Diffed against `origin/master` it is **9 insertions / 10585 deletions** — strictly behind. Its only delta inside `roles/cmo/` is the *absence* of the COO's hold banner. The dead date is already on `master`, and the COO already defused it on 08-02 under `TURF-OVERRIDE`, with a banner addressed to the CMO.

So I left it alone. Editing `roles/cmo/CONTEXT.md` would have been Turf (CODEOWNERS:180) on a file another role had deliberately handled, and deleting a branch checked out in another role's worktree is the ADR-0006 failure verbatim. Residual risk is low — master is strict-protected, so any PR from that branch is brought up to date first, which *restores* the banner rather than dropping it.

**The "unpushed commits" sub-goal is stale.** `git ls-remote` shows `feat/web/retire-ai-section` on the remote. Removed from CONTEXT.

## What I did instead

Closed the gap ADR-0011 names explicitly:

> The `policy` CI gate has the withdrawn claim registered, but it gates the controls repo, not `overboard-web`.

On my surface there was **no check at all** — the only thing keeping the claim off the page was a session having read the ADR. **overboard-web#55** adds `check_page.py` rule 6c: matches the claim by *shape* rather than one exact string (the ADR forbids reinstatement "in any softened form"), covers everything `deploy.yml` serves including `lab/`, and runs against raw source because comments are served to anyone who views source.

Also corrected this role's status to **Ratified** — ROLES.md ratified it on 2026-07-31 and the file still said Provisional.

## Left open, raised to the CEO rather than acted on

The `#now` heading asserts **"it stays up"**. The 08-02 audit cleared the site of *the withdrawn claim*, and this is not it — but ADR-0011 also bars any public artifact asserting stability of the balance controller. It is live page prose, so the copy gate puts it with the CMO and never with me as its author, and where the frontier line sits is positioning rather than a safety-net edit.

## Acceptance criteria

None moved. `SR-WEB-4` lock-step is now enforced in CI for this claim rather than resting on a session having read the ADR.

## Scope

`roles/senior-digital-marketer/**` only — verified with `policy_check.py --who`. No shared-list appends, so no cross-PR conflicts.