### PR TITLE
Pin the estimator trim and the reserve's derivation, and measure the incline tolerance -- ADR-0011 (f1)/(f2) + condition 2 (#207)

### DIFF
--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -46,6 +46,8 @@ extern "C" {
     fn plant_mujoco_get_qpos(data: *mut c_void, out: *mut f64, n: c_int);
     fn plant_mujoco_get_qvel(data: *mut c_void, out: *mut f64, n: c_int);
     fn plant_mujoco_timestep(model: *mut c_void) -> f64;
+    fn plant_mujoco_get_gravity(model: *mut c_void, out: *mut f64);
+    fn plant_mujoco_set_gravity(model: *mut c_void, g: *const f64);
     fn plant_mujoco_forward(model: *mut c_void, data: *mut c_void);
     fn plant_mujoco_sensor_id(model: *mut c_void, name: *const c_char) -> c_int;
     fn plant_mujoco_sensor_adr(model: *mut c_void, sensor_id: c_int) -> c_int;
@@ -311,6 +313,43 @@ impl Plant {
     pub fn timestep(&self) -> f64 {
         // SAFETY: `self.model` is non-null and owned for the life of `self`.
         unsafe { plant_mujoco_timestep(self.model) }
+    }
+
+    /// `mjModel::opt.gravity`, m/s^2, world frame.
+    pub fn gravity(&self) -> [f64; 3] {
+        let mut out = [0.0f64; 3];
+        // SAFETY: `self.model` is non-null and owned for the life of `self`;
+        // `out` is exactly the 3 doubles the shim copies.
+        unsafe { plant_mujoco_get_gravity(self.model, out.as_mut_ptr()) };
+        out
+    }
+
+    /// Overwrites `mjModel::opt.gravity` -- **verification only**, and the
+    /// only supported way to put this plant on a slope.
+    ///
+    /// A ground plane inclined by `phi` under vertical gravity and a flat
+    /// ground plane under gravity tilted by `phi` are the same rigid-body
+    /// problem in two frames, so this measures a real incline rather than
+    /// approximating one. It is done here rather than by editing the model's
+    /// `<geom type="plane">` because ground geometry is the fidelity
+    /// contract's (`sim/models/` is Sr. Mechanical & Systems' turf) and
+    /// because a *model* edit would change every scenario, not one run.
+    ///
+    /// Must be called before the first [`Plant::step`]: `opt.gravity` is read
+    /// every step, so changing it mid-run is a step disturbance rather than an
+    /// incline, and the caller almost never means that.
+    ///
+    /// # Panics
+    /// If called after any [`Plant::step`].
+    pub fn set_gravity(&mut self, g: [f64; 3]) {
+        assert!(
+            self.time() == 0.0,
+            "Plant::set_gravity must be called before the first Plant::step (mjData::time is \
+             {:.6}, not 0) -- a mid-run change is a disturbance, not an incline",
+            self.time()
+        );
+        // SAFETY: see `gravity`; `g` is 3 doubles the shim only reads.
+        unsafe { plant_mujoco_set_gravity(self.model, g.as_ptr()) };
     }
 
     /// `mj_forward` -- issue #107 (I1c) AC8, carried forward from I1b. Every

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -99,6 +99,24 @@ double plant_mujoco_timestep(void* model) {
   return ((mjModel*)model)->opt.timestep;
 }
 
+// `mjModel::opt.gravity`, m/s^2, world frame.
+//
+// Read AND write, because ADR-0011's world-authoring constraint needs the
+// incline the board tolerates to be a MEASURED number, and a slope is exactly
+// a rotated gravity vector: a flat plane under gravity tilted by phi is the
+// same rigid-body problem as a plane inclined by phi under vertical gravity,
+// rotated. Tilting gravity rather than the ground geom keeps the measurement
+// out of `sim/models/` (Sr. Mechanical & Systems' fidelity contract) and
+// applies the along-slope component to EVERY body's own mass, which an
+// external force on one body cannot do.
+void plant_mujoco_get_gravity(void* model, double* out) {
+  memcpy(out, ((mjModel*)model)->opt.gravity, 3 * sizeof(double));
+}
+
+void plant_mujoco_set_gravity(void* model, const double* g) {
+  memcpy(((mjModel*)model)->opt.gravity, g, 3 * sizeof(double));
+}
+
 // The pre-loop priming call the CONTROLLED scenarios make (AC8 / issue #107's
 // carried-forward criterion): populates sensordata and qacc_warmstart for the
 // controller's first cycle, in the same position relative to the first

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -158,6 +158,12 @@ pub struct SimBackend {
     /// Overrides `model_path()`'s default when `Some` (issue #161 W2). See
     /// [`SimBackend::with_model_path`].
     model_path_override: Option<PathBuf>,
+    /// **Verification only.** Ground incline, degrees, applied at `open()` by
+    /// tilting gravity. See [`SimBackend::set_incline_deg`]. Zero leaves
+    /// `mjModel::opt.gravity` untouched -- not merely set back to its own
+    /// value, so a run with no incline is bit-identical to one built before
+    /// this knob existed.
+    incline_deg: f64,
 }
 
 impl SimBackend {
@@ -199,6 +205,34 @@ impl SimBackend {
     pub fn set_ballast_targets(&mut self, fore_aft_m: f32, lateral_m: f32) {
         self.ballast_fa_target_m = fore_aft_m;
         self.ballast_lateral_target_m = lateral_m;
+    }
+
+    /// **Verification only.** Puts the plant on a constant slope of
+    /// `incline_deg`, taking effect at the next `open()`.
+    ///
+    /// Positive is UPHILL in the board's forward direction (forward is `-X`,
+    /// so gravity acquires a `+X` component that opposes forward travel).
+    ///
+    /// Implemented by rotating `mjModel::opt.gravity` about `Y`, not by
+    /// tilting the ground geom: a flat plane under tilted gravity and a
+    /// tilted plane under vertical gravity are the same rigid-body problem
+    /// expressed in two frames, and only the gravity form applies the
+    /// along-slope component to every body's own mass. The magnitude is taken
+    /// from whatever the open model declares rather than from a constant here,
+    /// so this rotates the model's gravity instead of replacing it.
+    ///
+    /// ADR-0011's second ratification makes the authored world a condition of
+    /// the launch hold ("the authored world is constrained to what the
+    /// controller survives, and the constraint is encoded as a checkable asset
+    /// rule"). That rule needs a MEASURED incline tolerance, which needs this.
+    ///
+    /// Note what this changes about `truth` pitch: MuJoCo reports attitude
+    /// against model `Z`, which under this transform is the SLOPE NORMAL,
+    /// while the IMU still measures true gravity. On an incline the two
+    /// references genuinely differ by `incline_deg`, and that is physics, not
+    /// an estimator fault.
+    pub fn set_incline_deg(&mut self, incline_deg: f64) {
+        self.incline_deg = incline_deg;
     }
 
     /// The current the plant is seeing. Exposed for tests.
@@ -509,6 +543,16 @@ impl BoardObserve for SimBackend {
             plant.timestep(),
         );
         self.steps_per_cycle = CYCLE_NS / dt_ns;
+
+        // The incline, if any, goes on BEFORE `forward()`: that call primes
+        // `sensordata`, and the accelerometer's very first sample has to see
+        // the slope or the estimator starts from a vertical it never had.
+        if self.incline_deg != 0.0 {
+            let g = plant.gravity();
+            let mag = (g[0] * g[0] + g[1] * g[1] + g[2] * g[2]).sqrt();
+            let (s, c) = self.incline_deg.to_radians().sin_cos();
+            plant.set_gravity([mag * s, 0.0, -mag * c]);
+        }
 
         // AC8 (issue #107, carried forward from I1b/#106): the CONTROLLED
         // Python scenarios call mj_forward once, before their first

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -12,7 +12,7 @@
 //!          [--stats-path PATH|none]
 //!          [--free-run] [--max-sim-secs SECONDS]
 //!          [--pitch-source estimator|truth] [--pitch-bias-deg DEGREES]
-//!          [--cmd-reserve FRACTION]
+//!          [--cmd-reserve FRACTION] [--incline-deg DEGREES]
 //!          [--disturbance t0,dur,fx,fy,fz,tx,ty,tz] [--trace-csv PATH]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
@@ -183,6 +183,26 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
                 cfg.cmd_envelope_reserve = Some(scale);
+                i += 2;
+            }
+            // A constant ground slope, degrees, positive uphill. ADR-0011's
+            // second ratification needs the tolerated incline as a MEASURED
+            // number before the authored world can carry a checkable asset
+            // rule; see HostConfig::incline_deg.
+            "--incline-deg" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --incline-deg needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(deg) = v.parse::<f64>() else {
+                    eprintln!("sim-host: --incline-deg value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                if !(-45.0..=45.0).contains(&deg) {
+                    eprintln!("sim-host: --incline-deg must be within [-45, 45], got {deg}");
+                    return ExitCode::FAILURE;
+                }
+                cfg.incline_deg = deg;
                 i += 2;
             }
             // `t0,duration,fx,fy,fz,tx,ty,tz` -- world frame, SI. The kerb

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -294,11 +294,10 @@ const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
 ///
 /// Holding full forward stick from rest inverts this board in ~6.5 s
 /// (issue #190). The flip boundary was measured between 0.95 and 0.97 of
-/// full stick, and **tuning to that boundary is forbidden**: it rests
-/// partly on an accidental ~1 deg nose-down estimator bias that happens to
-/// act as nose-up trim, and partly on `wheel_hinge`'s undocumented
-/// `damping="0.08"`. A constant sitting on either is a constant that moves
-/// when somebody fixes a bug.
+/// full stick, and **tuning to that boundary is forbidden**: it rests partly
+/// on the estimator's operating trim and partly on `wheel_hinge`'s
+/// undocumented `damping="0.08"`. A constant sitting on either is a constant
+/// that moves when somebody changes something unrelated.
 ///
 /// The derivation instead runs off the actuator envelope, per the
 /// command-map rule ADR-0011 propagates to the hardware spec -- *the
@@ -317,6 +316,28 @@ const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
 ///    **0.80**. Pinned as executable arithmetic by
 ///    `the_command_envelope_reserve_is_the_stated_reserve_divided_by_the_
 ///    measured_slope`, not merely written down here.
+///
+/// # TRIM-DERIVED, not geometry-derived -- read this before porting it
+///
+/// The step above says "measured", and the word is load-bearing in a way the
+/// phrase *derived from the actuator envelope* can easily be read past.
+/// [`PEAK_DEMAND_A_PER_UNIT_STICK`] was measured **at the estimator's current
+/// operating trim**, and it is a property of that trim, not of the vehicle.
+/// Measured in `test_f2_the_peak_demand_slope_is_trim_derived_not_geometry_
+/// derived`: shifting the trim by 0.10 deg moves the slope by ~5.2%, which
+/// is already outside the 5% band its own provenance check allows.
+///
+/// So this constant is honest for the frozen trim and for nothing else. It
+/// does not travel to hardware, to a retuned filter, or to a different
+/// operating point on its own authority. Describing it as geometry-derived --
+/// as something the actuator envelope alone fixes -- would be a
+/// rationalisation, and ADR-0011's second ratification says so in those
+/// words. The trim it rests on is pinned by
+/// `test_f1_the_estimator_trim_is_pinned_so_a_retune_cannot_move_it_silently`
+/// precisely so this constant cannot go stale quietly; ADR-0011 names any
+/// retune that moves that band as a blocking prerequisite for the
+/// headroom-based fix, which is the version of this that would NOT be
+/// trim-derived.
 ///
 /// # What it buys, measured
 ///
@@ -348,9 +369,11 @@ const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
 ///
 /// - **Criterion (f) -- fed MuJoCo truth -- fails at every value.** Sweeping
 ///   this constant from 1.00 down to 0.05 moves time-to-inversion from 4.42 s
-///   to 28.67 s and never removes it; only exactly zero stick survives. With
-///   the estimator bias removed a sustained forward lean has no equilibrium,
-///   so the reserve buys TIME, not survival.
+///   to 28.67 s and never removes it; only exactly zero stick survives.
+///   Feeding the regulator truth deletes the acceleration reference the lean
+///   is generated from, so a sustained forward lean has no equilibrium and
+///   the reserve buys TIME, not survival. ADR-0011's second ratification
+///   replaces this criterion with freeze-and-pin for exactly that reason.
 /// - **Criterion (a)'s kerb-strike entry fails** above roughly a 1 mm lip
 ///   struck at the worst point of a full-stick hold.
 ///
@@ -758,18 +781,23 @@ pub struct HostConfig {
     /// This is the robustness test ADR-0011 criterion (f) was reaching for.
     /// The ADR asks for acceptance "with the estimator bias removed" and
     /// implements that as "feed the regulator MuJoCo truth" -- but the
-    /// measured `est - truth` residual is not a static bias at all: it
-    /// regresses on unaided specific force at 5.7-6.1 deg per m/s^2, which is
-    /// 1 radian per g, i.e. it is the complementary filter reading the
-    /// APPARENT VERTICAL. Replacing it with truth therefore does not remove
-    /// an error, it deletes an acceleration reference and leaves a
-    /// pitch-only regulator (see `PitchSource::PlantTruth`).
+    /// measured `est - truth` residual is not a static bias at all: settled,
+    /// it is `atan(a_unaided / g)` to within 3%, i.e. 1 radian per g, i.e.
+    /// the complementary filter reading the APPARENT VERTICAL. Replacing it
+    /// with truth therefore does not remove an error, it deletes an
+    /// acceleration reference and leaves a pitch-only regulator (see
+    /// `PitchSource::PlantTruth`).
     ///
     /// Injecting a worst-case STATIC bias on top of the real signal path is
     /// the test that actually asks "does this margin survive an estimator
     /// that is wrong?" without silently changing which controller is under
     /// test. Both are run and both are reported;
     /// `tests/test_cmd_envelope_reserve.py` has the results.
+    ///
+    /// Second use, ADR-0011 (f2): a small offset here MOVES THE OPERATING
+    /// TRIM while changing nothing else, which is how the peak-demand slope
+    /// behind [`CMD_ENVELOPE_RESERVE`] is shown to be trim-derived rather
+    /// than geometric.
     pub pitch_bias_deg: f32,
 
     /// **Verification only.** Runs the loop as fast as the CPU allows,
@@ -802,6 +830,23 @@ pub struct HostConfig {
     /// behaviour.
     pub disturbance: Option<Disturbance>,
 
+    /// **Verification only.** Ground incline, DEGREES, positive uphill in the
+    /// board's forward direction. Zero is flat and leaves the plant's gravity
+    /// untouched.
+    ///
+    /// ADR-0011's second ratification makes the authored world one of the
+    /// three conditions the launch hold exits on: *the authored world is
+    /// constrained to what the controller survives, and the constraint is
+    /// encoded as a checkable asset rule.* An asset rule needs a number, the
+    /// number is an incline, and this is how it gets measured
+    /// (`tests/test_incline_tolerance.py`). It is deliberately a MEASUREMENT
+    /// knob and not a scenario parameter: no shipped configuration sets it.
+    ///
+    /// Applied by [`sim_backend::SimBackend::set_incline_deg`], which rotates
+    /// `mjModel::opt.gravity` rather than the ground geom -- see there for why
+    /// that is the same problem and not an approximation of it.
+    pub incline_deg: f64,
+
     /// **Verification only.** Writes one CSV row per control cycle to this
     /// path when the run ends. Buffered in memory and written once, never
     /// during the loop: a 500 Hz control thread does not do file I/O per
@@ -812,13 +857,24 @@ pub struct HostConfig {
 /// Where the regulator's attitude comes from -- ADR-0011 exit criterion (f).
 ///
 /// The default is the only one a deployed host may use. `PlantTruth` exists
-/// because the ADR requires every acceptance pass to hold **with the
-/// estimator bias removed**, and on this plant that is the measured-WORSE
-/// case, not the better one: the complementary filter's ~1 deg nose-down
-/// error acts as nose-up trim, so feeding the controller MuJoCo truth makes
-/// the board flip EARLIER. That is accidental model error, not a designed
-/// safety property, and criterion (f) exists precisely so no acceptance
-/// number is allowed to rest on it.
+/// because the ADR's FIRST ratification required every acceptance pass to
+/// hold **with the estimator bias removed**, and on this plant that is the
+/// measured-WORSE case, not the better one: feeding the controller MuJoCo
+/// truth makes the board flip EARLIER.
+///
+/// **The reason is not an accidental bias, and the ADR's second ratification
+/// corrects that reading.** The `est - truth` residual is the apparent
+/// vertical, `atan(a/g)` -- 1 radian per g, which is the same 5.84 deg per
+/// m/s^2 the ADR derives geometrically as the lean this board must hold to
+/// sustain acceleration `a`, because it is the same physics. The estimator is
+/// supplying the textbook balance-vehicle lean. Substituting truth therefore
+/// does not de-bias the loop, it deletes the only mechanism generating that
+/// lean and leaves a pitch-only regulator -- a different controller, not a
+/// cleaner one. What criterion (f) was right about is that nothing designed
+/// this and nothing held it in place; (f1)/(f2) fix that by pinning it
+/// (`tests/test_cmd_envelope_reserve.py`), and (f3) makes it explicit as a
+/// `theta_ref = atan(a_des / g)` feedforward, at which point this instrument
+/// becomes meaningful again.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PitchSource {
     /// The `ComplementaryFilter`, fed raw IMU through `hal` -- the real
@@ -869,6 +925,7 @@ impl Default for HostConfig {
             free_run: false,
             cmd_envelope_reserve: None,
             disturbance: None,
+            incline_deg: 0.0,
             trace_path: None,
         }
     }
@@ -1082,6 +1139,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     };
 
     let mut backend = SimBackend::with_model_path(params, rider_model_path());
+    // Before `open()`, which is where the tilt is applied -- see
+    // `HostConfig::incline_deg`.
+    backend.set_incline_deg(cfg.incline_deg);
     backend.open().map_err(HostError::Backend)?;
     // Armed unconditionally at startup, the same way every other Rust-hosted
     // harness in this repo arms (`impulse-response-rust`, `sim-backend`'s own
@@ -1495,8 +1555,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // On a deployed run this is the `Estimator` arm and the regulator
         // sees exactly what it always saw. On an acceptance run it is
         // `PlantTruth`, and the regulator sees MuJoCo -- which on this plant
-        // is the measured-WORSE case, because the filter's ~1 deg nose-down
-        // error acts as nose-up trim. See `PitchSource`.
+        // is the measured-WORSE case, because it deletes the apparent-vertical
+        // lean the estimate carries rather than de-biasing it. See
+        // `PitchSource`.
         let (source_pitch_rad, regulated_pitch_rate_rad_s) = match cfg.pitch_source {
             PitchSource::Estimator => (attitude.pitch_rad, attitude.pitch_rate_rad_s),
             PitchSource::PlantTruth => (pitch_rad, truth_pitch_rate_rad_s),

--- a/roles/senior-controls/CONTEXT.md
+++ b/roles/senior-controls/CONTEXT.md
@@ -6,6 +6,39 @@
 
 ## Current sub-goals
 
+> **Two Senior Controls sessions have been running in parallel** (Stage-0B Pi image, and the
+> ADR-0011 balance work). Both threads are below; they do not overlap in code.
+
+### ADR-0011 balance loop (issue #207) — the launch hold
+
+- **Read ADR-0011's SECOND RATIFICATION before touching anything in the balance loop.** It
+  replaced criterion (f) with freeze-and-pin, and the old "accidental ~1 deg nose-down
+  estimator bias" reading is superseded. The residual is `atan(a/g)`, one radian per g, which
+  is the *same number* as the ADR's geometric 5.84 °/(m/s²) because it is the same physics.
+  The estimator is implementing the textbook balance-vehicle lean. **Do not "fix" it.**
+- **(f1)/(f2) landed (PR #215).** The trim is pinned at **−2.501° ± 0.10°** and the reserve's
+  derivation is pinned to it. The band is NOT a tolerance — it is the trim movement at which
+  `CMD_ENVELOPE_RESERVE` stops being derived from anything true. **If a pin fails, re-derive;
+  never re-baseline.** ±0.25° is a measured characterisation and must never become a threshold
+  (ADR-0011 says so explicitly).
+- **Open and unowned: the world-authoring asset rule.** ADR-0011 condition 2 requires it, the
+  measured inputs now exist (`tests/test_incline_tolerance.py`), and **no role has picked up
+  writing it.** Not my turf. This will sit still until somebody claims it — flagged on the
+  2026-08-01 board.
+
+### Standing facts worth not rediscovering
+
+- **This sim is bit-identical across platforms.** Ubuntu CI and macOS/arm64 agreed to 16
+  significant figures on an 18.5 s closed-loop run (`−2.6896194189755955` vs `−2.6896`).
+  Tight pins here are safe; platform drift is not a reason to widen a band.
+- **`--incline-deg` exists now** (rotates `mjModel::opt.gravity` at plant open). It is the only
+  supported way to put the plant on a slope, and it keeps the change out of `sim/models/`.
+- **A slope is NOT an effective static pitch disturbance.** A static pitch *estimate error* is a
+  signal the controller cannot see; a slope is one it can. Anything reasoning from that
+  equivalence is wrong. The board inverts nowhere within ±12°.
+- **What binds on terrain is that there is no speed loop** — `MAX_GROUND_SPEED_M_S` shapes the
+  *stick*, and a stick cap cannot brake against gravity.
+
 ### Stage-0B Pi image (issue #182) — ACTIVE, this is the live thread
 Hardware (Pi 5 + Waveshare 2-CH CAN FD HAT, MCP2518FD) arrives 2026-08-03.
 
@@ -278,6 +311,25 @@ _Older entries collapsed above this line as the log grows; nothing predates the 
   First `continue-on-error: true`; then, after removing it, `docker … | tee` returning *tee's*
   exit status because Actions runs steps under `bash -e`, **not** `-o pipefail`.
   **Any step in this repo that pipes to `tee` has this bug.** Worth a sweep.
+- **The `est − truth` residual regressed across the acceleration ramp (2026-08-02).** Least
+  squares of residual against specific force over the ramp is a **badly conditioned
+  instrument**: the fitted slope moves 4.9 → 7.1 °/(m/s²) across reasonable fit windows on the
+  *same* run, because the filter's 2 s time constant makes the residual lag the specific force
+  throughout the ramp. Do not build a pin on it. Measure the identity in a **settled window**
+  instead (`_settled_trim`), where it holds to a few percent.
+- **Measuring anything on a board rolling BACKWARDS (2026-08-02).** It leaves the drivable
+  corridor after `CORRIDOR_X_MAX_M` = 50 m — about 17 s at 3° of slope — and the host then
+  applies `CORRIDOR_BRAKE_LEAN` = 0.6 for the rest of the run. This looked exactly like the
+  speed cap arresting a downhill roll, and was not. Check `applied_fore_aft` (it goes to exactly
+  0.60) before believing any run where the board decelerates on its own. Downhill-*forward* has
+  700 m of corridor and is the safe direction.
+- **`--max-sim-secs` does not EXTEND a scripted run (2026-08-02)**, only caps it. The
+  `full-stick` schedule ends at 18.5 s and that is the whole measurement window. Anything
+  needing longer — e.g. the steepest climbable grade, still unmeasured — needs a new schedule in
+  `scenario.rs`.
+- **`target/release/sim-host` cannot be run directly on macOS**; the linked libmujoco is only on
+  the loader path under `cargo run`. Every harness here shells out through `cargo run` for that
+  reason.
 
 - **Fetching vesc-project.com for the VESC 6 CAN Formats PDF (2026-07-28).**
   `WebFetch` returned HTTP 403 for every URL tried on that domain (the PDF

--- a/roles/senior-controls/log/2026-08-02-pin-trim-and-reserve.md
+++ b/roles/senior-controls/log/2026-08-02-pin-trim-and-reserve.md
@@ -1,0 +1,100 @@
+# 2026-08-02 — Issue #207: pin the estimator trim and the reserve's derivation
+
+ADR-0011 second ratification, criteria (f1) and (f2), plus the incline-tolerance
+measurement the world-authoring constraint was blocked on. PR #215.
+
+## What was pinned, and the instrument that had to be replaced to pin it
+
+The obvious instrument for (f1) — least squares of the `est − truth` residual against
+specific force across the acceleration ramp — is **badly conditioned**, and measuring it
+said so before anything was asserted: on one run the fitted slope moves **4.9 → 7.1 °/(m/s²)**
+across reasonable choices of fit window, because the complementary filter's 2 s time constant
+makes the residual lag the specific force throughout the ramp. A band tight enough to be a pin
+would have chattered on the window choice; a band loose enough not to would have detected
+nothing. The shipped test's ±25% band was the second of those.
+
+The identity is a **steady-state** statement, so it is now measured in steady state: residual
+against `atan(a_unaided/g)` over a fixed late window. Ratio **1.028**, unexplained static part
+**2.8%**. Asserted as the identity (ratio ≈ 1, ±5%) rather than as a fitted slope.
+
+Trim pinned at **−2.501 ± 0.10°**.
+
+## Where the band came from — this is the part worth remembering
+
+Not from what passed. Measured in the (f2) work: **shifting the trim 0.10° moves the
+peak-demand slope 5.19–5.26%**, against the **5%** band that slope's own provenance check
+allows. So 0.10° is the trim movement at which `CMD_ENVELOPE_RESERVE` stops being derived from
+anything true. The pin fires exactly where the derivation goes stale, which is the only place
+it has a principled reason to fire. (f1) and (f2) are therefore one pin seen twice.
+
+The ±0.25° static-error characterisation was used **only** as a sanity check in the safe
+direction — the band the derivation argument produced happens to sit well inside it. Had the
+derivation produced a wider band the answer would have been to look harder, not to borrow
+0.25°. Promoting 0.25° to a bar is the exact move criterion (f) exists to forbid.
+
+## The acceptance criterion was met by breaking CI on purpose, not by reading the test
+
+Spike PR #214: `ACCEL_FF_GAIN_M_S2_PER_A` 0.0584 → 0.0650 (a realistic re-derivation — the
+constant is `kt / (r_eff · total mass)`). `sim` went red on the trim pin.
+[Run](https://github.com/MikePaNtZ/overboard/actions/runs/30762664302/job/91535879744). Closed
+without merging.
+
+Two things fell out of it:
+
+- **The sim is bit-identical across platforms.** Ubuntu runner `−2.6896194189755955°`; macOS
+  arm64 `−2.6896°`. That was the open risk in a ±0.10° band on a 2.5° quantity, and it is
+  answered — the band cannot produce a platform-dependent false positive. Useful for anyone
+  pinning anything else here.
+- **A trim move of that size takes four other assertions with it** — peak-demand slope fell to
+  29.20 A/unit against 42.03, the unshaped positive control stopped inverting the board, and the
+  loss-of-authority warning stopped firing at all. The trim is load-bearing for most of what
+  ADR-0011 measures.
+
+## Incline tolerance — the prediction was wrong, and the premise was wrong
+
+Issue #207 predicted "under 0.5°", reasoning that a slope is an effective static pitch
+disturbance. **The middle step fails.** A static pitch *estimate error* is a signal the
+controller cannot see — it regulates a lie forever. A slope is one it **can** see: the IMU still
+measures true gravity, so attitude is correct on a hill and the slope arrives as an ordinary
+along-track force the balance loop already leans against. Different disturbances, different
+tolerances.
+
+Measured (`tests/test_incline_tolerance.py`; `--incline-deg` rotates `mjModel::opt.gravity` at
+open, which is the same rigid-body problem as a tilted ground plane and keeps the change out of
+`sim/models/`):
+
+| | measured |
+|---|---|
+| ADR-0011 matrix inverts | **nowhere** in ±12° (hold) / ±8° (reversal) — ≥24× the prediction |
+| station-keeping | **zero at every incline.** Released, free-rolls at 0.70·g·sin φ, 43 m/s on a 15° grade inside one 18.5 s schedule, nothing in the host intervening |
+| self-arrest at 0.6 lean | arrested to **6.5°**, outrun at **7.0°** |
+
+So the binding constraint is **not inversion, it is that there is no speed loop** —
+`MAX_GROUND_SPEED_M_S` shapes the *stick*, and a stick cap cannot brake against gravity. The
+asset rule needs an angle **and a run-out length**: a 0.25° grade is fine for a metre and not for
+a kilometre (~1159 m to speed-cap onset from rest).
+
+None of these is an acceptance threshold and the file says so at length. They are inputs the
+world-authoring role writes the rule *from*.
+
+## Trap worth knowing about: the corridor brake
+
+The first version of the self-arrest measurement attributed the braking to the speed cap. It is
+the **corridor brake** — roll backwards past `CORRIDOR_X_MAX_M` = 50 m and the host applies
+`CORRIDOR_BRAKE_LEAN` = 0.6 for the rest of the run. Caught by looking at `applied_fore_aft`,
+which goes to exactly 0.60. Any released-board measurement that rolls *backwards* hits this
+within ~17 s at 3°. The free-roll test therefore runs **downhill-forward** (700 m of corridor)
+and asserts `applied_fore_aft == 0` throughout.
+
+## Deliberately not delivered, flagged rather than fudged
+
+- **The steepest grade the board can climb at full stick.** Between 4° and 7°, and not reported:
+  the 18.5 s schedule cannot distinguish a board climbing slowly from one about to slide back.
+  Needs a longer scripted schedule — its own increment. Also the least safety-relevant of the
+  four: a grade the board cannot climb is a stuck player, not a fall.
+- **The incline numbers are not in `docs/`.** A new file under `docs/` is COO turf; the
+  measurement lives in the test file's docstring on the same precedent as issue #24 AC5. If the
+  world-authoring role wants it mirrored into `docs/`, that is a COO call, not mine to take.
+- **(f3), `θ_ref = atan(a_des/g)` as an explicit feedforward**, is untouched — ADR-0011 defers it
+  and bundles it with the headroom fix. This PR is what makes the accident safe to stand on
+  until then, not a substitute for it.

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -113,11 +113,6 @@ DISTURBANCE_WINDOW_S = 0.002
 #: physics rather than about `overboard_rider.xml`.
 G_M_S2 = 9.80665
 
-#: `ACCEL_FF_GAIN_M_S2_PER_A`, `host.rs`. The command feedforward already
-#: removes this much specific force per amp before the filter sees it, so the
-#: specific force the filter is left reading is `a_x - this * I`.
-ACCEL_FF_GAIN_M_S2_PER_A = 0.0584
-
 #: The window, in seconds of simulated time, over which the estimator trim is
 #: measured -- see `_settled_trim`. Late in the run on purpose, and stated as
 #: a constant so it is a fixed instrument rather than a fitting parameter.
@@ -245,6 +240,11 @@ def _settled_trim(rows, window=TRIM_WINDOW_S):
     """
     t_lo, t_hi = window
     half = DIFF_HALF_CYCLES
+    # Read from `host.rs`, not copied: the command feedforward already removes
+    # this much specific force per amp before the filter sees it, so a stale
+    # copy here would mis-state what the filter was left reading and the trim
+    # pin below would fire for the wrong reason -- or, worse, fail to.
+    accel_ff_gain = _rust_constant("ACCEL_FF_GAIN_M_S2_PER_A")
     residual, apparent = [], []
     for i in range(half, len(rows) - half):
         if not t_lo <= rows[i]["sim_time_s"] <= t_hi:
@@ -252,7 +252,7 @@ def _settled_trim(rows, window=TRIM_WINDOW_S):
         a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
             rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
         )
-        unaided = a_x - ACCEL_FF_GAIN_M_S2_PER_A * rows[i]["applied_amps"]
+        unaided = a_x - accel_ff_gain * rows[i]["applied_amps"]
         residual.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
         apparent.append(math.degrees(math.atan(unaided / G_M_S2)))
     assert residual, f"no rows in the trim window {window}"

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -576,7 +576,14 @@ def test_the_estimator_residual_is_specific_force_not_a_static_bias(tmp_path):
         f"({100 * abs(static_part / apparent):.1f}% of the apparent-vertical term)"
     )
 
-    assert abs(ratio - 1.0) < 0.10, (
+    # 5% is set by the instrument and by what the error MEANS, not by the
+    # measured 2.8%: it is about 1.7x this measurement's own sensitivity to
+    # the choice of settled window (the ratio moves over 1.009-1.039 across
+    # reasonable windows on one run), and 5% of the apparent-vertical term at
+    # this operating point is 0.12 deg of supplied lean -- half the smallest
+    # static perturbation this repo has characterised, so a scale error large
+    # enough to matter cannot hide inside it.
+    assert abs(ratio - 1.0) < 0.05, (
         f"the est-truth residual is no longer the apparent vertical (ratio "
         f"{ratio:.3f}). ADR-0011's second ratification rests on that identity; "
         "if this has genuinely changed, the ADR needs revisiting again rather "

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -108,6 +108,38 @@ KERB_MOMENT_ARM_M = 0.77885 - 0.1454
 #: 1), so an impulse delivered over this window is exact.
 DISTURBANCE_WINDOW_S = 0.002
 
+#: Standard gravity, m/s^2. CODATA, not the model's own `9.81` -- this is the
+#: constant in the `1 radian per g` identity, which is a statement about
+#: physics rather than about `overboard_rider.xml`.
+G_M_S2 = 9.80665
+
+#: `ACCEL_FF_GAIN_M_S2_PER_A`, `host.rs`. The command feedforward already
+#: removes this much specific force per amp before the filter sees it, so the
+#: specific force the filter is left reading is `a_x - this * I`.
+ACCEL_FF_GAIN_M_S2_PER_A = 0.0584
+
+#: The window, in seconds of simulated time, over which the estimator trim is
+#: measured -- see `_settled_trim`. Late in the run on purpose, and stated as
+#: a constant so it is a fixed instrument rather than a fitting parameter.
+TRIM_WINDOW_S = (12.0, 18.0)
+
+#: Half-width of the central difference used to recover forward acceleration
+#: from the speed trace, in control cycles. 50 cycles is +-0.1 s.
+DIFF_HALF_CYCLES = 50
+
+#: ADR-0011 (f1). The estimator trim as it stands today, degrees of `est -
+#: truth` over `TRIM_WINDOW_S` of the shipped full-stick hold. A MEASURED
+#: value being frozen, not a target: see
+#: `test_f1_the_estimator_trim_is_pinned_so_a_retune_cannot_move_it_silently`
+#: for why this is a drift detector and may never be cited as a tolerance.
+PINNED_TRIM_DEG = -2.501
+
+#: How far `PINNED_TRIM_DEG` may move before the build goes red. Set from the
+#: trim movement that puts `CMD_ENVELOPE_RESERVE`'s own derivation out of
+#: tolerance (measured: 0.10 deg of trim moves the peak-demand slope 5.2%,
+#: against a 5% band) -- NOT from what happens to pass. See the same test.
+PINNED_TRIM_BAND_DEG = 0.10
+
 
 # ---------------------------------------------------------------------------
 # Harness
@@ -187,6 +219,46 @@ def _peak_pitch_deg(rows):
     return max(abs(r["truth_pitch_deg"]) for r in _healthy(rows))
 
 
+def _settled_trim(rows, window=TRIM_WINDOW_S):
+    """The estimator trim, measured where the identity is actually testable.
+
+    Returns `(residual_deg, apparent_vertical_deg)`, both means over `window`:
+
+    * `residual_deg` -- mean `est - truth` pitch. This IS the trim: the lean
+      the estimator believes in that the plant does not have.
+    * `apparent_vertical_deg` -- mean `atan(a_unaided / g)`, the tilt an
+      accelerometer reports on a body under that specific force, where
+      `a_unaided = a_x - ACCEL_FF_GAIN * I` is the part the command
+      feedforward did not already remove.
+
+    **Why a settled window and not a regression over the whole run.** The
+    obvious instrument -- least squares of residual against specific force
+    across the acceleration ramp -- is badly conditioned here, and measuring
+    it says so: the fitted slope moves from 4.9 to 7.1 deg per m/s^2 across
+    reasonable choices of fit window on the SAME run, because the
+    complementary filter's 2 s time constant means the residual lags the
+    specific force throughout the ramp and the fit picks up whichever part of
+    that transient the window happens to contain. A band tight enough to be a
+    pin would chatter on the window choice; a band loose enough not to would
+    detect nothing. The identity is a STEADY-STATE statement, so it is
+    measured in steady state, where the ratio holds to a few percent.
+    """
+    t_lo, t_hi = window
+    half = DIFF_HALF_CYCLES
+    residual, apparent = [], []
+    for i in range(half, len(rows) - half):
+        if not t_lo <= rows[i]["sim_time_s"] <= t_hi:
+            continue
+        a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
+            rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
+        )
+        unaided = a_x - ACCEL_FF_GAIN_M_S2_PER_A * rows[i]["applied_amps"]
+        residual.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
+        apparent.append(math.degrees(math.atan(unaided / G_M_S2)))
+    assert residual, f"no rows in the trim window {window}"
+    return sum(residual) / len(residual), sum(apparent) / len(apparent)
+
+
 def _margin(rows) -> str:
     """The measured margin, in BOTH currencies ADR-0011 criterion (b) demands.
 
@@ -251,6 +323,78 @@ def test_peak_current_demand_is_linear_in_stick_at_the_documented_slope(tmp_path
         "the premise of the whole change is that full stick over-commands the "
         f"envelope; measured {slope:.2f} A/unit against {MAX_CURRENT_A} A"
     )
+
+
+def _peak_demand_slope(tmp_path, tag, **kw) -> float:
+    """Least squares through the origin of peak demand against stick."""
+    fractions = (0.30, 0.50, 0.70, 0.90)
+    peaks = [
+        _peak_demand_a(_run(tmp_path, f"{tag}{u}", "full-stick", cmd_reserve=u,
+                            pitch_source="estimator", **kw))
+        for u in fractions
+    ]
+    return sum(u * a for u, a in zip(fractions, peaks)) / sum(u * u for u in fractions)
+
+
+def test_f2_the_peak_demand_slope_is_trim_derived_not_geometry_derived(tmp_path):
+    """ADR-0011 (f2): pin the reserve's DERIVATION, not just its value.
+
+    `CMD_ENVELOPE_RESERVE` = 0.80 is
+    `STATED_ENVELOPE_RESERVE_FRACTION * MAX_CURRENT_A / PEAK_DEMAND_A_PER_UNIT_STICK`,
+    and `host.rs` enforces that arithmetic at compile time. What no compiler
+    can enforce is the status of the divisor: **41.97 A per unit stick was
+    measured at the current operating trim.** Describing the constant as
+    derived from the actuator envelope, and stopping there, reads as though it
+    were a geometric property that travels with the vehicle. It is not, and
+    calling it one would be a rationalisation.
+
+    This test makes the dependence a measurement rather than a caveat: shift
+    the trim by one `PINNED_TRIM_BAND_DEG` and re-take the slope.
+
+    The result is why (f1) and (f2) are one pin and not two. A 0.10 deg trim
+    shift moves the slope by about 5.2%, and
+    `test_peak_current_demand_is_linear_in_stick_at_the_documented_slope`
+    grants the slope a 5% band -- so **one pinned band of trim drift is
+    already enough to put the reserve's own provenance check out of
+    tolerance.** That is the calibration behind `PINNED_TRIM_BAND_DEG`: it is
+    the trim movement at which `CMD_ENVELOPE_RESERVE` stops being derived from
+    anything true, which is a stronger reason for its width than any statement
+    about what the board survives.
+
+    The bar asserted is deliberately loose. A geometry-derived constant would
+    move by exactly 0%; 3% is low enough to be robust to platform
+    floating-point differences and far too high to be reached by rounding, so
+    clearing it refutes "geometry-derived" without pinning a derivative.
+
+    The trim is shifted with `--pitch-bias-deg` rather than by retuning the
+    filter, because the question is what a MOVED TRIM does to the slope, and
+    an injected offset moves the trim while changing nothing else -- a
+    retuned `ESTIMATOR_TAU_S` would move several things at once and the result
+    could not be attributed.
+    """
+    base = _peak_demand_slope(tmp_path, "f2base")
+    moved = {
+        sign * PINNED_TRIM_BAND_DEG: _peak_demand_slope(
+            tmp_path, f"f2{sign}", pitch_bias_deg=sign * PINNED_TRIM_BAND_DEG
+        )
+        for sign in (-1, 1)
+    }
+    print(f"\n(f2) peak-demand slope at the shipped trim: {base:.3f} A/unit")
+    for shift, slope in sorted(moved.items()):
+        print(
+            f"     trim shifted {shift:+.2f} deg: {slope:.3f} A/unit "
+            f"({100 * (slope - base) / base:+.2f}%)"
+        )
+
+    for shift, slope in moved.items():
+        moved_pct = 100 * abs(slope - base) / base
+        assert moved_pct > 3.0, (
+            f"shifting the trim {shift:+.2f} deg moved the peak-demand slope "
+            f"only {moved_pct:.2f}%. If the slope has genuinely stopped "
+            "depending on the trim then CMD_ENVELOPE_RESERVE is better founded "
+            "than ADR-0011 claims and the ADR should be amended to say so -- "
+            "but do not reach that conclusion by loosening this test."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -391,51 +535,128 @@ def test_the_truth_pitch_rate_is_the_derivative_of_the_truth_pitch(tmp_path):
 
 
 def test_the_estimator_residual_is_specific_force_not_a_static_bias(tmp_path):
-    """WHY CRITERION (f) IS MIS-SPECIFIED, as a measurement.
+    """WHY CRITERION (f) WAS MIS-SPECIFIED, as a measurement.
 
-    ADR-0011 describes the `est - truth` gap as a "~1 deg nose-down estimator
-    bias" and implements "remove the bias" as "feed the regulator truth". It
-    is not a bias. Regressed against the specific force the command feedforward
-    failed to remove (`a_x - ACCEL_FF_GAIN * I`), it comes out at ~5.8 deg per
-    m/s^2 -- and 1 radian per g is 57.2958/9.81 = 5.84 deg per m/s^2. That is
-    a complementary filter reporting the APPARENT VERTICAL, which is what an
-    accelerometer measures on a vehicle that accelerates.
+    ADR-0011's first ratification described the `est - truth` gap as a "~1 deg
+    nose-down estimator bias" and implemented "remove the bias" as "feed the
+    regulator truth". It is not a bias, and one identity settles it:
+
+        1 radian per g = 57.2958 / 9.80665 = 5.8425 deg per m/s^2
+
+    and ADR-0011's own geometric lean sensitivity -- how far this board must
+    lean to sustain acceleration `a` -- is 5.84 deg per m/s^2. **Those are the
+    same number because they are the same physics.** The lean an inverted
+    pendulum needs to sustain `a` is `atan(a/g)`, and `atan(a/g)` is exactly
+    the tilt of the apparent vertical a complementary filter reads off an
+    accelerometer. The estimator is not carrying an error that flatters the
+    controller; it is implementing the textbook balance-vehicle lean.
+
+    Asserted here as the identity itself rather than as a fitted slope: the
+    settled residual over `TRIM_WINDOW_S` against `atan(a_unaided/g)` over the
+    same window, whose ratio is 1 if and only if the estimate is the apparent
+    vertical. `_settled_trim` records why the fitted-slope form was the wrong
+    instrument.
 
     The consequence is structural, not cosmetic: the estimate carries an
     acceleration reference, so replacing it with truth does not correct an
-    error, it removes a feedback path and leaves a pitch-only regulator. That
+    error, it deletes a feedback path and leaves a pitch-only regulator. That
     is why the criterion (f) result below is a continuum in time-to-inversion
     rather than a threshold in stick.
     """
-    rows = _run(tmp_path, "resid", "full-stick", cmd_reserve=0.6, pitch_source="estimator")
-    accel_ff_gain = 0.0584  # ACCEL_FF_GAIN_M_S2_PER_A, host.rs
-    half = 50  # +-0.1 s central difference, to see through per-cycle noise
-    xs, ys = [], []
-    for i in range(half, len(rows) - half):
-        if not 1.0 <= rows[i]["sim_time_s"] <= 15.0:
-            continue
-        a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
-            rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
-        )
-        xs.append(a_x - accel_ff_gain * rows[i]["applied_amps"])
-        ys.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
-    n = len(xs)
-    sx, sy = sum(xs), sum(ys)
-    slope = (n * sum(x * y for x, y in zip(xs, ys)) - sx * sy) / (n * sum(x * x for x in xs) - sx * sx)
-    intercept = (sy - slope * sx) / n
-    one_rad_per_g = math.degrees(1.0) / 9.81
+    rows = _run(tmp_path, "resid", "full-stick", pitch_source="estimator")
+    residual, apparent = _settled_trim(rows)
+    ratio = residual / apparent
+    static_part = residual - apparent
     print(
-        f"\nest-truth residual vs unaided specific force: {slope:.2f} deg per m/s^2 "
-        f"(1 rad/g = {one_rad_per_g:.2f}), intercept {intercept:+.3f} deg"
+        f"\nsettled trim over t in {TRIM_WINDOW_S} s:"
+        f"\n    est-truth residual        {residual:+.4f} deg"
+        f"\n    apparent vertical         {apparent:+.4f} deg  (= atan(a_unaided/g))"
+        f"\n    ratio                     {ratio:.4f}   (1 rad/g holds iff this is 1)"
+        f"\n    unexplained static part   {static_part:+.4f} deg "
+        f"({100 * abs(static_part / apparent):.1f}% of the apparent-vertical term)"
     )
-    assert abs(abs(slope) - one_rad_per_g) / one_rad_per_g < 0.25, (
-        "the est-truth residual no longer looks like an apparent-vertical "
-        "reading. If that is real, ADR-0011 criterion (f)'s framing needs "
-        "revisiting again, in the other direction."
+
+    assert abs(ratio - 1.0) < 0.10, (
+        f"the est-truth residual is no longer the apparent vertical (ratio "
+        f"{ratio:.3f}). ADR-0011's second ratification rests on that identity; "
+        "if this has genuinely changed, the ADR needs revisiting again rather "
+        "than this band being widened."
     )
-    assert abs(intercept) < 0.5, (
-        "a large intercept would mean there IS a static bias component after "
-        "all, which would make the ADR's framing partly right"
+    # A RELATIVE bound, because the claim under test is relative: the residual
+    # is specific force RATHER THAN a static bias. 10% of the apparent-vertical
+    # term is the largest static component that still leaves that sentence
+    # true. Not derived from the measured value, which is 2.8%.
+    assert abs(static_part) < 0.10 * abs(apparent), (
+        f"a static component of {static_part:+.3f} deg against an "
+        f"apparent-vertical term of {apparent:+.3f} deg would mean there IS a "
+        "meaningful static bias after all, making the ADR's original framing "
+        "partly right"
+    )
+
+
+def test_f1_the_estimator_trim_is_pinned_so_a_retune_cannot_move_it_silently(tmp_path):
+    """ADR-0011 (f1), and the reason the second ratification exists.
+
+    The board survives full stick because the estimator supplies the lean the
+    acceleration physically requires. That is correct behaviour, but nothing
+    designed it and until this test nothing held it in place: any change to
+    `ESTIMATOR_TAU_S`, `ACCEL_FF_GAIN_M_S2_PER_A`, the IMU wiring or the
+    regulator gains could move the trim, and the first symptom would be the
+    board flipping again. (f1) exists to make that a RED BUILD instead.
+
+    # What the band is, and what it is emphatically not
+
+    `PINNED_TRIM_BAND_DEG` is a **drift detector**, not a tolerance. It does
+    not assert that a trim anywhere inside it is safe, and no acceptance
+    number anywhere in this repo may be justified by it.
+
+    Its width comes from what a moved trim BREAKS, which is measured in
+    `test_f2_the_peak_demand_slope_is_trim_derived_not_geometry_derived`:
+    shifting the trim by 0.10 deg moves the peak-demand slope by about 5.2%,
+    and that slope is the divisor `CMD_ENVELOPE_RESERVE` is derived from, held
+    to a 5% band by
+    `test_peak_current_demand_is_linear_in_stick_at_the_documented_slope`. So
+    0.10 deg is the trim movement at which the shipped reserve stops being
+    derived from anything true. The pin fires exactly where the derivation
+    goes stale, which is the only place it has a principled reason to fire.
+
+    It is worth stating what this band is NOT derived from. The measured
+    static-error characterisation -- 0.25 deg survived, 0.5 deg inverted the
+    board -- is **not a threshold**, and ADR-0011 is explicit that promoting
+    0.25 deg to a bar would be deriving acceptance from whatever happened to
+    pass, the precise move criterion (f) exists to forbid. Those numbers are
+    used here only as a sanity check in the safe direction: the band that the
+    derivation argument produced happens to sit well inside them, so the pin
+    also cannot fail to fire before a trim reaches a value whose consequences
+    are unknown. Had the derivation argument produced a wider band, the answer
+    would have been to look harder, not to quietly borrow 0.25 deg.
+
+    There is no lower bound worth arguing about. Every run here is
+    bit-deterministic (`--free-run`, fixed-timestep RK4, schedule indexed on
+    simulated time), so a band this size cannot chatter; it can only be moved
+    by somebody actually changing the controller.
+
+    # If this test fails
+
+    Do not widen the band, and do not adjust the pinned value to match. The
+    trim moved, which means `CMD_ENVELOPE_RESERVE`'s provenance moved with it
+    (see `test_f2_...`) and ADR-0011's named blocking prerequisite -- the
+    headroom-based fix -- has come due. Re-derive; do not re-baseline.
+    """
+    rows = _run(tmp_path, "f1trim", "full-stick", pitch_source="estimator")
+    residual, apparent = _settled_trim(rows)
+    print(
+        f"\n(f1) pinned trim: {residual:+.4f} deg measured, "
+        f"{PINNED_TRIM_DEG:+.3f} {chr(177)} {PINNED_TRIM_BAND_DEG:.2f} deg pinned"
+    )
+    assert abs(residual - PINNED_TRIM_DEG) < PINNED_TRIM_BAND_DEG, (
+        f"the estimator trim has moved to {residual:+.4f} deg from the pinned "
+        f"{PINNED_TRIM_DEG:+.3f} deg. ADR-0011's exit rests on the trim being "
+        "frozen: the 0.80 command-envelope reserve was derived at THIS "
+        "operating trim and is honest only for it, and the ADR names any "
+        "retune that moves this band as a blocking prerequisite for the "
+        "headroom-based fix. Re-derive the reserve from a re-measured slope; "
+        "do not re-baseline this number to make the build green."
     )
 
 

--- a/tests/test_incline_tolerance.py
+++ b/tests/test_incline_tolerance.py
@@ -1,0 +1,402 @@
+"""The authored-terrain incline this board tolerates, MEASURED.
+
+ADR-0011's second ratification makes the launch hold conditional on three
+things, and the second is a world-authoring constraint:
+
+    The authored world is constrained to what the controller survives, and the
+    constraint is encoded as a checkable asset rule -- not a hope. [...]
+    authored inclines must stay well inside the measured static tolerance (a
+    0.5 deg slope is an effective static pitch disturbance).
+
+An asset rule needs a number, and issue #207 says plainly that the number in
+that sentence is a prediction rather than a measurement. This file is the
+measurement. Its headline result is that **the prediction is wrong, and wrong
+in a way that matters more than its magnitude.**
+
+WHAT THE PREDICTION ASSUMED, AND WHY IT DOES NOT HOLD
+-----------------------------------------------------
+The prediction reasons: a slope is an effective static pitch disturbance; the
+board inverts at 0.5 deg of static pitch error and survives 0.25 deg;
+therefore it tolerates well under 0.5 deg of incline.
+
+The middle step is the one that fails. A static pitch *estimate error* is a
+signal the controller **cannot see** -- it regulates a lie, and the lean it
+holds is wrong by that much forever. A slope is a signal the controller **can
+see**: the IMU still measures true gravity, so the board's attitude estimate
+is correct on a hill, and the slope shows up as an ordinary along-track force
+the balance loop already knows how to lean against. The two are not the same
+disturbance and they do not have the same tolerance.
+
+Measured: the board does not invert at any incline in the swept range, which
+reaches 24x the predicted 0.5 deg. Nothing in the ADR's acceptance matrix
+inverts on a hill.
+
+WHAT ACTUALLY BINDS, WHICH IS NOT INVERSION
+--------------------------------------------
+The board is a pitch regulator. It has no position loop and no speed loop --
+`MAX_GROUND_SPEED_M_S` shapes the *stick*, and a stick cap cannot brake
+against gravity. So on a slope:
+
+* **Station-keeping is zero at every nonzero incline.** Released with no
+  stick, the board rolls downhill and keeps accelerating, to 43 m/s on a
+  15 deg grade inside one 18.5 s schedule, with nothing in the host
+  intervening at any point. Measured acceleration is linear in `sin(phi)` at
+  0.70 g from 0.25 to 15 deg, the reduction being the wheel's rotational
+  inertia and the balancing lean. There is no incline small enough for a
+  stationary board to stay put.
+* **The board can arrest itself, but only up to a measured grade.** Under the
+  largest sustained braking this host ever commands on its own -- 0.6 of full
+  lean -- a downhill roll is arrested up to 6.5 deg and outrun at 7.0 deg.
+
+So the constraint an asset rule needs is **not only an angle**. A slope that
+is individually harmless produces an arbitrary speed if it is long enough,
+and speed is the axis on which nothing else in this repo is characterised.
+The rule needs an angle AND a run-out length, and this file measures the
+inputs to both.
+
+**A number this file deliberately does not give.** The steepest grade the
+board can CLIMB at full stick is somewhere between 4 and 7 deg, and it is not
+reported: the 18.5 s schedule is not long enough to tell a board that is
+climbing slowly from one that is about to slide back, and a number produced
+by squinting at that is worse than no number. It needs a longer scripted
+schedule, which is its own increment. It is also the least safety-relevant of
+the four -- a grade the board cannot climb is a stuck player, not a fall.
+
+WHAT THIS FILE IS NOT
+---------------------
+None of these numbers is an acceptance threshold, and none may be promoted to
+one. ADR-0011 forbids deriving a bar from whatever happened to pass -- that
+is what criterion (f) exists to prevent -- and a tolerance requirement comes
+from the environment (what the world author needs to build) rather than from
+the vehicle (what it happened to survive). These are measured
+characterisations, offered as the input the asset rule is written FROM. The
+rule itself is the world-authoring role's to write, and it should sit inside
+these numbers with whatever margin that role judges, not on them.
+
+METHOD
+------
+A slope is applied by rotating `mjModel::opt.gravity` about `Y` at plant open
+(`--incline-deg`, `sim_backend::SimBackend::set_incline_deg`). A flat ground
+plane under gravity tilted by `phi` and a ground plane inclined by `phi` under
+vertical gravity are the same rigid-body problem in two frames, so this is a
+real slope rather than an approximation of one -- and unlike an external force
+on one body it applies the along-slope component to every body's own mass.
+Positive is uphill in the board's forward direction.
+`test_the_incline_knob_is_a_slope_and_not_something_else` is the positive
+control for all of it.
+
+Every run is `--scripted-scenario ... --free-run`, so the whole sweep is
+deterministic and costs seconds. THE BINARY MUST BE BUILT -- same rule as
+`tests/test_cmd_envelope_reserve.py`, for the same reason.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+#: Ports well away from both the documented 9601/9602 and the ones
+#: `test_cmd_envelope_reserve.py` uses, so a parallel run cannot collide.
+STATE_OUT = "127.0.0.1:19603"
+INPUT_IN = "127.0.0.1:19604"
+
+#: Pitch beyond which the board is unambiguously going over. Measured against
+#: the SLOPE normal, which is what MuJoCo reports under this transform; at the
+#: inclines swept here the difference from true vertical is irrelevant at 90
+#: deg.
+INVERTED_DEG = 90.0
+
+#: `overboard_rider.xml`'s own `<option gravity>` magnitude. Used only to
+#: predict the free-roll acceleration this file checks the slope against, so
+#: it must be the MODEL's value and not standard gravity.
+G_MODEL_M_S2 = 9.81
+
+#: Where `SPEED_CAP_MARGIN_M_S` starts withdrawing accelerating authority
+#: (`host.rs`: `MAX_GROUND_SPEED_M_S` 9.34 - `SPEED_CAP_MARGIN_M_S` 1.0).
+#: Used here only as the reference speed for the free-roll run-out figures --
+#: the first speed at which the board is outside its shaped envelope. The cap
+#: itself scales the STICK and so does nothing on a released run.
+SPEED_CAP_ONSET_M_S = 8.34
+
+#: The scripted schedule runs 15.5 s plus a 3 s tail. Speed trend is taken
+#: over the last 2 s of that.
+RUN_END_S = 18.5
+TREND_WINDOW_S = 2.0
+
+
+def _run(tmp_path: Path, name: str, scenario: str, **kw) -> list[dict]:
+    """One deterministic free run; returns the per-cycle trace.
+
+    Through `cargo run` rather than the raw binary for the reason
+    `test_cmd_envelope_reserve.py` documents: Cargo puts the linked
+    libmujoco's `OUT_DIR` on the dynamic loader path.
+    """
+    out = tmp_path / f"{name}.csv"
+    argv = [
+        "cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+        "--scripted-scenario", scenario,
+        "--free-run",
+        "--stats-path", "none",
+        "--pitch-source", "estimator",
+        "--state-out-addr", STATE_OUT,
+        "--input-in-addr", INPUT_IN,
+        "--trace-csv", str(out),
+    ]
+    for flag, value in kw.items():
+        if value is None:
+            continue
+        argv += [f"--{flag.replace('_', '-')}", str(value)]
+    proc = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert proc.returncode == 0, f"sim-host failed:\n{proc.stderr[-4000:]}"
+    with out.open() as f:
+        return [{k: float(v) for k, v in row.items()} for row in csv.DictReader(f)]
+
+
+def _inversion_time(rows):
+    return next((r["sim_time_s"] for r in rows if abs(r["truth_pitch_deg"]) > INVERTED_DEG), None)
+
+
+def _at(rows, t):
+    return min(rows, key=lambda r: abs(r["sim_time_s"] - t))
+
+
+def _released(tmp_path, name, incline_deg):
+    """Board released on a slope with the stick at zero."""
+    return _run(tmp_path, name, "full-stick", incline_deg=incline_deg, cmd_reserve=0.0)
+
+
+def test_the_sim_host_binary_is_actually_built():
+    assert (REPO / "target" / "release" / "sim-host").exists(), (
+        "sim-host is not built, so this whole gate would be vacuous. Run:\n"
+        "    cargo build --release -p sim-host --bin sim-host"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The positive control: is `--incline-deg` really a slope?
+# ---------------------------------------------------------------------------
+
+
+def test_the_incline_knob_is_a_slope_and_not_something_else(tmp_path):
+    """Everything below is worthless if this knob does something other than
+    what it claims, and "I rotated the gravity vector" is exactly the kind of
+    change that can look plausible while being wrong by a sign or a frame.
+
+    Three independent checks, none of which can pass by accident:
+
+    1. **Zero is a no-op.** Not merely "flat", but bit-identical to a run that
+       never passed the flag -- the gravity vector is left alone rather than
+       rewritten with its own value.
+    2. **A released board accelerates downhill at `g sin(phi)`, times a
+       constant.** The constant is below 1 because the wheel's rotational
+       inertia and the balancing lean both resist, and it must be the SAME
+       constant at every angle -- proportionality to `sin(phi)` over a 40x
+       range is a property a mis-scaled or mis-framed transform does not have.
+    3. **The sign is right.** Positive is uphill in the forward direction, so
+       a released board rolls BACKWARD.
+    """
+    flat = _run(tmp_path, "ctrl_flat", "full-stick", incline_deg=0.0)
+    unset = _run(tmp_path, "ctrl_unset", "full-stick")
+    assert [list(r.values()) for r in flat] == [list(r.values()) for r in unset], (
+        "--incline-deg 0 is not bit-identical to omitting the flag, so the "
+        "knob perturbs a flat run and every other test in this repo is now "
+        "measuring something slightly different"
+    )
+
+    print("\nfree-roll check -- a released board on a slope:")
+    ratios = []
+    for phi in (0.25, 1.0, 5.0, 10.0):
+        rows = _released(tmp_path, f"ctrl{phi}", phi)
+        v0, v1 = _at(rows, 0.5), _at(rows, 4.0)
+        dv = v1["forward_speed_m_s"] - v0["forward_speed_m_s"]
+        measured = dv / (v1["sim_time_s"] - v0["sim_time_s"])
+        free_roll = G_MODEL_M_S2 * math.sin(math.radians(phi))
+        ratios.append(abs(measured) / free_roll)
+        print(
+            f"  {phi:5.2f} deg: {measured:+.4f} m/s^2 measured, "
+            f"g sin(phi) = {free_roll:.4f}, ratio {abs(measured) / free_roll:.4f}"
+        )
+        assert measured < 0, (
+            f"at +{phi} deg (uphill forward) the board should roll BACKWARD; "
+            f"measured acceleration {measured:+.4f} m/s^2. The sign of the "
+            "gravity rotation is wrong."
+        )
+
+    spread = max(ratios) - min(ratios)
+    print(f"  ratio spread across a 40x range of angle: {spread:.4f}")
+    assert spread < 0.02, (
+        f"acceleration is not proportional to sin(phi) (ratios {ratios}). "
+        "Whatever --incline-deg is doing, it is not applying a uniform "
+        "gravitational field, and no number in this file means anything."
+    )
+    assert 0.5 < min(ratios) < 1.0, (
+        f"a released board accelerates at {min(ratios):.3f} of g sin(phi). "
+        "Above 1 is unphysical for a body with rotational inertia; far below "
+        "it would mean something is braking that should not be."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inversion: the thing the prediction was about, and the thing that does not
+# turn out to bind
+# ---------------------------------------------------------------------------
+
+
+def test_adr_0011s_acceptance_matrix_does_not_invert_on_any_swept_incline(tmp_path):
+    """The prediction was "under 0.5 deg". Measured, nothing inverts at 24x it.
+
+    Both deployed-path entries of ADR-0011's criterion (a) matrix are re-run
+    across the sweep. The kerb-strike entry is not: it fails on flat ground
+    already (`tests/test_cmd_envelope_reserve.py` records it as a strict
+    xfail), so running it on a hill would measure nothing new.
+
+    Asserted as "no inversion anywhere in the swept range" rather than as a
+    bisected boundary. A boundary here would be a number begging to be read as
+    a tolerance, and this file's whole point is that inversion is not what
+    binds -- see `test_a_released_board_does_not_stay_put_on_any_incline`.
+    """
+    for scenario, sweep in (
+        ("full-stick", (-12.0, -8.0, -4.0, -1.0, 0.0, 1.0, 4.0, 8.0, 12.0)),
+        ("stick-reversal", (-8.0, -4.0, -2.0, -0.5, 0.0, 0.5, 2.0, 4.0, 8.0)),
+    ):
+        print(f"\n{scenario} on a slope (+ uphill):")
+        for phi in sweep:
+            rows = _run(tmp_path, f"m{scenario}{phi}", scenario, incline_deg=phi)
+            t = _inversion_time(rows)
+            peak_pitch = max(abs(r["truth_pitch_deg"]) for r in rows)
+            peak_amps = max(abs(r["proposed_amps"]) for r in rows)
+            print(
+                f"  {phi:+6.1f} deg: {'held' if t is None else f'INVERTED at {t:.2f} s'}, "
+                f"peak lean {peak_pitch:5.2f} deg, peak demand {peak_amps:5.2f} A"
+            )
+            assert t is None, (
+                f"{scenario} inverted at {phi:+} deg of incline. That is a "
+                "real change in the world-authoring input and the number in "
+                "this file's docstring is now wrong -- re-measure it, and tell "
+                "whoever owns the asset rule."
+            )
+
+
+# ---------------------------------------------------------------------------
+# What actually binds
+# ---------------------------------------------------------------------------
+
+
+def test_a_released_board_does_not_stay_put_on_any_incline(tmp_path):
+    """Station-keeping tolerance is ZERO, and this is the finding that most
+    changes what an asset rule has to say.
+
+    The board has no position loop and no speed loop. `MAX_GROUND_SPEED_M_S`
+    shapes the STICK, and a stick cap cannot brake against gravity, so a board
+    left alone on any slope rolls away and keeps accelerating. The asset rule
+    therefore cannot be written as "slopes up to X deg are fine": a 0.25 deg
+    slope is fine for a metre and not fine for a kilometre.
+
+    Run DOWNHILL-FORWARD (negative incline) on purpose. Rolling backwards the
+    board leaves the drivable corridor after `CORRIDOR_X_MAX_M` = 50 m and the
+    host applies `CORRIDOR_BRAKE_LEAN`, which would arrest the roll and make
+    this test measure the corridor brake instead of the absence of a speed
+    loop. Forward there are 700 m, which no run here comes close to using, and
+    the test asserts directly that the host never intervened.
+
+    The run-out distances printed alongside are kinematics from the measured
+    acceleration, and are labelled derived rather than measured because the
+    18.5 s schedule is far too short to drive them.
+    """
+    print("\nreleased on a downgrade, does it stay put?")
+    print(f"{'incline':>8} {'a (m/s^2)':>10} {'v at end':>9} {'still gaining':>14} "
+          f"{'run-out to cap':>15}")
+    for phi in (-0.25, -0.5, -1.0, -3.0, -7.0, -15.0):
+        rows = _released(tmp_path, f"stay{phi}", phi)
+        assert all(r["applied_fore_aft"] == 0.0 for r in rows), (
+            f"at {phi} deg the host applied a nonzero fore/aft command on a run "
+            "whose stick is at zero -- the corridor brake or the speed cap has "
+            "intervened, and this run is measuring that instead of free roll"
+        )
+        v0, v1 = _at(rows, 0.5), _at(rows, 4.0)
+        a = abs(v1["forward_speed_m_s"] - v0["forward_speed_m_s"]) / (
+            v1["sim_time_s"] - v0["sim_time_s"]
+        )
+        end = _at(rows, RUN_END_S)
+        prev = _at(rows, RUN_END_S - TREND_WINDOW_S)
+        gaining = abs(end["forward_speed_m_s"]) > abs(prev["forward_speed_m_s"])
+        print(
+            f"{phi:8.2f} {a:10.4f} {abs(end['forward_speed_m_s']):9.3f} "
+            f"{str(gaining):>14} {SPEED_CAP_ONSET_M_S**2 / (2 * a):12.0f} m*"
+        )
+        assert gaining, (
+            f"at {phi} deg the board stopped gaining speed with the stick at "
+            "zero. Something now supplies station-keeping authority that did "
+            "not before, and this file's central claim needs re-deriving."
+        )
+    print("  * distance from rest to speed-cap onset, derived from the measured")
+    print("    acceleration -- NOT measured: the 18.5 s schedule is far too short.")
+
+
+def test_the_downgrade_at_which_full_braking_stops_arresting_the_roll(tmp_path):
+    """The steepest sustained downgrade the board can arrest itself on.
+
+    Since nothing arrests a free roll (above), the useful number is the one
+    that applies when the board *does* brake. This measures it using the
+    host's own emergency authority: leave the drivable corridor and the host
+    applies `CORRIDOR_BRAKE_LEAN` = 0.6 of full lean against the direction of
+    travel, sustained, for the rest of the run. It is the largest sustained
+    braking command this host ever issues on its own.
+
+    **This is the corridor brake and not the speed cap**, which is worth
+    stating because the two are easy to confuse here and the first version of
+    this measurement confused them. The speed cap scales the stick; on a run
+    whose stick is zero it has nothing to scale and contributes nothing. The
+    arrest visible below is `applied_fore_aft` going to exactly 0.6, and the
+    test asserts that is what happened rather than assuming it.
+
+    Classification, stated before the numbers so it cannot be fitted to them:
+    once the brake is applied, ARRESTED if speed is falling over the final
+    `TREND_WINDOW_S`, OUTRUN if it is still rising.
+
+    Deliberately NOT bisected finer than the 0.5 deg sweep. A more precise
+    answer would be a number precise enough to be mistaken for a limit, which
+    is exactly what this file must not produce.
+    """
+    print("\nrolling downhill under the host's own full braking:")
+    print(f"{'incline':>8} {'v at end':>9} {'trend':>8}  verdict")
+    arrested, outrun = [], []
+    for phi in (4.0, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 9.0):
+        rows = _released(tmp_path, f"brake{phi}", phi)
+        braking = [r for r in rows if r["applied_fore_aft"] != 0.0]
+        assert braking, f"at {phi} deg the corridor brake never engaged"
+        assert all(abs(abs(r["applied_fore_aft"]) - 0.6) < 1e-6 for r in braking), (
+            "the sustained command here is no longer CORRIDOR_BRAKE_LEAN, so "
+            "this test is measuring a different braking authority than it says"
+        )
+        end = _at(rows, RUN_END_S)
+        prev = _at(rows, RUN_END_S - TREND_WINDOW_S)
+        v_end = abs(end["forward_speed_m_s"])
+        trend = (v_end - abs(prev["forward_speed_m_s"])) / TREND_WINDOW_S
+        if trend > 0.0:
+            verdict, _ = "OUTRUN", outrun.append(phi)
+        else:
+            verdict, _ = "arrested", arrested.append(phi)
+        print(f"{phi:8.2f} {v_end:9.3f} {trend:+8.3f}  {verdict}")
+
+    assert arrested and outrun, (
+        "the sweep no longer straddles the boundary it exists to locate; "
+        f"arrested={arrested}, outrun={outrun}. Widen the sweep and re-measure."
+    )
+    assert max(arrested) < min(outrun), (
+        f"arrested and outrun inclines interleave (arrested={arrested}, "
+        f"outrun={outrun}), so there is no single boundary and the asset rule "
+        "cannot be written from one angle. That is a real finding, not a test "
+        "defect -- report it rather than adjusting the sweep."
+    )
+    print(
+        f"\nMEASURED, and not a threshold: at 0.6 of full lean the board "
+        f"arrests a downhill roll up to {max(arrested):.1f} deg and is outrun "
+        f"at {min(outrun):.1f} deg. Sweep resolution 0.5 deg."
+    )


### PR DESCRIPTION
Closes #207. The controls half of what now clears the ADR-0011 hold.

The board survives full stick because the estimator supplies the lean the
acceleration physically requires — `atan(a/g)`, one radian per g, which is the
**same number** as ADR-0011's geometric 5.84 °/(m/s²) because it is the same
physics. Correct behaviour, arrived at by accident, and until this PR held in
place by nothing. This freezes and pins it.

## (f1) — the pin, and the instrument that had to be replaced to build it

The obvious instrument is a least-squares fit of the `est − truth` residual
against specific force across the acceleration ramp. Measuring it first showed
it is the **wrong** instrument: on one run the fitted slope moves **4.9 → 7.1
°/(m/s²)** across reasonable choices of fit window, because the filter's 2 s
time constant makes the residual lag the specific force throughout the ramp. A
band tight enough to be a pin would chatter on the window choice; a band loose
enough not to would detect nothing — which is what the shipped ±25% band was.

The identity is a **steady-state** statement, so it is now measured in steady
state: residual against `atan(a_unaided/g)` over a fixed late window.

| | measured |
|---|---|
| residual | **−2.5009°** |
| apparent vertical `atan(a_unaided/g)` | −2.4327° |
| ratio (1 rad/g holds iff this is 1) | **1.028** |
| unexplained static part | −0.068°, **2.8%** of the apparent-vertical term |

Trim pinned at **−2.501 ± 0.10°**.

## Where the band comes from — not from what passed

Measured in the (f2) work below: **shifting the trim 0.10° moves the
peak-demand slope 5.19–5.26%**, against the **5%** band that slope's own
provenance check allows. So 0.10° is the trim movement at which
`CMD_ENVELOPE_RESERVE` stops being derived from anything true. The pin fires
exactly where the derivation goes stale. **(f1) and (f2) are one pin seen
twice.**

The ±0.25° static-error characterisation is used **only** as a sanity check in
the safe direction — the band the derivation argument produced happens to sit
well inside it. Had the derivation produced a wider band the answer would have
been to look harder, not to borrow 0.25°. It is never asserted as a bar, per
the issue's explicit instruction and criterion (f)'s whole purpose.

## (f2) — the reserve is TRIM-derived, and that is now measured, not claimed

`test_f2_the_peak_demand_slope_is_trim_derived_not_geometry_derived` shifts the
trim by one pinned band and re-takes the slope: **41.967 → 39.790 (−5.19%) /
44.176 (+5.26%) A per unit stick.** A geometry-derived constant would not move
at all.

Doc comments carrying the superseded reading are corrected: the "accidental ~1
deg nose-down estimator bias" framing is gone from `CMD_ENVELOPE_RESERVE`,
`PitchSource`, `pitch_bias_deg` and the run loop, and `CMD_ENVELOPE_RESERVE`
now says plainly that it is trim-derived, does not travel to hardware or a
retuned filter, and that describing it otherwise is a rationalisation.

Also: the test's copy of `ACCEL_FF_GAIN_M_S2_PER_A` is now read out of
`host.rs` instead of duplicated, so a retune cannot leave the harness
measuring against a stale gain.

## Acceptance criterion 1 — proved by breaking CI, not by reading the test

> Demonstrate it by moving the trim on purpose and watching it go red —
> reading the test is not evidence it works.

Spike PR #214: `ACCEL_FF_GAIN_M_S2_PER_A` 0.0584 → 0.0650, a realistic
re-derivation (the constant is `kt / (r_eff · total mass)`). `sim` went **red**
on the trim pin. [Run](https://github.com/MikePaNtZ/overboard/actions/runs/30762664302/job/91535879744).
Closed without merging; branch deleted.

Two things fell out of it that are worth more than the pass/fail:

- **The sim is bit-identical across platforms.** Ubuntu runner
  `−2.6896194189755955°`, macOS arm64 `−2.6896°`. That was the open risk in a
  ±0.10° band on a 2.5° quantity, and it is answered.
- **A trim move of that size takes four other assertions with it** — the
  peak-demand slope fell to 29.20 A/unit against 42.03, the unshaped positive
  control stopped inverting the board, and the loss-of-authority warning
  stopped firing at all. The trim is load-bearing for most of what ADR-0011
  measures, and until now a change of this size could have landed green on the
  numbers that mattered.

## Incline tolerance — the prediction was wrong, and so was its premise

**This is the input the world-authoring constraint (ADR-0011 condition 2) was
blocked on, and the finding changes what the asset rule has to say.**

#207 predicted "under 0.5°", reasoning that a slope is an effective static
pitch disturbance. The middle step fails. A static pitch *estimate error* is a
signal the controller **cannot see** — it regulates a lie forever. A slope is
one it **can** see: the IMU still measures true gravity, so attitude is correct
on a hill and the slope arrives as an ordinary along-track force the balance
loop already leans against.

| | measured |
|---|---|
| ADR-0011 matrix inverts | **nowhere** in ±12° (hold) / ±8° (reversal) — ≥24× the prediction |
| station-keeping | **zero at every incline.** Released, free-rolls at 0.70·g·sin φ, 43 m/s on a 15° grade inside one 18.5 s schedule, nothing in the host intervening |
| self-arrest at 0.6 lean | arrested to **6.5°**, outrun at **7.0°** |

What binds is **not inversion — it is that there is no speed loop.**
`MAX_GROUND_SPEED_M_S` shapes the *stick*, and a stick cap cannot brake against
gravity. So the rule needs an angle **and a run-out length**: a 0.25° grade is
fine for a metre and not for a kilometre (~1159 m from rest to speed-cap onset).

None of these is an acceptance threshold, and `tests/test_incline_tolerance.py`
says so at length. They are the inputs the world-authoring role writes the rule
*from*, with whatever margin that role judges.

**Method.** `--incline-deg` rotates `mjModel::opt.gravity` at plant open. A flat
plane under tilted gravity and a tilted plane under vertical gravity are the
same rigid-body problem in two frames, so this is a real slope rather than an
approximation of one; it applies the along-slope component to every body's own
mass, which an external force on one body cannot; and it keeps the change out of
`sim/models/` (Mechanical's fidelity contract). A positive control asserts zero
is bit-identical to omitting the flag, that acceleration is proportional to
`sin φ` over a 40× range of angle, and that the sign is right.

**One trap recorded rather than left for the next session.** The first version
of the self-arrest measurement attributed the braking to the speed cap. It is
the **corridor brake** — roll backwards past `CORRIDOR_X_MAX_M` = 50 m and the
host applies `CORRIDOR_BRAKE_LEAN` = 0.6 for the rest of the run, which at 3°
happens within one schedule. Caught by looking at `applied_fore_aft`. The
free-roll test now runs downhill-**forward**, where there are 700 m, and
asserts `applied_fore_aft` stays zero throughout.

## Acceptance criteria

1. **A retune outside the band fails CI** — demonstrated on #214, not asserted. ✅
2. **The measured A/unit slope is asserted** — and its trim-dependence is now measured too. ✅
3. **The incline tolerance is a measured number with a stated method** — with the correction that the useful number is not the one the issue predicted. ✅
4. **No threshold derived from a passing measurement** — the band is derived from what a moved trim *breaks*; ±0.25° is used only as a one-way sanity check and never as a bar. ✅

## Deliberately not delivered, flagged rather than fudged

- **The steepest grade the board can climb at full stick.** Between 4° and 7°,
  and not reported: the 18.5 s schedule cannot distinguish a board climbing
  slowly from one about to slide back. Needs a longer scripted schedule — its
  own increment, and the least safety-relevant of the four (a grade the board
  cannot climb is a stuck player, not a fall).
- **The incline numbers are not mirrored into `docs/`.** A new file there is COO
  turf; the measurement lives in the test docstring on the same precedent as
  issue #24 AC5. Mirroring it is a COO call.
- **(f3), `θ_ref = atan(a_des/g)` as an explicit feedforward**, is untouched —
  ADR-0011 defers it and bundles it with the headroom fix. This PR makes the
  accident safe to stand on until then; it is not a substitute for it.

Full local suite: 325 passed, 6 xfailed. `cargo test --workspace`, `clippy
-D warnings`, `fmt --check` and `xtask gate` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)