### PR TITLE
ops(controls): teardown 2026-08-02 — Stage-0B image, profiler, flash path

### DIFF
--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -5,25 +5,32 @@
 - **Read first:** [`docs/decisions/INDEX.md`](../../docs/decisions/INDEX.md)
 
 ## Current sub-goals
-- **Was blocking the first public announcement, now partly cleared (PR TBD, issue #24 AC1):**
-  `RustController`'s `use_estimator` default flipped `False` → `True`, so the driverless
-  disturbance-rejection gate (`tests/test_closed_loop.py`), the ridden cascade gate, and
-  `scripts/render_scenario.py --compare` — the exact script that produces the artifact CI
-  publishes to `sim-latest` — now all run on the attitude **estimate**, not ground truth, by
-  default. hill.py/terrain.py/shuttle_run.py already did this; the driverless impulse gate,
-  which is what the published render and its `impulse_closed_loop_metrics.json` actually show,
-  did not. One pinned regression threshold moved with it and was re-measured rather than
-  loosened blindly: `test_there_is_large_margin_on_actuation_delay` was pinned at 6.80 deg
-  (truth pitch) and is now 9.71 deg (the honest number) — still clear of the 18.57 deg strike
-  angle, re-baselined to `< 10.5`.
-  **AC2 also now cleared (#67):** the disturbance-rejection envelope is mapped, not one fixed
-  magnitude. **AC3 also now cleared (see the decision-log entry below):** the `r_eff` tyre-ground
-  question — couldn't be justified, so fixed. **AC4 addressed in a separate open PR (#74, not
-  yet merged as of this entry):** determinism audited across all four scenarios. **Still open —
-  issue #24's one remaining AC:** an audit marking every acceptance number in the scenario docs
-  as measured vs. assumed. Its own well-scoped increment, not a blocker for any of the above.
-- Closed-loop control is in sim; the estimator now closes the loop on the driverless impulse gate
-  and the ridden cascade too, not only the shuttle.
+
+### Stage-0B Pi image (issue #182) — ACTIVE, this is the live thread
+Hardware (Pi 5 + Waveshare 2-CH CAN FD HAT, MCP2518FD) arrives 2026-08-03.
+
+**Landed on master:**
+- `crates/loop-profiler` / `overboard-loop-profile` (#181) — AC-5's instrument. Wake latency
+  + control-law compute as tail percentiles. Runs in CI on every PR (AC-12).
+  **Its first finding shapes everything:** control law p99.9 = **0.7 µs against a 2000 µs
+  budget**. Loop-rate viability is a *scheduler* question, not a compute one. Do not spend
+  time optimising the law.
+- `scripts/pi/` (#184) — the D3 spike, AC-1 pin verification, AC-2 kernel-contents
+  verification, `flash_pi.sh`, credential staging, the secret guard.
+
+**I0 ANSWERED GREEN.** `rpi-image-gen` builds in a privileged `debian:trixie` container on
+`ubuntu-24.04-arm`, native arm64, no QEMU. Design §3's primary choice stands;
+**derive-from-stock is retired as the active plan** (still documented as the regression path).
+
+**I1 in flight — PR #197, DOES NOT BUILD YET.** Four rounds. Next failure is *one line*:
+`chroot: failed to run command 'apt'` from the STOCK `image-rpios` layer's
+`customize05-pkgs`. Our base is slim and apt is not installed in the target.
+**Fix: add `apt` to `packages:` in `scripts/pi/image/layer/overboard-base.yaml`.**
+High confidence, untested.
+
+### Other controls threads
+- Issue #24's last AC (audit every scenario acceptance number as measured vs assumed) remains
+  open. Not blocking anything.
 
 ## Turf notes
 - Owns `crates/`, `tests/`, `scripts/`, most of `sim/` — but **not** `sim/models/`,
@@ -31,6 +38,13 @@
 - **Inside `sim/models/`:** `<sensor>` and `<actuator>` elements are yours and need no row.
   Mass, inertia, geometry, contact and friction are Mechanical's and do.
 - `.github/workflows/ci.yml` is yours. `.github/policy_check.py` and `CODEOWNERS` are the COO's.
+- **A NEW workflow file is COO turf, and so is any new top-level directory.**
+  `.github/workflows/pi-image.yml` needs `TURF-OVERRIDE:` in a commit message on every branch
+  that touches it — and **a rebase drops it**, because the gate reads commit messages, not the
+  PR body. #197 went red for exactly this after #184 merged. Re-assert it after any rebase.
+- **`pi/` at the top level falls to the CEO catch-all** (`policy_check.py --who pi` confirms).
+  Design §1 pre-provisioned `scripts/pi/` as the non-blocking fallback; the Pi work lives there
+  deliberately, not by accident. Do not "tidy" it into `pi/` without a CODEOWNERS row first.
 
 ## Decisions made (edit in place — completed work goes in log/, not here)
 
@@ -239,6 +253,31 @@
 _Older entries collapsed above this line as the log grows; nothing predates the crate-exclusion entry._
 
 ## Known dead ends
+
+- **Guessing rpi-image-gen's interface from convention (2026-08-02). Cost five CI rounds.**
+  `./build.sh` (does not exist) → `./bin/idp.sh` (exists, and is a *fastboot provisioner*, not
+  a builder — the worst kind of wrong answer) → a config *directory* where a `.yaml` file was
+  wanted → a missing `-S`. The entrypoint is `./rpi-image-gen`, extensionless, and
+  `-c` is relative to `-S`.
+  **What actually worked was reading the tool's own example layers over HTTP from GitHub**
+  (`raw.githubusercontent.com` / the contents API both work from this sandbox). Half an hour of
+  that turned I1 into a near-first-attempt job after I0 had burned five rounds.
+  **Rule for next time: fetch and read the upstream source before writing config against it.**
+
+- **Copying from the nearest example rather than the thing being replaced (2026-08-02).**
+  The recurring root cause of this whole workstream. `Provides: device,rpi-device` was copied
+  from the *slim example* (which requires `device-base`); the right reference was the stock
+  `rpi5` layer (which requires `rpi-device-base` and provides `rpi-device` alone). Cost a build.
+
+- **Prose inside a `# METABEGIN` block (2026-08-02).** It is machine-parsed DEB822, not a
+  comment block, despite every line starting with `#`. A malformed header does **not** fail
+  where the mistake is — it makes the layer *invisible* and the build fails elsewhere reporting
+  it "not found". `scripts/pi/check_layer_headers.py` now guards this in CI.
+
+- **A check reporting green over a red script — twice, two mechanisms (2026-08-02).**
+  First `continue-on-error: true`; then, after removing it, `docker … | tee` returning *tee's*
+  exit status because Actions runs steps under `bash -e`, **not** `-o pipefail`.
+  **Any step in this repo that pipes to `tee` has this bug.** Worth a sweep.
 
 - **Fetching vesc-project.com for the VESC 6 CAN Formats PDF (2026-07-28).**
   `WebFetch` returned HTTP 403 for every URL tried on that domain (the PDF

--- a/roles/senior-controls/log/2026-08-02-pi-image-stage0b.md
+++ b/roles/senior-controls/log/2026-08-02-pi-image-stage0b.md
@@ -1,0 +1,105 @@
+# 2026-08-02 — Stage-0B: the loop profiler, the flash path, and the image build
+
+Issue [#182](https://github.com/MikePaNtZ/overboard/issues/182). Triggered by the CEO asking
+three questions the day before the Pi arrives: is the image built, how do I flash it, and can I
+profile the loop.
+
+**The honest answer to the first was no.** The design ([#32](https://github.com/MikePaNtZ/overboard/issues/32),
+PR [#51](https://github.com/MikePaNtZ/overboard/pull/51)) was approved on 2026-07-27 and the
+implementation issue was *never opened*, so nothing existed: no `pi/`, no image workflow, no
+release, and the D3 spike unrun. That gap is the finding of the session; everything below is
+the response to it.
+
+## Landed
+
+| | |
+|---|---|
+| [#181](https://github.com/MikePaNtZ/overboard/pull/181) | `crates/loop-profiler` — AC-5's instrument |
+| [#184](https://github.com/MikePaNtZ/overboard/pull/184) | `scripts/pi/` — spike, AC-1/AC-2 verification, flash + credential path, secret guard |
+| [#197](https://github.com/MikePaNtZ/overboard/pull/197) | I1 — the real image tree. **Open, does not build yet.** |
+
+## The number that reframes Stage 0B
+
+`overboard-loop-profile` on first run: **control-law compute p99.9 = 0.7 µs against a 2000 µs
+period.** ~0.03% of budget.
+
+Loop-rate viability is therefore *entirely* a scheduler question. If the Pi cannot hold 2 ms it
+will not be because of our arithmetic, and time spent optimising the control law is time wasted.
+This should be stated before anyone starts tuning.
+
+The profiler also **withholds its verdict** rather than failing when the platform cannot support
+one (`ac5_verdict()` returns `None` off PREEMPT_RT, not `Some(false)`) — "could not measure" and
+"platform failed" are different findings and only one is about the Pi.
+
+## Findings worth carrying
+
+**1. Debian Trixie will not verify `archive.raspberrypi.com`.** Trixie's Sequoia `sqv` rejects
+SHA-1 from 2026-02-01; the Pi archive key carries a SHA-1 self-certification. This blocks *every*
+Trixie-hosted build against that archive — the exact shape design §3 chose.
+Handled in `scripts/pi/add_rpi_archive.sh` by relaxing the **hash policy only**; signature
+verification stays enforced. `[trusted=yes]` was explicitly rejected: it turns verification off
+entirely, and this is a kernel that will command a motor. Applied only when the default policy
+actually refuses, so it retires itself when the key is re-signed.
+
+**2. I0 is GREEN.** `rpi-image-gen` builds in a privileged `debian:trixie` container on
+`ubuntu-24.04-arm`, native arm64, no QEMU (`build exit: 0`, 277 MB `.img`). The "containers not
+formally supported" risk is answered in the affirmative. **Derive-from-stock is retired** as the
+active plan.
+
+**3. The stock `rpi5` device layer is unusable, and quietly so.** It requires `rpi-linux-2712` —
+the 16K-page flavour with **no RT build**. Using it would put a non-RT kernel on a card whose
+purpose is measuring real-time latency, and **the image would build green while being wrong**.
+`scripts/pi/image/device/overboard-pi5/device.yaml` is the stock layer with the kernel
+requirement swapped, and is the one place design §4's tradeoff becomes a file.
+
+**4. `kernel=kernel8.img` is the Q12 attempt, marked UNVERIFIED in `config.txt`.** Pi 5 firmware
+defaults to `kernel_2712.img`; the RT kernel ships as `kernel8.img`. If the board does not boot
+tomorrow, **that line is the first thing to change.**
+
+**5. The artefact format does not match the design.** `rpi-image-gen` deploys `.img.zst`; §2
+specifies `.img.xz` and `flash_pi.sh` expects `.img.xz`. One of the three must move. Publishing
+is deliberately **switched off** until it is settled — the build uploads a CI artefact instead.
+
+## Where I1 stopped
+
+Four build rounds, each failing further in:
+provider conflict → DEB822 header → `apt-mark` absent → **`apt` absent**.
+
+Current failure is one line, in the *stock* `image-rpios` layer's `customize05-pkgs`:
+
+```
+chroot: failed to run command 'apt': No such file or directory
+```
+
+Our base is slim and apt is not installed in the target.
+**Fix: add `apt` to `packages:` in `scripts/pi/image/layer/overboard-base.yaml`.**
+High confidence, untested — the next session should start here.
+
+## Not done, and needed
+
+- **I5 — the controller pipeline.** *No Overboard code ships in the image.* Not the controller,
+  not the profiler, not the repo. `flash_pi.sh` was printing `sudo overboard-loop-profile …` as
+  a next step, which would have sent someone debugging a working card; corrected to name the
+  manual clone-and-build path and point at I5. Until I5 exists, getting code onto the Pi is
+  `git clone` + `cargo build --release -p loop-profiler` on the board (~10 min, few deps).
+- **I7 — sim-in-the-loop self-test.** Needs the workspace plus MuJoCo on arm64. Note: do **not**
+  step MuJoCo inside the RT thread's deadline — physics on a non-isolated core, controller on
+  the isolated one. Mixing them makes a scheduler problem indistinguishable from a physics-step
+  problem, which is the ambiguity Stage 0B exists to avoid.
+
+## ⚠️ Untested safety catch — needs a human
+
+`flash_pi.sh` refuses non-removable disks. This session's sandbox **blocks `diskutil`**, so only
+the fail-closed path was exercised (unreadable device → refuse). The discrimination logic —
+correctly identifying a real internal disk and refusing it — has never run.
+**Run `--dry-run` against a real SD card before trusting it with a real one.**
+
+## Process notes
+
+- **Three PRs ran zero CI for hours.** GitHub schedules no `pull_request` runs when it cannot
+  compute a merge commit, so a `CONFLICTING` PR looks normal and simply has no checks. Bit us
+  three ways: a stale base branch, a squash-merge making a different commit than the branch
+  carried, and a stale async status. **Check `mergeStateStatus`, not just the checks list.**
+- **The primary working directory is not safe to assume.** Mid-session
+  `/Users/mike/projects/overboard` was switched to another role's branch with their uncommitted
+  work. This teardown was done from a throwaway worktree. ADR-0006 exists for this reason.


### PR DESCRIPTION
Session teardown per the protocol. Standing context + one log entry.

`CONTEXT.md` **edited in place, not appended** — the stale issue-#24 sub-goal block (mostly cleared, still referencing "PR TBD") is replaced by the live Stage-0B thread.

## The entries a successor most needs

**Turf, learned the hard way today:**
- A **new** workflow file is COO turf, and **a rebase drops the `TURF-OVERRIDE`** — the gate reads commit messages, not the PR body. #197 went red for exactly this after #184 merged.
- `pi/` at top level falls to the CEO catch-all. `scripts/pi/` is the design's pre-provisioned fallback — deliberate, not accidental. Don't "tidy" it without a CODEOWNERS row.

**Four dead ends, one root cause:** reaching for the nearest example instead of the thing being replaced, and guessing an interface instead of reading it. What worked was fetching `rpi-image-gen`'s own layers over HTTP and reading them — half an hour of that turned I1 into a near-first-attempt job after I0 had burned five rounds.

**One generic bug worth a sweep:** a check reported green over a red script twice, by two mechanisms. The second — `docker … | tee` returning *tee's* exit status, because Actions runs steps under `bash -e` and **not** `-o pipefail` — is not specific to that job. **Any step in this repo piping to `tee` has it.**

## The number that reframes Stage 0B

Control-law compute **p99.9 = 0.7 µs against a 2000 µs period** — ~0.03% of budget. Loop-rate viability is *entirely* a scheduler question. Worth stating before anyone starts tuning the control law: that time is wasted.

## State

- **Landed:** #181 (loop profiler), #184 (`scripts/pi/` — spike, AC-1/AC-2 verification, flash + credential path, secret guard).
- **I0 answered GREEN** — `rpi-image-gen` builds in our CI shape. Derive-from-stock retired as the active plan.
- **I1 open (#197), does not build yet.** Next failure is one line: `apt` is absent from the slim target, wanted by the stock `image-rpios` layer. Fix is to add `apt` to `packages:` in `overboard-base.yaml`. High confidence, untested.

## ⚠️ Needs a human before it is trusted

`flash_pi.sh`'s internal-disk refusal is **untested**. This session's sandbox blocks `diskutil`, so only the fail-closed path ran. Do one `--dry-run` against a real SD card before trusting it with a real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)