### PR TITLE
docs(sdm): the #now heading stays — CEO ruling, closing the session's one open thread

### DIFF
--- a/roles/senior-digital-marketer/CONTEXT.md
+++ b/roles/senior-digital-marketer/CONTEXT.md
@@ -26,11 +26,8 @@ Owns nothing in the `overboard` repo except `roles/senior-digital-marketer/**`; 
 ## Current sub-goals
 - The L1 announcement is drafted and deliberately held on two engineering conditions, plus the
   ADR-0011 hold. It does not go out on a date — it goes out on the exit criteria.
-- **Open question with the CEO:** the `#now` heading, "Right now: it stays up, and it goes where
-  it's told." ADR-0011 bars any public artifact asserting stability of the balance controller;
-  the 08-02 audit cleared the site of *the withdrawn claim*, which this is not. Whether the
-  frontier line needs re-basing is a positioning call, and the copy gate puts it with the CMO,
-  not me. Raised 2026-08-02, not acted on.
+- **The `#now` heading is settled — do not reopen it.** See "Decisions made" below. It moves when
+  the frontier moves, not because of the hold.
 
 ## Rules
 - Lead with the measured surprise, not the ambition. Tag every link so we can tell which
@@ -40,6 +37,14 @@ Owns nothing in the `overboard` repo except `roles/senior-digital-marketer/**`; 
 
 ## Decisions made (edit in place — completed work goes in log/, not here)
 
+- **2026-08-02 — the `#now` heading stays as written. CEO ruling, "audit is fine."** I raised
+  that "Right now: it stays up, and it goes where it's told" might fall under ADR-0011's broader
+  bar on asserting balance-controller stability, even though it is not the withdrawn claim and
+  the 08-02 audit cleared it. **The CEO ruled the audit's scope is correct.** The heading is not
+  a hold problem. It still moves under its own standing rule — it names the *current* failure
+  mode and gets rewritten when the frontier moves — so it will be re-based when the control fix
+  lands, as ordinary lock-step, not as claim remediation. Do not re-litigate this against the
+  hold; it was asked and answered.
 - **2026-08-02 — did not touch `feat/marketing/board-0801-relaunch`.** ADR-0011 assigned it to
   me, but it is the CMO's branch (`feat/marketing/`, `roles/cmo/**`, checked out in
   `~/projects/overboard-cmo`), it **merged as #164 on 08-01**, and the dead date it carried was

--- a/roles/senior-digital-marketer/log/2026-08-02-launch-hold-gated-on-my-surface.md
+++ b/roles/senior-digital-marketer/log/2026-08-02-launch-hold-gated-on-my-surface.md
@@ -76,7 +76,15 @@ Recorded the decision in `overboard-web/CLAUDE.md` beside the lock-step rule, pe
 own convention. **When the hold lifts this gets narrowed, not deleted** — in the same pass as
 the superseding ADR, with a measured number in place of the word "stable" (exit criterion 2).
 
-## Open — raised to the CEO, deliberately not acted on
+## Raised to the CEO — RESOLVED same session: the heading stays
+
+> **Ruling (CEO, 2026-08-02): "audit is fine."** The audit's scope was correct; the `#now`
+> heading is not a hold problem and no copy change is required. It still moves under its own
+> standing rule when the frontier moves — ordinary lock-step once the control fix lands, not
+> claim remediation. Closed, not parked. The original reasoning is kept below because the
+> distinction it turns on — the withdrawn claim vs. the ADR's broader stability sentence — is
+> the thing a future session will re-derive if it is not written down.
+
 
 The `#now` heading reads **"Right now: it stays up, and it goes where it's told — as long as
 it's carrying a rider's weight."**
@@ -91,9 +99,9 @@ on 08-02: full forward stick from rest inverts the board.
 Not acted on, for three reasons that all point the same way: it is live page prose, so the copy
 gate applies and I am the author (CMO clears, never me); the brief was explicit that nothing
 publishes; and where the frontier line sits is positioning, which is the CEO's and the CMO's
-call, not a safety-net edit. **Raised in the session report for a decision.** It is not urgent
-in the sense that anything false is live under the audit's scope — it is a question of whether
-that scope was the right one.
+call, not a safety-net edit. **Raised in the session report for a decision** rather than acted
+on. Nothing false was live under the audit's scope; the only question was whether that scope was
+the right one — and the ruling above says it was.
 
 The three clips the heading sits above are shove-rejection and a scripted shuttle route, both
 still true of what they show. The exposure is the general present-tense framing, not the
@@ -106,4 +114,8 @@ captions.
 - The gate is the durable artefact. A session that never reads ADR-0011 now cannot put the
   claim or the date on the page — which was the whole failure mode ADR-0011 warns about when
   it says the date "binds only sessions that read it".
-- The `#now` heading question is the one live thread. Nothing else is parked on me.
+- **Nothing is parked on me and nothing is parked on anyone else by me.** The `#now` heading was
+  the session's one open thread and the CEO closed it the same session — the audit's scope was
+  right, the heading stays, and it re-bases under ordinary lock-step when the control fix lands.
+- The next thing this desk owes is the L1 announcement, which goes out on ADR-0011's exit
+  criteria and not on a date.


### PR DESCRIPTION
## What changed

`roles/senior-digital-marketer/` only. No page copy, no site change.

## The ruling

I raised that the `#now` heading — *"Right now: it stays up, and it goes where it's told"* — might fall under ADR-0011's broader sentence barring any public artifact from asserting stability of the balance controller, even though it is **not** the withdrawn claim and the 2026-08-02 audit had cleared it.

**The CEO ruled the audit's scope is correct: "audit is fine."**

So the heading stays as written. It is not a hold problem. It still moves under its own standing rule — it names the *current* failure mode and gets rewritten every time the frontier moves — so it will be re-based when the control fix lands, as **ordinary lock-step, not claim remediation**.

## Why this is three edits and not one line

The failure mode this org keeps hitting is a successor re-deriving something already answered. So:

- **CONTEXT "Decisions made"** carries the ruling and says explicitly not to re-litigate it against the hold.
- **The sub-goal** that carried it as an open question is closed.
- **The log entry's** open section is marked `RESOLVED`, with the original reasoning kept — because the distinction it turns on (the withdrawn claim vs. ADR-0011's broader stability sentence) is precisely what would otherwise be worked out from scratch by the next session.

## State

Nothing is parked on me, and nothing is parked on anyone else by me. The hold is intact, the site is untouched, and `check_page.py` rule 6c (overboard-web#55, merged) still gates the withdrawn claim and the dead date on that surface.

## Acceptance criteria

None moved.