### PR TITLE
DO NOT MERGE -- spike: prove the ADR-0011 (f1) trim pin actually fires (#207)

### DIFF
--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -46,6 +46,8 @@ extern "C" {
     fn plant_mujoco_get_qpos(data: *mut c_void, out: *mut f64, n: c_int);
     fn plant_mujoco_get_qvel(data: *mut c_void, out: *mut f64, n: c_int);
     fn plant_mujoco_timestep(model: *mut c_void) -> f64;
+    fn plant_mujoco_get_gravity(model: *mut c_void, out: *mut f64);
+    fn plant_mujoco_set_gravity(model: *mut c_void, g: *const f64);
     fn plant_mujoco_forward(model: *mut c_void, data: *mut c_void);
     fn plant_mujoco_sensor_id(model: *mut c_void, name: *const c_char) -> c_int;
     fn plant_mujoco_sensor_adr(model: *mut c_void, sensor_id: c_int) -> c_int;
@@ -311,6 +313,43 @@ impl Plant {
     pub fn timestep(&self) -> f64 {
         // SAFETY: `self.model` is non-null and owned for the life of `self`.
         unsafe { plant_mujoco_timestep(self.model) }
+    }
+
+    /// `mjModel::opt.gravity`, m/s^2, world frame.
+    pub fn gravity(&self) -> [f64; 3] {
+        let mut out = [0.0f64; 3];
+        // SAFETY: `self.model` is non-null and owned for the life of `self`;
+        // `out` is exactly the 3 doubles the shim copies.
+        unsafe { plant_mujoco_get_gravity(self.model, out.as_mut_ptr()) };
+        out
+    }
+
+    /// Overwrites `mjModel::opt.gravity` -- **verification only**, and the
+    /// only supported way to put this plant on a slope.
+    ///
+    /// A ground plane inclined by `phi` under vertical gravity and a flat
+    /// ground plane under gravity tilted by `phi` are the same rigid-body
+    /// problem in two frames, so this measures a real incline rather than
+    /// approximating one. It is done here rather than by editing the model's
+    /// `<geom type="plane">` because ground geometry is the fidelity
+    /// contract's (`sim/models/` is Sr. Mechanical & Systems' turf) and
+    /// because a *model* edit would change every scenario, not one run.
+    ///
+    /// Must be called before the first [`Plant::step`]: `opt.gravity` is read
+    /// every step, so changing it mid-run is a step disturbance rather than an
+    /// incline, and the caller almost never means that.
+    ///
+    /// # Panics
+    /// If called after any [`Plant::step`].
+    pub fn set_gravity(&mut self, g: [f64; 3]) {
+        assert!(
+            self.time() == 0.0,
+            "Plant::set_gravity must be called before the first Plant::step (mjData::time is \
+             {:.6}, not 0) -- a mid-run change is a disturbance, not an incline",
+            self.time()
+        );
+        // SAFETY: see `gravity`; `g` is 3 doubles the shim only reads.
+        unsafe { plant_mujoco_set_gravity(self.model, g.as_ptr()) };
     }
 
     /// `mj_forward` -- issue #107 (I1c) AC8, carried forward from I1b. Every

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -99,6 +99,24 @@ double plant_mujoco_timestep(void* model) {
   return ((mjModel*)model)->opt.timestep;
 }
 
+// `mjModel::opt.gravity`, m/s^2, world frame.
+//
+// Read AND write, because ADR-0011's world-authoring constraint needs the
+// incline the board tolerates to be a MEASURED number, and a slope is exactly
+// a rotated gravity vector: a flat plane under gravity tilted by phi is the
+// same rigid-body problem as a plane inclined by phi under vertical gravity,
+// rotated. Tilting gravity rather than the ground geom keeps the measurement
+// out of `sim/models/` (Sr. Mechanical & Systems' fidelity contract) and
+// applies the along-slope component to EVERY body's own mass, which an
+// external force on one body cannot do.
+void plant_mujoco_get_gravity(void* model, double* out) {
+  memcpy(out, ((mjModel*)model)->opt.gravity, 3 * sizeof(double));
+}
+
+void plant_mujoco_set_gravity(void* model, const double* g) {
+  memcpy(((mjModel*)model)->opt.gravity, g, 3 * sizeof(double));
+}
+
 // The pre-loop priming call the CONTROLLED scenarios make (AC8 / issue #107's
 // carried-forward criterion): populates sensordata and qacc_warmstart for the
 // controller's first cycle, in the same position relative to the first

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -158,6 +158,12 @@ pub struct SimBackend {
     /// Overrides `model_path()`'s default when `Some` (issue #161 W2). See
     /// [`SimBackend::with_model_path`].
     model_path_override: Option<PathBuf>,
+    /// **Verification only.** Ground incline, degrees, applied at `open()` by
+    /// tilting gravity. See [`SimBackend::set_incline_deg`]. Zero leaves
+    /// `mjModel::opt.gravity` untouched -- not merely set back to its own
+    /// value, so a run with no incline is bit-identical to one built before
+    /// this knob existed.
+    incline_deg: f64,
 }
 
 impl SimBackend {
@@ -199,6 +205,34 @@ impl SimBackend {
     pub fn set_ballast_targets(&mut self, fore_aft_m: f32, lateral_m: f32) {
         self.ballast_fa_target_m = fore_aft_m;
         self.ballast_lateral_target_m = lateral_m;
+    }
+
+    /// **Verification only.** Puts the plant on a constant slope of
+    /// `incline_deg`, taking effect at the next `open()`.
+    ///
+    /// Positive is UPHILL in the board's forward direction (forward is `-X`,
+    /// so gravity acquires a `+X` component that opposes forward travel).
+    ///
+    /// Implemented by rotating `mjModel::opt.gravity` about `Y`, not by
+    /// tilting the ground geom: a flat plane under tilted gravity and a
+    /// tilted plane under vertical gravity are the same rigid-body problem
+    /// expressed in two frames, and only the gravity form applies the
+    /// along-slope component to every body's own mass. The magnitude is taken
+    /// from whatever the open model declares rather than from a constant here,
+    /// so this rotates the model's gravity instead of replacing it.
+    ///
+    /// ADR-0011's second ratification makes the authored world a condition of
+    /// the launch hold ("the authored world is constrained to what the
+    /// controller survives, and the constraint is encoded as a checkable asset
+    /// rule"). That rule needs a MEASURED incline tolerance, which needs this.
+    ///
+    /// Note what this changes about `truth` pitch: MuJoCo reports attitude
+    /// against model `Z`, which under this transform is the SLOPE NORMAL,
+    /// while the IMU still measures true gravity. On an incline the two
+    /// references genuinely differ by `incline_deg`, and that is physics, not
+    /// an estimator fault.
+    pub fn set_incline_deg(&mut self, incline_deg: f64) {
+        self.incline_deg = incline_deg;
     }
 
     /// The current the plant is seeing. Exposed for tests.
@@ -509,6 +543,16 @@ impl BoardObserve for SimBackend {
             plant.timestep(),
         );
         self.steps_per_cycle = CYCLE_NS / dt_ns;
+
+        // The incline, if any, goes on BEFORE `forward()`: that call primes
+        // `sensordata`, and the accelerometer's very first sample has to see
+        // the slope or the estimator starts from a vertical it never had.
+        if self.incline_deg != 0.0 {
+            let g = plant.gravity();
+            let mag = (g[0] * g[0] + g[1] * g[1] + g[2] * g[2]).sqrt();
+            let (s, c) = self.incline_deg.to_radians().sin_cos();
+            plant.set_gravity([mag * s, 0.0, -mag * c]);
+        }
 
         // AC8 (issue #107, carried forward from I1b/#106): the CONTROLLED
         // Python scenarios call mj_forward once, before their first

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -12,7 +12,7 @@
 //!          [--stats-path PATH|none]
 //!          [--free-run] [--max-sim-secs SECONDS]
 //!          [--pitch-source estimator|truth] [--pitch-bias-deg DEGREES]
-//!          [--cmd-reserve FRACTION]
+//!          [--cmd-reserve FRACTION] [--incline-deg DEGREES]
 //!          [--disturbance t0,dur,fx,fy,fz,tx,ty,tz] [--trace-csv PATH]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
@@ -183,6 +183,26 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
                 cfg.cmd_envelope_reserve = Some(scale);
+                i += 2;
+            }
+            // A constant ground slope, degrees, positive uphill. ADR-0011's
+            // second ratification needs the tolerated incline as a MEASURED
+            // number before the authored world can carry a checkable asset
+            // rule; see HostConfig::incline_deg.
+            "--incline-deg" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --incline-deg needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(deg) = v.parse::<f64>() else {
+                    eprintln!("sim-host: --incline-deg value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                if !(-45.0..=45.0).contains(&deg) {
+                    eprintln!("sim-host: --incline-deg must be within [-45, 45], got {deg}");
+                    return ExitCode::FAILURE;
+                }
+                cfg.incline_deg = deg;
                 i += 2;
             }
             // `t0,duration,fx,fy,fz,tx,ty,tz` -- world frame, SI. The kerb

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -176,7 +176,7 @@ const ESTIMATOR_TAU_S: f32 = 2.0;
 /// `shuttle_run.py`'s tuned controller relies on this same FFI fallback
 /// rather than passing its own gain, so this host does too, duplicated here
 /// because this host does not link `control-ffi`.
-const ACCEL_FF_GAIN_M_S2_PER_A: f32 = 0.0584;
+const ACCEL_FF_GAIN_M_S2_PER_A: f32 = 0.0650;
 
 /// `weight_shift_fore_aft` / `weight_shift_lateral`, both clamped to
 /// `[-1, 1]` on the wire, map linearly onto this range -- the SAME +/-0.05 m

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -294,11 +294,10 @@ const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
 ///
 /// Holding full forward stick from rest inverts this board in ~6.5 s
 /// (issue #190). The flip boundary was measured between 0.95 and 0.97 of
-/// full stick, and **tuning to that boundary is forbidden**: it rests
-/// partly on an accidental ~1 deg nose-down estimator bias that happens to
-/// act as nose-up trim, and partly on `wheel_hinge`'s undocumented
-/// `damping="0.08"`. A constant sitting on either is a constant that moves
-/// when somebody fixes a bug.
+/// full stick, and **tuning to that boundary is forbidden**: it rests partly
+/// on the estimator's operating trim and partly on `wheel_hinge`'s
+/// undocumented `damping="0.08"`. A constant sitting on either is a constant
+/// that moves when somebody changes something unrelated.
 ///
 /// The derivation instead runs off the actuator envelope, per the
 /// command-map rule ADR-0011 propagates to the hardware spec -- *the
@@ -317,6 +316,28 @@ const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
 ///    **0.80**. Pinned as executable arithmetic by
 ///    `the_command_envelope_reserve_is_the_stated_reserve_divided_by_the_
 ///    measured_slope`, not merely written down here.
+///
+/// # TRIM-DERIVED, not geometry-derived -- read this before porting it
+///
+/// The step above says "measured", and the word is load-bearing in a way the
+/// phrase *derived from the actuator envelope* can easily be read past.
+/// [`PEAK_DEMAND_A_PER_UNIT_STICK`] was measured **at the estimator's current
+/// operating trim**, and it is a property of that trim, not of the vehicle.
+/// Measured in `test_f2_the_peak_demand_slope_is_trim_derived_not_geometry_
+/// derived`: shifting the trim by 0.10 deg moves the slope by ~5.2%, which
+/// is already outside the 5% band its own provenance check allows.
+///
+/// So this constant is honest for the frozen trim and for nothing else. It
+/// does not travel to hardware, to a retuned filter, or to a different
+/// operating point on its own authority. Describing it as geometry-derived --
+/// as something the actuator envelope alone fixes -- would be a
+/// rationalisation, and ADR-0011's second ratification says so in those
+/// words. The trim it rests on is pinned by
+/// `test_f1_the_estimator_trim_is_pinned_so_a_retune_cannot_move_it_silently`
+/// precisely so this constant cannot go stale quietly; ADR-0011 names any
+/// retune that moves that band as a blocking prerequisite for the
+/// headroom-based fix, which is the version of this that would NOT be
+/// trim-derived.
 ///
 /// # What it buys, measured
 ///
@@ -348,9 +369,11 @@ const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
 ///
 /// - **Criterion (f) -- fed MuJoCo truth -- fails at every value.** Sweeping
 ///   this constant from 1.00 down to 0.05 moves time-to-inversion from 4.42 s
-///   to 28.67 s and never removes it; only exactly zero stick survives. With
-///   the estimator bias removed a sustained forward lean has no equilibrium,
-///   so the reserve buys TIME, not survival.
+///   to 28.67 s and never removes it; only exactly zero stick survives.
+///   Feeding the regulator truth deletes the acceleration reference the lean
+///   is generated from, so a sustained forward lean has no equilibrium and
+///   the reserve buys TIME, not survival. ADR-0011's second ratification
+///   replaces this criterion with freeze-and-pin for exactly that reason.
 /// - **Criterion (a)'s kerb-strike entry fails** above roughly a 1 mm lip
 ///   struck at the worst point of a full-stick hold.
 ///
@@ -758,18 +781,23 @@ pub struct HostConfig {
     /// This is the robustness test ADR-0011 criterion (f) was reaching for.
     /// The ADR asks for acceptance "with the estimator bias removed" and
     /// implements that as "feed the regulator MuJoCo truth" -- but the
-    /// measured `est - truth` residual is not a static bias at all: it
-    /// regresses on unaided specific force at 5.7-6.1 deg per m/s^2, which is
-    /// 1 radian per g, i.e. it is the complementary filter reading the
-    /// APPARENT VERTICAL. Replacing it with truth therefore does not remove
-    /// an error, it deletes an acceleration reference and leaves a
-    /// pitch-only regulator (see `PitchSource::PlantTruth`).
+    /// measured `est - truth` residual is not a static bias at all: settled,
+    /// it is `atan(a_unaided / g)` to within 3%, i.e. 1 radian per g, i.e.
+    /// the complementary filter reading the APPARENT VERTICAL. Replacing it
+    /// with truth therefore does not remove an error, it deletes an
+    /// acceleration reference and leaves a pitch-only regulator (see
+    /// `PitchSource::PlantTruth`).
     ///
     /// Injecting a worst-case STATIC bias on top of the real signal path is
     /// the test that actually asks "does this margin survive an estimator
     /// that is wrong?" without silently changing which controller is under
     /// test. Both are run and both are reported;
     /// `tests/test_cmd_envelope_reserve.py` has the results.
+    ///
+    /// Second use, ADR-0011 (f2): a small offset here MOVES THE OPERATING
+    /// TRIM while changing nothing else, which is how the peak-demand slope
+    /// behind [`CMD_ENVELOPE_RESERVE`] is shown to be trim-derived rather
+    /// than geometric.
     pub pitch_bias_deg: f32,
 
     /// **Verification only.** Runs the loop as fast as the CPU allows,
@@ -802,6 +830,23 @@ pub struct HostConfig {
     /// behaviour.
     pub disturbance: Option<Disturbance>,
 
+    /// **Verification only.** Ground incline, DEGREES, positive uphill in the
+    /// board's forward direction. Zero is flat and leaves the plant's gravity
+    /// untouched.
+    ///
+    /// ADR-0011's second ratification makes the authored world one of the
+    /// three conditions the launch hold exits on: *the authored world is
+    /// constrained to what the controller survives, and the constraint is
+    /// encoded as a checkable asset rule.* An asset rule needs a number, the
+    /// number is an incline, and this is how it gets measured
+    /// (`tests/test_incline_tolerance.py`). It is deliberately a MEASUREMENT
+    /// knob and not a scenario parameter: no shipped configuration sets it.
+    ///
+    /// Applied by [`sim_backend::SimBackend::set_incline_deg`], which rotates
+    /// `mjModel::opt.gravity` rather than the ground geom -- see there for why
+    /// that is the same problem and not an approximation of it.
+    pub incline_deg: f64,
+
     /// **Verification only.** Writes one CSV row per control cycle to this
     /// path when the run ends. Buffered in memory and written once, never
     /// during the loop: a 500 Hz control thread does not do file I/O per
@@ -812,13 +857,24 @@ pub struct HostConfig {
 /// Where the regulator's attitude comes from -- ADR-0011 exit criterion (f).
 ///
 /// The default is the only one a deployed host may use. `PlantTruth` exists
-/// because the ADR requires every acceptance pass to hold **with the
-/// estimator bias removed**, and on this plant that is the measured-WORSE
-/// case, not the better one: the complementary filter's ~1 deg nose-down
-/// error acts as nose-up trim, so feeding the controller MuJoCo truth makes
-/// the board flip EARLIER. That is accidental model error, not a designed
-/// safety property, and criterion (f) exists precisely so no acceptance
-/// number is allowed to rest on it.
+/// because the ADR's FIRST ratification required every acceptance pass to
+/// hold **with the estimator bias removed**, and on this plant that is the
+/// measured-WORSE case, not the better one: feeding the controller MuJoCo
+/// truth makes the board flip EARLIER.
+///
+/// **The reason is not an accidental bias, and the ADR's second ratification
+/// corrects that reading.** The `est - truth` residual is the apparent
+/// vertical, `atan(a/g)` -- 1 radian per g, which is the same 5.84 deg per
+/// m/s^2 the ADR derives geometrically as the lean this board must hold to
+/// sustain acceleration `a`, because it is the same physics. The estimator is
+/// supplying the textbook balance-vehicle lean. Substituting truth therefore
+/// does not de-bias the loop, it deletes the only mechanism generating that
+/// lean and leaves a pitch-only regulator -- a different controller, not a
+/// cleaner one. What criterion (f) was right about is that nothing designed
+/// this and nothing held it in place; (f1)/(f2) fix that by pinning it
+/// (`tests/test_cmd_envelope_reserve.py`), and (f3) makes it explicit as a
+/// `theta_ref = atan(a_des / g)` feedforward, at which point this instrument
+/// becomes meaningful again.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PitchSource {
     /// The `ComplementaryFilter`, fed raw IMU through `hal` -- the real
@@ -869,6 +925,7 @@ impl Default for HostConfig {
             free_run: false,
             cmd_envelope_reserve: None,
             disturbance: None,
+            incline_deg: 0.0,
             trace_path: None,
         }
     }
@@ -1082,6 +1139,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     };
 
     let mut backend = SimBackend::with_model_path(params, rider_model_path());
+    // Before `open()`, which is where the tilt is applied -- see
+    // `HostConfig::incline_deg`.
+    backend.set_incline_deg(cfg.incline_deg);
     backend.open().map_err(HostError::Backend)?;
     // Armed unconditionally at startup, the same way every other Rust-hosted
     // harness in this repo arms (`impulse-response-rust`, `sim-backend`'s own
@@ -1495,8 +1555,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // On a deployed run this is the `Estimator` arm and the regulator
         // sees exactly what it always saw. On an acceptance run it is
         // `PlantTruth`, and the regulator sees MuJoCo -- which on this plant
-        // is the measured-WORSE case, because the filter's ~1 deg nose-down
-        // error acts as nose-up trim. See `PitchSource`.
+        // is the measured-WORSE case, because it deletes the apparent-vertical
+        // lean the estimate carries rather than de-biasing it. See
+        // `PitchSource`.
         let (source_pitch_rad, regulated_pitch_rate_rad_s) = match cfg.pitch_source {
             PitchSource::Estimator => (attitude.pitch_rad, attitude.pitch_rate_rad_s),
             PitchSource::PlantTruth => (pitch_rad, truth_pitch_rate_rad_s),

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -113,11 +113,6 @@ DISTURBANCE_WINDOW_S = 0.002
 #: physics rather than about `overboard_rider.xml`.
 G_M_S2 = 9.80665
 
-#: `ACCEL_FF_GAIN_M_S2_PER_A`, `host.rs`. The command feedforward already
-#: removes this much specific force per amp before the filter sees it, so the
-#: specific force the filter is left reading is `a_x - this * I`.
-ACCEL_FF_GAIN_M_S2_PER_A = 0.0584
-
 #: The window, in seconds of simulated time, over which the estimator trim is
 #: measured -- see `_settled_trim`. Late in the run on purpose, and stated as
 #: a constant so it is a fixed instrument rather than a fitting parameter.
@@ -245,6 +240,11 @@ def _settled_trim(rows, window=TRIM_WINDOW_S):
     """
     t_lo, t_hi = window
     half = DIFF_HALF_CYCLES
+    # Read from `host.rs`, not copied: the command feedforward already removes
+    # this much specific force per amp before the filter sees it, so a stale
+    # copy here would mis-state what the filter was left reading and the trim
+    # pin below would fire for the wrong reason -- or, worse, fail to.
+    accel_ff_gain = _rust_constant("ACCEL_FF_GAIN_M_S2_PER_A")
     residual, apparent = [], []
     for i in range(half, len(rows) - half):
         if not t_lo <= rows[i]["sim_time_s"] <= t_hi:
@@ -252,7 +252,7 @@ def _settled_trim(rows, window=TRIM_WINDOW_S):
         a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
             rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
         )
-        unaided = a_x - ACCEL_FF_GAIN_M_S2_PER_A * rows[i]["applied_amps"]
+        unaided = a_x - accel_ff_gain * rows[i]["applied_amps"]
         residual.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
         apparent.append(math.degrees(math.atan(unaided / G_M_S2)))
     assert residual, f"no rows in the trim window {window}"

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -108,6 +108,38 @@ KERB_MOMENT_ARM_M = 0.77885 - 0.1454
 #: 1), so an impulse delivered over this window is exact.
 DISTURBANCE_WINDOW_S = 0.002
 
+#: Standard gravity, m/s^2. CODATA, not the model's own `9.81` -- this is the
+#: constant in the `1 radian per g` identity, which is a statement about
+#: physics rather than about `overboard_rider.xml`.
+G_M_S2 = 9.80665
+
+#: `ACCEL_FF_GAIN_M_S2_PER_A`, `host.rs`. The command feedforward already
+#: removes this much specific force per amp before the filter sees it, so the
+#: specific force the filter is left reading is `a_x - this * I`.
+ACCEL_FF_GAIN_M_S2_PER_A = 0.0584
+
+#: The window, in seconds of simulated time, over which the estimator trim is
+#: measured -- see `_settled_trim`. Late in the run on purpose, and stated as
+#: a constant so it is a fixed instrument rather than a fitting parameter.
+TRIM_WINDOW_S = (12.0, 18.0)
+
+#: Half-width of the central difference used to recover forward acceleration
+#: from the speed trace, in control cycles. 50 cycles is +-0.1 s.
+DIFF_HALF_CYCLES = 50
+
+#: ADR-0011 (f1). The estimator trim as it stands today, degrees of `est -
+#: truth` over `TRIM_WINDOW_S` of the shipped full-stick hold. A MEASURED
+#: value being frozen, not a target: see
+#: `test_f1_the_estimator_trim_is_pinned_so_a_retune_cannot_move_it_silently`
+#: for why this is a drift detector and may never be cited as a tolerance.
+PINNED_TRIM_DEG = -2.501
+
+#: How far `PINNED_TRIM_DEG` may move before the build goes red. Set from the
+#: trim movement that puts `CMD_ENVELOPE_RESERVE`'s own derivation out of
+#: tolerance (measured: 0.10 deg of trim moves the peak-demand slope 5.2%,
+#: against a 5% band) -- NOT from what happens to pass. See the same test.
+PINNED_TRIM_BAND_DEG = 0.10
+
 
 # ---------------------------------------------------------------------------
 # Harness
@@ -187,6 +219,46 @@ def _peak_pitch_deg(rows):
     return max(abs(r["truth_pitch_deg"]) for r in _healthy(rows))
 
 
+def _settled_trim(rows, window=TRIM_WINDOW_S):
+    """The estimator trim, measured where the identity is actually testable.
+
+    Returns `(residual_deg, apparent_vertical_deg)`, both means over `window`:
+
+    * `residual_deg` -- mean `est - truth` pitch. This IS the trim: the lean
+      the estimator believes in that the plant does not have.
+    * `apparent_vertical_deg` -- mean `atan(a_unaided / g)`, the tilt an
+      accelerometer reports on a body under that specific force, where
+      `a_unaided = a_x - ACCEL_FF_GAIN * I` is the part the command
+      feedforward did not already remove.
+
+    **Why a settled window and not a regression over the whole run.** The
+    obvious instrument -- least squares of residual against specific force
+    across the acceleration ramp -- is badly conditioned here, and measuring
+    it says so: the fitted slope moves from 4.9 to 7.1 deg per m/s^2 across
+    reasonable choices of fit window on the SAME run, because the
+    complementary filter's 2 s time constant means the residual lags the
+    specific force throughout the ramp and the fit picks up whichever part of
+    that transient the window happens to contain. A band tight enough to be a
+    pin would chatter on the window choice; a band loose enough not to would
+    detect nothing. The identity is a STEADY-STATE statement, so it is
+    measured in steady state, where the ratio holds to a few percent.
+    """
+    t_lo, t_hi = window
+    half = DIFF_HALF_CYCLES
+    residual, apparent = [], []
+    for i in range(half, len(rows) - half):
+        if not t_lo <= rows[i]["sim_time_s"] <= t_hi:
+            continue
+        a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
+            rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
+        )
+        unaided = a_x - ACCEL_FF_GAIN_M_S2_PER_A * rows[i]["applied_amps"]
+        residual.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
+        apparent.append(math.degrees(math.atan(unaided / G_M_S2)))
+    assert residual, f"no rows in the trim window {window}"
+    return sum(residual) / len(residual), sum(apparent) / len(apparent)
+
+
 def _margin(rows) -> str:
     """The measured margin, in BOTH currencies ADR-0011 criterion (b) demands.
 
@@ -251,6 +323,78 @@ def test_peak_current_demand_is_linear_in_stick_at_the_documented_slope(tmp_path
         "the premise of the whole change is that full stick over-commands the "
         f"envelope; measured {slope:.2f} A/unit against {MAX_CURRENT_A} A"
     )
+
+
+def _peak_demand_slope(tmp_path, tag, **kw) -> float:
+    """Least squares through the origin of peak demand against stick."""
+    fractions = (0.30, 0.50, 0.70, 0.90)
+    peaks = [
+        _peak_demand_a(_run(tmp_path, f"{tag}{u}", "full-stick", cmd_reserve=u,
+                            pitch_source="estimator", **kw))
+        for u in fractions
+    ]
+    return sum(u * a for u, a in zip(fractions, peaks)) / sum(u * u for u in fractions)
+
+
+def test_f2_the_peak_demand_slope_is_trim_derived_not_geometry_derived(tmp_path):
+    """ADR-0011 (f2): pin the reserve's DERIVATION, not just its value.
+
+    `CMD_ENVELOPE_RESERVE` = 0.80 is
+    `STATED_ENVELOPE_RESERVE_FRACTION * MAX_CURRENT_A / PEAK_DEMAND_A_PER_UNIT_STICK`,
+    and `host.rs` enforces that arithmetic at compile time. What no compiler
+    can enforce is the status of the divisor: **41.97 A per unit stick was
+    measured at the current operating trim.** Describing the constant as
+    derived from the actuator envelope, and stopping there, reads as though it
+    were a geometric property that travels with the vehicle. It is not, and
+    calling it one would be a rationalisation.
+
+    This test makes the dependence a measurement rather than a caveat: shift
+    the trim by one `PINNED_TRIM_BAND_DEG` and re-take the slope.
+
+    The result is why (f1) and (f2) are one pin and not two. A 0.10 deg trim
+    shift moves the slope by about 5.2%, and
+    `test_peak_current_demand_is_linear_in_stick_at_the_documented_slope`
+    grants the slope a 5% band -- so **one pinned band of trim drift is
+    already enough to put the reserve's own provenance check out of
+    tolerance.** That is the calibration behind `PINNED_TRIM_BAND_DEG`: it is
+    the trim movement at which `CMD_ENVELOPE_RESERVE` stops being derived from
+    anything true, which is a stronger reason for its width than any statement
+    about what the board survives.
+
+    The bar asserted is deliberately loose. A geometry-derived constant would
+    move by exactly 0%; 3% is low enough to be robust to platform
+    floating-point differences and far too high to be reached by rounding, so
+    clearing it refutes "geometry-derived" without pinning a derivative.
+
+    The trim is shifted with `--pitch-bias-deg` rather than by retuning the
+    filter, because the question is what a MOVED TRIM does to the slope, and
+    an injected offset moves the trim while changing nothing else -- a
+    retuned `ESTIMATOR_TAU_S` would move several things at once and the result
+    could not be attributed.
+    """
+    base = _peak_demand_slope(tmp_path, "f2base")
+    moved = {
+        sign * PINNED_TRIM_BAND_DEG: _peak_demand_slope(
+            tmp_path, f"f2{sign}", pitch_bias_deg=sign * PINNED_TRIM_BAND_DEG
+        )
+        for sign in (-1, 1)
+    }
+    print(f"\n(f2) peak-demand slope at the shipped trim: {base:.3f} A/unit")
+    for shift, slope in sorted(moved.items()):
+        print(
+            f"     trim shifted {shift:+.2f} deg: {slope:.3f} A/unit "
+            f"({100 * (slope - base) / base:+.2f}%)"
+        )
+
+    for shift, slope in moved.items():
+        moved_pct = 100 * abs(slope - base) / base
+        assert moved_pct > 3.0, (
+            f"shifting the trim {shift:+.2f} deg moved the peak-demand slope "
+            f"only {moved_pct:.2f}%. If the slope has genuinely stopped "
+            "depending on the trim then CMD_ENVELOPE_RESERVE is better founded "
+            "than ADR-0011 claims and the ADR should be amended to say so -- "
+            "but do not reach that conclusion by loosening this test."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -391,51 +535,128 @@ def test_the_truth_pitch_rate_is_the_derivative_of_the_truth_pitch(tmp_path):
 
 
 def test_the_estimator_residual_is_specific_force_not_a_static_bias(tmp_path):
-    """WHY CRITERION (f) IS MIS-SPECIFIED, as a measurement.
+    """WHY CRITERION (f) WAS MIS-SPECIFIED, as a measurement.
 
-    ADR-0011 describes the `est - truth` gap as a "~1 deg nose-down estimator
-    bias" and implements "remove the bias" as "feed the regulator truth". It
-    is not a bias. Regressed against the specific force the command feedforward
-    failed to remove (`a_x - ACCEL_FF_GAIN * I`), it comes out at ~5.8 deg per
-    m/s^2 -- and 1 radian per g is 57.2958/9.81 = 5.84 deg per m/s^2. That is
-    a complementary filter reporting the APPARENT VERTICAL, which is what an
-    accelerometer measures on a vehicle that accelerates.
+    ADR-0011's first ratification described the `est - truth` gap as a "~1 deg
+    nose-down estimator bias" and implemented "remove the bias" as "feed the
+    regulator truth". It is not a bias, and one identity settles it:
+
+        1 radian per g = 57.2958 / 9.80665 = 5.8425 deg per m/s^2
+
+    and ADR-0011's own geometric lean sensitivity -- how far this board must
+    lean to sustain acceleration `a` -- is 5.84 deg per m/s^2. **Those are the
+    same number because they are the same physics.** The lean an inverted
+    pendulum needs to sustain `a` is `atan(a/g)`, and `atan(a/g)` is exactly
+    the tilt of the apparent vertical a complementary filter reads off an
+    accelerometer. The estimator is not carrying an error that flatters the
+    controller; it is implementing the textbook balance-vehicle lean.
+
+    Asserted here as the identity itself rather than as a fitted slope: the
+    settled residual over `TRIM_WINDOW_S` against `atan(a_unaided/g)` over the
+    same window, whose ratio is 1 if and only if the estimate is the apparent
+    vertical. `_settled_trim` records why the fitted-slope form was the wrong
+    instrument.
 
     The consequence is structural, not cosmetic: the estimate carries an
     acceleration reference, so replacing it with truth does not correct an
-    error, it removes a feedback path and leaves a pitch-only regulator. That
+    error, it deletes a feedback path and leaves a pitch-only regulator. That
     is why the criterion (f) result below is a continuum in time-to-inversion
     rather than a threshold in stick.
     """
-    rows = _run(tmp_path, "resid", "full-stick", cmd_reserve=0.6, pitch_source="estimator")
-    accel_ff_gain = 0.0584  # ACCEL_FF_GAIN_M_S2_PER_A, host.rs
-    half = 50  # +-0.1 s central difference, to see through per-cycle noise
-    xs, ys = [], []
-    for i in range(half, len(rows) - half):
-        if not 1.0 <= rows[i]["sim_time_s"] <= 15.0:
-            continue
-        a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
-            rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
-        )
-        xs.append(a_x - accel_ff_gain * rows[i]["applied_amps"])
-        ys.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
-    n = len(xs)
-    sx, sy = sum(xs), sum(ys)
-    slope = (n * sum(x * y for x, y in zip(xs, ys)) - sx * sy) / (n * sum(x * x for x in xs) - sx * sx)
-    intercept = (sy - slope * sx) / n
-    one_rad_per_g = math.degrees(1.0) / 9.81
+    rows = _run(tmp_path, "resid", "full-stick", pitch_source="estimator")
+    residual, apparent = _settled_trim(rows)
+    ratio = residual / apparent
+    static_part = residual - apparent
     print(
-        f"\nest-truth residual vs unaided specific force: {slope:.2f} deg per m/s^2 "
-        f"(1 rad/g = {one_rad_per_g:.2f}), intercept {intercept:+.3f} deg"
+        f"\nsettled trim over t in {TRIM_WINDOW_S} s:"
+        f"\n    est-truth residual        {residual:+.4f} deg"
+        f"\n    apparent vertical         {apparent:+.4f} deg  (= atan(a_unaided/g))"
+        f"\n    ratio                     {ratio:.4f}   (1 rad/g holds iff this is 1)"
+        f"\n    unexplained static part   {static_part:+.4f} deg "
+        f"({100 * abs(static_part / apparent):.1f}% of the apparent-vertical term)"
     )
-    assert abs(abs(slope) - one_rad_per_g) / one_rad_per_g < 0.25, (
-        "the est-truth residual no longer looks like an apparent-vertical "
-        "reading. If that is real, ADR-0011 criterion (f)'s framing needs "
-        "revisiting again, in the other direction."
+
+    assert abs(ratio - 1.0) < 0.10, (
+        f"the est-truth residual is no longer the apparent vertical (ratio "
+        f"{ratio:.3f}). ADR-0011's second ratification rests on that identity; "
+        "if this has genuinely changed, the ADR needs revisiting again rather "
+        "than this band being widened."
     )
-    assert abs(intercept) < 0.5, (
-        "a large intercept would mean there IS a static bias component after "
-        "all, which would make the ADR's framing partly right"
+    # A RELATIVE bound, because the claim under test is relative: the residual
+    # is specific force RATHER THAN a static bias. 10% of the apparent-vertical
+    # term is the largest static component that still leaves that sentence
+    # true. Not derived from the measured value, which is 2.8%.
+    assert abs(static_part) < 0.10 * abs(apparent), (
+        f"a static component of {static_part:+.3f} deg against an "
+        f"apparent-vertical term of {apparent:+.3f} deg would mean there IS a "
+        "meaningful static bias after all, making the ADR's original framing "
+        "partly right"
+    )
+
+
+def test_f1_the_estimator_trim_is_pinned_so_a_retune_cannot_move_it_silently(tmp_path):
+    """ADR-0011 (f1), and the reason the second ratification exists.
+
+    The board survives full stick because the estimator supplies the lean the
+    acceleration physically requires. That is correct behaviour, but nothing
+    designed it and until this test nothing held it in place: any change to
+    `ESTIMATOR_TAU_S`, `ACCEL_FF_GAIN_M_S2_PER_A`, the IMU wiring or the
+    regulator gains could move the trim, and the first symptom would be the
+    board flipping again. (f1) exists to make that a RED BUILD instead.
+
+    # What the band is, and what it is emphatically not
+
+    `PINNED_TRIM_BAND_DEG` is a **drift detector**, not a tolerance. It does
+    not assert that a trim anywhere inside it is safe, and no acceptance
+    number anywhere in this repo may be justified by it.
+
+    Its width comes from what a moved trim BREAKS, which is measured in
+    `test_f2_the_peak_demand_slope_is_trim_derived_not_geometry_derived`:
+    shifting the trim by 0.10 deg moves the peak-demand slope by about 5.2%,
+    and that slope is the divisor `CMD_ENVELOPE_RESERVE` is derived from, held
+    to a 5% band by
+    `test_peak_current_demand_is_linear_in_stick_at_the_documented_slope`. So
+    0.10 deg is the trim movement at which the shipped reserve stops being
+    derived from anything true. The pin fires exactly where the derivation
+    goes stale, which is the only place it has a principled reason to fire.
+
+    It is worth stating what this band is NOT derived from. The measured
+    static-error characterisation -- 0.25 deg survived, 0.5 deg inverted the
+    board -- is **not a threshold**, and ADR-0011 is explicit that promoting
+    0.25 deg to a bar would be deriving acceptance from whatever happened to
+    pass, the precise move criterion (f) exists to forbid. Those numbers are
+    used here only as a sanity check in the safe direction: the band that the
+    derivation argument produced happens to sit well inside them, so the pin
+    also cannot fail to fire before a trim reaches a value whose consequences
+    are unknown. Had the derivation argument produced a wider band, the answer
+    would have been to look harder, not to quietly borrow 0.25 deg.
+
+    There is no lower bound worth arguing about. Every run here is
+    bit-deterministic (`--free-run`, fixed-timestep RK4, schedule indexed on
+    simulated time), so a band this size cannot chatter; it can only be moved
+    by somebody actually changing the controller.
+
+    # If this test fails
+
+    Do not widen the band, and do not adjust the pinned value to match. The
+    trim moved, which means `CMD_ENVELOPE_RESERVE`'s provenance moved with it
+    (see `test_f2_...`) and ADR-0011's named blocking prerequisite -- the
+    headroom-based fix -- has come due. Re-derive; do not re-baseline.
+    """
+    rows = _run(tmp_path, "f1trim", "full-stick", pitch_source="estimator")
+    residual, apparent = _settled_trim(rows)
+    print(
+        f"\n(f1) pinned trim: {residual:+.4f} deg measured, "
+        f"{PINNED_TRIM_DEG:+.3f} {chr(177)} {PINNED_TRIM_BAND_DEG:.2f} deg pinned"
+    )
+    assert abs(residual - PINNED_TRIM_DEG) < PINNED_TRIM_BAND_DEG, (
+        f"the estimator trim has moved to {residual:+.4f} deg from the pinned "
+        f"{PINNED_TRIM_DEG:+.3f} deg. ADR-0011's exit rests on the trim being "
+        "frozen: the 0.80 command-envelope reserve was derived at THIS "
+        "operating trim and is honest only for it, and the ADR names any "
+        "retune that moves this band as a blocking prerequisite for the "
+        "headroom-based fix. Re-derive the reserve from a re-measured slope; "
+        "do not re-baseline this number to make the build green."
     )
 
 


### PR DESCRIPTION
**Do not merge. Close once CI reports.**

ADR-0011 (f1)'s acceptance criterion for issue #207 is explicit that reading
the test is not evidence it works:

> A retune that shifts the estimator trim outside the pinned band **fails
> CI**. Demonstrate it by moving the trim on purpose and watching it go red.

This is that demonstration. On top of `feat/controls/pin-trim-and-reserve`
(which adds the pin), one constant is moved:

`ACCEL_FF_GAIN_M_S2_PER_A` **0.0584 -> 0.0650**

That is a realistic retune rather than a contrived one -- the constant is
`kt / (r_eff * total ridden mass)`, so re-measuring rider mass moves it. It
shifts the settled `est - truth` trim from **-2.501 deg to -2.690 deg**,
outside the pinned +-0.10 deg band.

Expected result: the `sim` check fails on
`test_f1_the_estimator_trim_is_pinned_so_a_retune_cannot_move_it_silently`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)