### PR TITLE
Give braking its own command-envelope reserve -- 4.9% quicker stops, and where the input-side ceiling is

### DIFF
--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -8,11 +8,13 @@
 //! ```text
 //! sim-host [--duration-secs SECONDS] [--startup-kick]
 //!          [--state-out-addr ADDR] [--input-in-addr ADDR]
-//!          [--scripted-scenario default|s-curve|full-stick|stick-reversal]
+//!          [--scripted-scenario default|s-curve|full-stick|stick-reversal|
+//!                              brake-stop|brake-turn|cruise-turn]
 //!          [--stats-path PATH|none]
 //!          [--free-run] [--max-sim-secs SECONDS]
 //!          [--pitch-source estimator|truth] [--pitch-bias-deg DEGREES]
-//!          [--cmd-reserve FRACTION] [--incline-deg DEGREES]
+//!          [--cmd-reserve FRACTION] [--cmd-reserve-braking FRACTION]
+//!          [--incline-deg DEGREES]
 //!          [--disturbance t0,dur,fx,fy,fz,tx,ty,tz] [--trace-csv PATH]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
@@ -183,6 +185,25 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
                 cfg.cmd_envelope_reserve = Some(scale);
+                i += 2;
+            }
+            // Overrides CMD_ENVELOPE_RESERVE_BRAKING -- the reserve spent
+            // when the stick opposes the motion. Sweeping this measures what
+            // braking authority costs at ADR-0011's worst matrix point.
+            "--cmd-reserve-braking" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --cmd-reserve-braking needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(scale) = v.parse::<f32>() else {
+                    eprintln!("sim-host: --cmd-reserve-braking value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                if !(0.0..=1.0).contains(&scale) {
+                    eprintln!("sim-host: --cmd-reserve-braking must be within [0, 1], got {scale}");
+                    return ExitCode::FAILURE;
+                }
+                cfg.cmd_envelope_reserve_braking = Some(scale);
                 i += 2;
             }
             // A constant ground slope, degrees, positive uphill. ADR-0011's

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -383,6 +383,88 @@ const SPEED_CAP_ONSET_M_S: f32 = MAX_GROUND_SPEED_M_S - SPEED_CAP_MARGIN_M_S;
 /// problem, which is the only way a known failure stays known.
 const CMD_ENVELOPE_RESERVE: f32 = 0.80;
 
+/// The command-envelope reserve spent when the stick OPPOSES the current
+/// motion — i.e. when the rider is braking rather than accelerating.
+///
+/// # Why braking gets its own number at all
+///
+/// [`CMD_ENVELOPE_RESERVE`] was derived from a peak-demand slope measured on
+/// the **forward full-stick hold**, where the board accelerates from rest and
+/// full stick over-commands the envelope by 5%. Applying that same 0.80 to a
+/// braking command was never derived, only inherited: the shaping was one
+/// multiply and the sign never entered it. The cost is that the rider gets
+/// 80% of the lean they asked for when trying to stop, for a reason that only
+/// ever applied to setting off.
+///
+/// The CEO's report from driving the build is the ask this answers: *"you
+/// should be able to stop faster by leaning back [...] but we don't need to
+/// overdo it."*
+///
+/// # Why the test is OPPOSITION, not sign
+///
+/// The naive version of this is "aft stick gets more authority". That
+/// reintroduces the ADR-0011 defect in mirror image: full aft from rest is a
+/// backward standing start, which over-commands the envelope exactly as the
+/// forward one does. Braking is not a direction, it is a *relationship*
+/// between the command and the motion, so the test is `stick * speed < 0` —
+/// the same one the speed cap already uses.
+///
+/// # What it costs, and why this value
+///
+/// Braking authority is not free: it is spent out of the same envelope, and
+/// the worst point in ADR-0011's acceptance matrix — the full reverse-to-
+/// forward stick reversal at speed — is a braking event by this definition.
+/// Raising this constant eats that entry's headroom directly. Measured across
+/// the sweep in `tests/test_braking_authority.py`, and the value here is
+/// chosen to keep the reversal's measured margins clear rather than to
+/// maximise braking.
+///
+/// Deliberately NOT raised to 1.0. At 1.0 the braking command is unshaped,
+/// which reproduces the over-command the reserve exists to remove — the
+/// direction it acts in is the only thing that changed.
+const CMD_ENVELOPE_RESERVE_BRAKING: f32 = 0.85;
+
+/// Ground speed below which no command counts as braking, m/s.
+///
+/// Without this the opposition test fires on the standing start it is meant
+/// to exclude. **Measured, not guessed:** a full-stick launch from rest rocks
+/// the board BACKWARD to -0.085 m/s between t = 0.504 s and t = 1.112 s
+/// before it moves off, so for six tenths of a second the forward stick
+/// genuinely opposes the motion and would have drawn the braking reserve.
+/// That would have changed ADR-0011's `full-stick` acceptance run — the one
+/// the estimator trim and [`PEAK_DEMAND_A_PER_UNIT_STICK`] are both pinned
+/// against — for a manoeuvre with no braking in it at all.
+///
+/// 0.25 m/s is about 3x that transient. Well under walking pace, so no stop
+/// a rider would call a stop begins below it, and well above anything the
+/// launch rock produces. The property that matters is pinned by
+/// `the_braking_reserve_is_not_spent_on_a_standing_start`.
+const BRAKING_RESERVE_MIN_SPEED_M_S: f32 = 0.25;
+
+/// The braking reserve's two bounds, enforced by the COMPILER.
+///
+/// Equal to [`CMD_ENVELOPE_RESERVE`] would make the constant inert; 1.0 would
+/// reproduce the over-command the reserve exists to remove, with only the
+/// direction it acts in changed. And a full braking command must not demand
+/// the whole envelope on its own, or there is nothing left for the
+/// disturbance the reserve is named for.
+const _: () = {
+    assert!(
+        CMD_ENVELOPE_RESERVE_BRAKING > CMD_ENVELOPE_RESERVE,
+        "CMD_ENVELOPE_RESERVE_BRAKING at or below CMD_ENVELOPE_RESERVE buys nothing -- \
+         delete it rather than shipping a constant that does not act"
+    );
+    assert!(
+        CMD_ENVELOPE_RESERVE_BRAKING < 1.0,
+        "an unshaped braking command is exactly the over-command ADR-0011's reserve \
+         was introduced to remove"
+    );
+    assert!(
+        CMD_ENVELOPE_RESERVE_BRAKING * PEAK_DEMAND_A_PER_UNIT_STICK < MAX_CURRENT_A,
+        "a full braking command must not demand the whole actuator envelope on its own"
+    );
+};
+
 /// The measurement [`CMD_ENVELOPE_RESERVE`] is derived FROM, in amps of peak
 /// fore/aft current demand per unit of fore/aft stick.
 ///
@@ -825,6 +907,18 @@ pub struct HostConfig {
     /// shipped constant.
     pub cmd_envelope_reserve: Option<f32>,
 
+    /// **Verification only.** Overrides [`CMD_ENVELOPE_RESERVE_BRAKING`] --
+    /// the reserve spent when the stick opposes the motion. Sweeping this is
+    /// how that constant's cost against ADR-0011's worst matrix point is
+    /// measured rather than assumed.
+    ///
+    /// `None` falls back to [`HostConfig::cmd_envelope_reserve`] if THAT is
+    /// set, and only then to the shipped constant. So `--cmd-reserve X` on
+    /// its own still scales the whole fore/aft command, which is what every
+    /// sweep written before braking had its own reserve assumes -- including
+    /// `--cmd-reserve 0` meaning "no stick at all".
+    pub cmd_envelope_reserve_braking: Option<f32>,
+
     /// **Verification only.** A scheduled external disturbance -- see
     /// [`Disturbance`]. `None` applies none, which is the deployed
     /// behaviour.
@@ -924,6 +1018,7 @@ impl Default for HostConfig {
             pitch_bias_deg: 0.0,
             free_run: false,
             cmd_envelope_reserve: None,
+            cmd_envelope_reserve_braking: None,
             disturbance: None,
             incline_deg: 0.0,
             trace_path: None,
@@ -1084,6 +1179,34 @@ fn shape_fore_aft_command(stick: f32, reserve: f32) -> f32 {
     stick * reserve
 }
 
+/// Like [`shape_fore_aft_command`], but spends the BRAKING reserve when the
+/// command opposes the current motion. See [`CMD_ENVELOPE_RESERVE_BRAKING`].
+///
+/// The opposition test is `stick * speed < 0`, deliberately the same one
+/// [`speed_capped_fore_aft`] already uses, so there is one definition of
+/// "this command opposes the motion" in this file rather than two that can
+/// drift apart.
+///
+/// **At rest the accelerating reserve applies** (`stick * 0.0 >= 0.0`), which
+/// is the case that matters for safety: full aft from a standstill is a
+/// backward standing start, not a stop, and it over-commands the envelope
+/// exactly as the forward one does. That is the mirror of the defect
+/// ADR-0011 was called for, and it keeps the accelerating reserve.
+fn shape_fore_aft_command_directional(
+    stick: f32,
+    reserve: f32,
+    braking_reserve: f32,
+    last_forward_speed_m_s: f32,
+) -> f32 {
+    if last_forward_speed_m_s.abs() > BRAKING_RESERVE_MIN_SPEED_M_S
+        && stick * last_forward_speed_m_s < 0.0
+    {
+        shape_fore_aft_command(stick, braking_reserve)
+    } else {
+        shape_fore_aft_command(stick, reserve)
+    }
+}
+
 /// The speed cap's authority ramp, as a function -- unchanged in behaviour,
 /// extracted so ADR-0011 criterion (a)'s reversal entry can be stated as a
 /// unit test as well as a sim run.
@@ -1228,6 +1351,16 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     // HostConfig::cmd_envelope_reserve, which is how the constant's own
     // provenance measurement is taken).
     let cmd_envelope_reserve = cfg.cmd_envelope_reserve.unwrap_or(CMD_ENVELOPE_RESERVE);
+    // `--cmd-reserve` alone still means "scale the WHOLE fore/aft command by
+    // this", which is what every sweep that predates the braking reserve
+    // assumes -- `PEAK_DEMAND_A_PER_UNIT_STICK`'s provenance sweep among them,
+    // and `--cmd-reserve 0` as the way to say "no stick at all". Without this
+    // fallback a run asking for zero stick still gets a braking command the
+    // moment the board rolls backwards, which is exactly how it was found.
+    let cmd_envelope_reserve_braking = cfg
+        .cmd_envelope_reserve_braking
+        .or(cfg.cmd_envelope_reserve)
+        .unwrap_or(CMD_ENVELOPE_RESERVE_BRAKING);
     let pitch_bias_rad = cfg.pitch_bias_deg.to_radians();
     // Low-passed |proposed current| / MAX_CURRENT_A. Starts at zero, which is
     // true: an unarmed board at rest is asking for nothing.
@@ -1358,7 +1491,16 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // measured full-stick effect on this geometry is 0.03 deg of roll
         // (see ROLL_FULL_YAW_AUTHORITY_RAD) and which consumes no wheel
         // torque at all. Scaling it would cost steering feel to buy nothing.
-        let weight_shift_fore_aft = shape_fore_aft_command(stick_fore_aft, cmd_envelope_reserve);
+        //
+        // Braking spends its own reserve (CMD_ENVELOPE_RESERVE_BRAKING).
+        // Gated on `last_forward_speed_m_s` -- one cycle old, the same lag
+        // the speed cap below runs on, and for the same reason.
+        let weight_shift_fore_aft = shape_fore_aft_command_directional(
+            stick_fore_aft,
+            cmd_envelope_reserve,
+            cmd_envelope_reserve_braking,
+            last_forward_speed_m_s,
+        );
 
         // `arm`/`reset` bits: accepted and tracked, logged on change rather
         // than every tick. Neither gates anything yet -- the host self-arms
@@ -2105,9 +2247,90 @@ mod tests {
             assert_eq!(
                 shape_fore_aft_command(-u, CMD_ENVELOPE_RESERVE),
                 -shaped,
-                "u={u}: braking authority must be shaped exactly like driving authority; \
-                 a one-sided cap is an asymmetric-authority bug that only shows up under a \
-                 hard recovery in one direction"
+                "u={u}: at a given reserve the shaping must not depend on the SIGN of the \
+                 stick; a one-sided cap is an asymmetric-authority bug that only shows up \
+                 under a hard recovery in one direction"
+            );
+        }
+    }
+
+    /// The braking reserve is not a one-sided cap either -- the property the
+    /// test above protects still holds, one level up.
+    ///
+    /// `shape_fore_aft_command_directional` is asymmetric in
+    /// (stick, motion) TOGETHER, not in the sign of the stick: braking is a
+    /// relationship between the command and the motion. So flipping both
+    /// signs must give exactly the mirrored command, at every speed. A board
+    /// that stopped harder going forwards than backwards would be the
+    /// asymmetric-authority bug in a new place.
+    #[test]
+    fn the_braking_reserve_is_symmetric_under_flipping_stick_and_motion_together() {
+        for &v in &[0.0f32, 0.1, 0.25, 0.3, 1.0, 5.0, 9.34, 12.0] {
+            for &u in &[0.0f32, 0.1, 0.5, 1.0] {
+                let forward = shape_fore_aft_command_directional(
+                    u,
+                    CMD_ENVELOPE_RESERVE,
+                    CMD_ENVELOPE_RESERVE_BRAKING,
+                    v,
+                );
+                let mirrored = shape_fore_aft_command_directional(
+                    -u,
+                    CMD_ENVELOPE_RESERVE,
+                    CMD_ENVELOPE_RESERVE_BRAKING,
+                    -v,
+                );
+                assert_eq!(
+                    forward, -mirrored,
+                    "u={u}, v={v}: braking is not mirror-symmetric"
+                );
+            }
+        }
+    }
+
+    /// Below the speed gate NOTHING draws the braking reserve, whatever the
+    /// signs say.
+    ///
+    /// This is the property that keeps ADR-0011's `full-stick` acceptance run
+    /// -- the run the estimator trim and `PEAK_DEMAND_A_PER_UNIT_STICK` are
+    /// both pinned against -- bit-identical under any braking reserve. The
+    /// launch transient really does move the board backward under forward
+    /// stick (measured: to -0.085 m/s for six tenths of a second), so without
+    /// the gate that run would silently become a braking run.
+    #[test]
+    fn the_braking_reserve_is_not_spent_on_a_standing_start() {
+        // Every speed here is inside the gate, and -0.085 is the measured
+        // launch-transient extreme the gate exists to cover.
+        for &v in &[0.0f32, -0.085, 0.085, -0.24, 0.24] {
+            for &u in &[-1.0f32, -0.5, 0.5, 1.0] {
+                assert_eq!(
+                    shape_fore_aft_command_directional(
+                        u,
+                        CMD_ENVELOPE_RESERVE,
+                        CMD_ENVELOPE_RESERVE_BRAKING,
+                        v,
+                    ),
+                    shape_fore_aft_command(u, CMD_ENVELOPE_RESERVE),
+                    "u={u} at {v} m/s drew the braking reserve below the gate"
+                );
+            }
+        }
+    }
+
+    /// Opposing the motion above the gate DOES draw it, or the constant is
+    /// inert. The companion to the test above: together they pin both sides
+    /// of the gate rather than only the safe one.
+    #[test]
+    fn opposing_the_motion_above_the_gate_draws_the_braking_reserve() {
+        for &v in &[0.3f32, 1.0, 5.0, 9.34] {
+            assert_eq!(
+                shape_fore_aft_command_directional(
+                    -1.0,
+                    CMD_ENVELOPE_RESERVE,
+                    CMD_ENVELOPE_RESERVE_BRAKING,
+                    v,
+                ),
+                -CMD_ENVELOPE_RESERVE_BRAKING,
+                "full aft at {v} m/s forward did not draw the braking reserve"
             );
         }
     }

--- a/crates/sim-host/src/scenario.rs
+++ b/crates/sim-host/src/scenario.rs
@@ -262,12 +262,138 @@ pub const STICK_REVERSAL_SCHEDULE: Schedule = &[
     (30.5, 32.5, 0.0, 0.0, 0.0, "release"),
 ];
 
+// --- Braking authority: the CEO's report from driving the build ----------
+//
+// "I would say you should be able to stop faster by leaning back [...] but in
+// general I should be able to cut a tight turn by braking and turning at the
+// same time while keeping speed."
+//
+// Neither of those is measurable against the schedules above: `full-stick`
+// only accelerates, and `stick-reversal` slams through zero into a reverse
+// standing start, so the stop is over before it can be measured and is then
+// buried under a re-acceleration. These two isolate the stop.
+
+/// How long the two braking schedules build speed before braking. Long
+/// enough to settle at the speed cap on the shipped reserve (the board
+/// reaches ~9.15 m/s at ~12 s), so the brake starts from cruise rather than
+/// from the middle of an acceleration ramp.
+pub const BRAKE_BUILD_S: f64 = 12.0;
+
+/// How long the brake is held. Deliberately long enough to carry the board
+/// through zero and into reverse: the stop itself is the measurement, and
+/// cutting the schedule at the stop would hide anything that happens right
+/// after it.
+pub const BRAKE_HOLD_S: f64 = 8.0;
+
+/// **Stop from cruise.** Build to the speed cap at full stick, then full aft
+/// stick and hold. The reference for "how fast can this thing stop".
+pub const BRAKE_STOP_SCHEDULE: Schedule = &[
+    (0.0, ACCEPTANCE_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
+    (
+        ACCEPTANCE_SETTLE_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S,
+        1.0,
+        0.0,
+        0.0,
+        "build to the speed cap",
+    ),
+    (
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S,
+        -1.0,
+        0.0,
+        0.0,
+        "full aft stick (brake to a stop, then reverse)",
+    ),
+    (
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S + 2.0,
+        0.0,
+        0.0,
+        0.0,
+        "release",
+    ),
+];
+
+/// **Brake and turn together**, which is the manoeuvre the CEO reported as
+/// not working: identical to [`BRAKE_STOP_SCHEDULE`] except that full steer
+/// and full lateral lean go in at the same instant as the brake.
+///
+/// Carrying a yaw channel into a measurement is normally something this
+/// module refuses (see the acceptance-matrix note above), and the reason
+/// stands: yaw here is kinematically injected and declared non-physical. It
+/// is admitted HERE because the question being asked is explicitly about
+/// feel — does braking cost the turn, does turning cost the stop — and that
+/// question does not exist without the yaw channel. Nothing measured on this
+/// schedule may be cited as a stability result.
+pub const BRAKE_TURN_SCHEDULE: Schedule = &[
+    (0.0, ACCEPTANCE_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
+    (
+        ACCEPTANCE_SETTLE_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S,
+        1.0,
+        0.0,
+        0.0,
+        "build to the speed cap",
+    ),
+    (
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S,
+        -1.0,
+        1.0,
+        1.0,
+        "full aft stick AND full steer (brake into a turn)",
+    ),
+    (
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S + 2.0,
+        0.0,
+        0.0,
+        0.0,
+        "release",
+    ),
+];
+
+/// **Turn at cruise, no brake** — the control for [`BRAKE_TURN_SCHEDULE`].
+/// Without it, "the turn is tighter when braking" has nothing to be tighter
+/// than.
+pub const CRUISE_TURN_SCHEDULE: Schedule = &[
+    (0.0, ACCEPTANCE_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
+    (
+        ACCEPTANCE_SETTLE_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S,
+        1.0,
+        0.0,
+        0.0,
+        "build to the speed cap",
+    ),
+    (
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S,
+        1.0,
+        1.0,
+        1.0,
+        "hold speed AND full steer (turn at cruise)",
+    ),
+    (
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S,
+        ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S + BRAKE_HOLD_S + 2.0,
+        0.0,
+        0.0,
+        0.0,
+        "release",
+    ),
+];
+
 /// Every schedule a `--scenario`/`--scripted-scenario` flag accepts, by name.
 pub const BY_NAME: &[(&str, Schedule)] = &[
     ("default", DEFAULT_SCHEDULE),
     ("s-curve", S_CURVE_SCHEDULE),
     ("full-stick", FULL_STICK_SCHEDULE),
     ("stick-reversal", STICK_REVERSAL_SCHEDULE),
+    ("brake-stop", BRAKE_STOP_SCHEDULE),
+    ("brake-turn", BRAKE_TURN_SCHEDULE),
+    ("cruise-turn", CRUISE_TURN_SCHEDULE),
 ];
 
 /// Looks up a schedule by its command-line name.

--- a/tests/test_braking_authority.py
+++ b/tests/test_braking_authority.py
@@ -1,0 +1,371 @@
+"""Braking authority: what it buys, what it costs, and where the ceiling is.
+
+The CEO drove the build and reported two things:
+
+    "I would say you should be able to stop faster by leaning back. hopefully
+    you can tune that up on the input side. but we dont need to overdo it. but
+    in general i should be able to cut a tight turn by breaking and turning at
+    same time while keeping speed."
+
+This file is the measurement behind the answer to both.
+
+THE CHANGE THIS PINS
+--------------------
+`CMD_ENVELOPE_RESERVE` = 0.80 was derived from a peak-demand slope measured on
+the **forward full-stick hold** (ADR-0011). It was then applied to every
+fore/aft command including braking, which was never derived -- the shaping was
+one multiply and the sign never entered it. `CMD_ENVELOPE_RESERVE_BRAKING`
+gives braking its own number, spent only when the stick opposes the motion.
+
+WHY THE OPPOSITION TEST AND THE SPEED GATE BOTH MATTER
+-------------------------------------------------------
+"Aft stick gets more authority" would reintroduce ADR-0011's defect in mirror
+image: full aft from rest is a backward standing start, and it over-commands
+the envelope exactly as the forward one does. So the test is `stick * speed <
+0` -- braking is a relationship, not a direction.
+
+The speed gate then excludes the standing start proper. A full-stick launch
+rocks the board backward to -0.085 m/s for six tenths of a second before it
+moves off, and without the gate that transient draws the braking reserve --
+silently changing ADR-0011's `full-stick` run, which is the run the estimator
+trim and `PEAK_DEMAND_A_PER_UNIT_STICK` are both pinned against.
+`test_the_pinned_adr_0011_runs_are_untouched_by_braking_authority` is the
+guard, and it is the most important test in this file.
+
+THE FINDING THAT MATTERS MORE THAN THE TUNING
+----------------------------------------------
+**The stop is lean-rate limited, not envelope limited.** Half a second after
+the stick is slammed to full aft from 9.68 m/s, the board has produced about
+3 A of braking out of 40 available; it takes ~2 s to reach 57% of the
+envelope, and the peak demand of the whole schedule occurs 8 s later during
+the reverse standing start, not during the stop at all.
+
+That is why scaling the command buys so little: scaling raises the FINAL
+lean, and the stopping distance is spent in the first second, at nearly zero
+braking effort, at the highest speed. The dead time is structural -- the only
+thing that leans this board is ballast mass being dragged fore/aft, and the
+balance regulator actively resists it, because it is regulating pitch to zero
+and has no lean setpoint.
+
+The fix for that is already named in ADR-0011 and deliberately deferred:
+criterion (f3), `theta_ref = atan(a_des / g)` as an explicit lean feedforward.
+Nothing on the input side substitutes for it, and this file exists partly to
+document that the input side has been tried and measured.
+
+NOTHING HERE IS AN ACCEPTANCE THRESHOLD.
+The stop times and distances are characterisations of current feel. ADR-0011
+forbids deriving a bar from whatever happened to pass, and a stopping-distance
+requirement would have to come from the game design, not from the vehicle.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+HOST_RS = REPO / "crates" / "sim-host" / "src" / "host.rs"
+
+STATE_OUT = "127.0.0.1:19605"
+INPUT_IN = "127.0.0.1:19606"
+
+INVERTED_DEG = 90.0
+MAX_CURRENT_A = 40.0
+KT_NM_PER_A = 0.7
+KP_NM_PER_RAD = 140.0
+PITCH_CEILING_DEG = math.degrees(MAX_CURRENT_A * KT_NM_PER_A / KP_NM_PER_RAD)
+
+#: `ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S` from `scenario.rs` -- when the brake
+#: goes in on `brake-stop`/`brake-turn`.
+BRAKE_T0_S = 12.5
+
+
+def _rust_constant(name: str) -> float:
+    import re
+
+    m = re.search(rf"^const {name}: f32 = ([0-9.]+);", HOST_RS.read_text(), re.M)
+    assert m is not None, f"{name} is not a plain f32 const in {HOST_RS}"
+    return float(m.group(1))
+
+
+def _run(tmp_path: Path, name: str, scenario: str, **kw) -> list[dict]:
+    out = tmp_path / f"{name}.csv"
+    argv = [
+        "cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+        "--scripted-scenario", scenario,
+        "--free-run",
+        "--stats-path", "none",
+        "--pitch-source", "estimator",
+        "--state-out-addr", STATE_OUT,
+        "--input-in-addr", INPUT_IN,
+        "--trace-csv", str(out),
+    ]
+    for flag, value in kw.items():
+        if value is None:
+            continue
+        argv += [f"--{flag.replace('_', '-')}", str(value)]
+    proc = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert proc.returncode == 0, f"sim-host failed:\n{proc.stderr[-4000:]}"
+    with out.open() as f:
+        return [{k: float(v) for k, v in row.items()} for row in csv.DictReader(f)]
+
+
+def _inversion_time(rows):
+    return next((r["sim_time_s"] for r in rows if abs(r["truth_pitch_deg"]) > INVERTED_DEG), None)
+
+
+def _healthy(rows):
+    t = _inversion_time(rows)
+    return [r for r in rows if t is None or r["sim_time_s"] < t]
+
+
+def _at(rows, t):
+    return min(rows, key=lambda r: abs(r["sim_time_s"] - t))
+
+
+def _stop(rows):
+    """`(entry_speed, time_to_stop, distance_to_stop)` from brake application."""
+    dt = rows[1]["sim_time_s"] - rows[0]["sim_time_s"]
+    v0 = _at(rows, BRAKE_T0_S)["forward_speed_m_s"]
+    dist = 0.0
+    for r in rows:
+        if r["sim_time_s"] < BRAKE_T0_S:
+            continue
+        if r["forward_speed_m_s"] <= 0.0:
+            return v0, r["sim_time_s"] - BRAKE_T0_S, dist
+        dist += r["forward_speed_m_s"] * dt
+    return v0, None, dist
+
+
+def test_the_sim_host_binary_is_actually_built():
+    assert (REPO / "target" / "release" / "sim-host").exists(), (
+        "sim-host is not built, so this whole gate would be vacuous. Run:\n"
+        "    cargo build --release -p sim-host --bin sim-host"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The guard that lets this change exist at all
+# ---------------------------------------------------------------------------
+
+
+def test_the_pinned_adr_0011_runs_are_untouched_by_braking_authority(tmp_path):
+    """**The most important test in this file.**
+
+    ADR-0011's second ratification pins the estimator trim and the
+    `PEAK_DEMAND_A_PER_UNIT_STICK` slope, both measured on the `full-stick`
+    hold, and names any retune that moves the trim band as a blocking
+    prerequisite for the deferred headroom fix. A braking-authority change
+    must therefore be provably orthogonal to that run -- not "probably fine",
+    and not "the pin still passes", but bit-identical.
+
+    Asserted at the extremes of the braking reserve's whole legal range. If
+    the run were sensitive to it at all, 0.0 against 1.0 would show it.
+
+    This is what the speed gate buys. Without it the launch transient -- the
+    board rocks backward for six tenths of a second before moving off -- draws
+    the braking reserve, and the trim moves for a manoeuvre containing no
+    braking.
+    """
+    for scenario in ("full-stick",):
+        lo = _run(tmp_path, f"{scenario}lo", scenario, cmd_reserve_braking=0.0)
+        hi = _run(tmp_path, f"{scenario}hi", scenario, cmd_reserve_braking=1.0)
+        assert [list(r.values()) for r in lo] == [list(r.values()) for r in hi], (
+            f"the {scenario} acceptance run is no longer independent of the "
+            "braking reserve. ADR-0011's trim pin and the reserve's own "
+            "provenance slope are both measured on it, so this change is no "
+            "longer orthogonal to them -- fix the gate, do not re-baseline."
+        )
+
+
+def test_cmd_reserve_alone_still_scales_the_whole_command(tmp_path):
+    """`--cmd-reserve X` on its own must still mean "scale the WHOLE fore/aft
+    command", including `--cmd-reserve 0` meaning "no stick at all".
+
+    This is a regression test for a trap this change walked straight into.
+    Every sweep written before braking had its own reserve assumes that
+    meaning -- `PEAK_DEMAND_A_PER_UNIT_STICK`'s provenance sweep, and
+    `tests/test_incline_tolerance.py`'s released-board runs, which use
+    `--cmd-reserve 0` as the way to say "hands off". Once braking had a
+    separate reserve that ignored the override, a "hands off" run started
+    issuing a full braking command the instant the board rolled backwards on
+    a slope, and the measured free-roll acceleration silently changed sign.
+
+    So the braking override falls back to `--cmd-reserve` before it falls back
+    to the shipped constant.
+    """
+    rows = _run(tmp_path, "zero", "full-stick", cmd_reserve=0.0, incline_deg=1.0)
+    worst = max(rows, key=lambda r: abs(r["shaped_fore_aft"]))
+    print(
+        f"\n--cmd-reserve 0 on a 1 deg slope: largest shaped command "
+        f"{worst['shaped_fore_aft']:+.6f}"
+    )
+    assert all(r["shaped_fore_aft"] == 0.0 for r in rows), (
+        "--cmd-reserve 0 no longer means zero stick. A run that asked for no "
+        "command is issuing one, and every measurement that uses this idiom to "
+        "mean 'hands off' is now measuring a commanded board."
+    )
+
+
+def test_the_braking_reserve_is_not_spent_on_a_standing_start(tmp_path):
+    """A stick opposing motion below the speed gate is a standing start.
+
+    The failure this forbids is the ADR-0011 defect in mirror image: full aft
+    from rest is a BACKWARD launch, and it over-commands the envelope exactly
+    as the forward one does. The gate is what keeps "braking" meaning "shed
+    speed you already have".
+
+    Measured on the launch transient itself rather than argued: during the
+    first second of a full-stick launch the board really is moving backward,
+    and the shaped command must still be the accelerating reserve.
+    """
+    gate = _rust_constant("BRAKING_RESERVE_MIN_SPEED_M_S")
+    reserve = _rust_constant("CMD_ENVELOPE_RESERVE")
+    rows = _run(tmp_path, "standing", "full-stick")
+    opposing = [
+        r for r in rows
+        if r["stick_fore_aft"] * r["forward_speed_m_s"] < 0.0
+        and abs(r["forward_speed_m_s"]) < gate
+    ]
+    assert opposing, (
+        "the launch transient no longer produces a backward-moving board under "
+        "forward stick, so this test is not measuring what it says it is"
+    )
+    worst = max(opposing, key=lambda r: abs(r["shaped_fore_aft"]))
+    print(
+        f"\n{len(opposing)} cycles with the stick opposing motion below the "
+        f"{gate} m/s gate; largest shaped command {worst['shaped_fore_aft']:+.4f}"
+    )
+    assert abs(worst["shaped_fore_aft"]) <= abs(worst["stick_fore_aft"]) * reserve + 1e-6, (
+        "a command below the speed gate was shaped with the braking reserve"
+    )
+
+
+# ---------------------------------------------------------------------------
+# What the tuning buys, and what it costs
+# ---------------------------------------------------------------------------
+
+
+def test_braking_authority_buys_a_shorter_stop_and_costs_reversal_headroom(tmp_path):
+    """Both halves of the trade, in one place, because neither means anything
+    without the other.
+
+    The costed entry is ADR-0011 criterion (a)'s second matrix point -- the
+    full reverse-to-forward stick reversal at speed, which the ADR names as
+    the worst case. It is a braking event by the opposition test, so it spends
+    this same reserve. **The two cannot be separated:** braking hard from
+    speed IS the load case, so every metre of stopping distance is bought out
+    of that entry's margin.
+
+    No pass/fail bound on the stopping numbers -- they are the deliverable,
+    and a bound on them would be a target. The assertions are only that the
+    trade still points the way the shipped constant was chosen on: braking
+    authority must still shorten the stop, and the worst matrix point must
+    still hold with margin in BOTH currencies ADR-0011 quotes.
+    """
+    shipped = _rust_constant("CMD_ENVELOPE_RESERVE_BRAKING")
+    accel = _rust_constant("CMD_ENVELOPE_RESERVE")
+
+    print(f"\nBUYS -- stop from cruise (shipped braking reserve {shipped})")
+    print(f"{'braking':>9} {'t_stop':>8} {'distance':>9}")
+    stops = {}
+    for br in (accel, shipped):
+        rows = _run(tmp_path, f"stop{br}", "brake-stop", cmd_reserve_braking=br)
+        v0, t_stop, dist = _stop(rows)
+        stops[br] = (t_stop, dist)
+        assert t_stop is not None, f"the board never stopped at braking reserve {br}"
+        print(f"{br:9.2f} {t_stop:8.3f} {dist:9.2f}   (entry speed {v0:.3f} m/s)")
+    gain_t = 100 * (stops[accel][0] - stops[shipped][0]) / stops[accel][0]
+    gain_d = 100 * (stops[accel][1] - stops[shipped][1]) / stops[accel][1]
+    print(f"  shipped vs the old symmetric reserve: {gain_t:.1f}% quicker, {gain_d:.1f}% shorter")
+    assert stops[shipped][0] < stops[accel][0], (
+        "the braking reserve no longer shortens the stop, which is the only "
+        "thing it exists to do"
+    )
+
+    print("\nCOSTS -- ADR-0011's worst matrix point (stick reversal at speed)")
+    print(f"{'braking':>9} {'peak A':>8} {'A left':>8} {'peak lean':>10} {'deg left':>9}")
+    for br in (accel, shipped):
+        rows = _run(tmp_path, f"rev{br}", "stick-reversal", cmd_reserve_braking=br)
+        h = _healthy(rows)
+        pk = max(abs(r["proposed_amps"]) for r in h)
+        pl = max(abs(r["truth_pitch_deg"]) for r in h)
+        print(f"{br:9.2f} {pk:8.2f} {MAX_CURRENT_A - pk:8.2f} {pl:10.2f} "
+              f"{PITCH_CEILING_DEG - pl:9.2f}")
+        assert _inversion_time(rows) is None, (
+            f"the stick reversal inverted the board at braking reserve {br}"
+        )
+        assert pk < MAX_CURRENT_A, f"peak demand {pk:.2f} A reached the envelope"
+        assert pl < PITCH_CEILING_DEG, (
+            f"peak lean {pl:.2f} deg reached the {PITCH_CEILING_DEG:.2f} deg pitch "
+            "ceiling -- the board has no pitch authority left at the worst point "
+            "in ADR-0011's matrix. Lower CMD_ENVELOPE_RESERVE_BRAKING."
+        )
+
+
+def test_the_stop_is_lean_rate_limited_not_envelope_limited(tmp_path):
+    """The finding that says the input side is nearly tapped out.
+
+    If the stop were envelope limited, the board would be sitting at the
+    current ceiling for most of it and more command would buy nothing. It is
+    the opposite: for the first half-second of a maximum-effort stop the board
+    produces almost no braking at all, because the only thing that leans it is
+    ballast mass being dragged against a regulator that is holding pitch to
+    zero.
+
+    Recorded as an assertion so that the day somebody implements ADR-0011's
+    deferred (f3) lean feedforward, this test turns red and says so -- at
+    which point the whole trade above should be re-derived, because braking
+    would stop being rate limited and the reserve would stop being the lever.
+    """
+    rows = _run(tmp_path, "ratelimit", "brake-stop")
+    early = _at(rows, BRAKE_T0_S + 0.5)
+    late = _at(rows, BRAKE_T0_S + 2.0)
+    print(
+        f"\n0.5 s into a maximum-effort stop: {abs(early['proposed_amps']):.2f} A of "
+        f"{MAX_CURRENT_A:.0f} ({100 * abs(early['proposed_amps']) / MAX_CURRENT_A:.0f}% "
+        f"of envelope), lean {early['truth_pitch_deg']:.2f} deg, still doing "
+        f"{early['forward_speed_m_s']:.2f} m/s"
+        f"\n2.0 s in: {abs(late['proposed_amps']):.2f} A "
+        f"({100 * abs(late['proposed_amps']) / MAX_CURRENT_A:.0f}%), "
+        f"lean {late['truth_pitch_deg']:.2f} deg"
+    )
+    assert abs(early["proposed_amps"]) < 0.25 * MAX_CURRENT_A, (
+        "the board now reaches a quarter of its envelope within half a second "
+        "of a full braking command. If that is real, the stop is no longer "
+        "rate limited and CMD_ENVELOPE_RESERVE_BRAKING's whole justification "
+        "needs re-deriving -- see ADR-0011 (f3)."
+    )
+
+
+def test_braking_into_a_turn_is_stable_and_does_not_reach_the_envelope(tmp_path):
+    """The CEO's second manoeuvre: brake and turn at the same time.
+
+    Worth measuring rather than assuming, because it is a load case ADR-0011's
+    straight-line matrix does not contain: yaw is injected kinematically, so
+    the board is being turned while its pitch loop is at its hardest-working
+    point.
+
+    **What this test cannot tell you, and the answer to the other half of the
+    report:** turn radius here is `1 / (steer * curvature * roll_authority)` --
+    it has no speed term at all, so braking cannot tighten the turn by any
+    amount. That is a property of the yaw model, not something a measurement
+    reveals, and changing it is a change to a declared non-physical channel.
+    Recorded here so the next reader does not go looking for it in the data.
+    """
+    rows = _run(tmp_path, "braketurn", "brake-turn")
+    h = _healthy(rows)
+    pk = max(abs(r["proposed_amps"]) for r in h)
+    pl = max(abs(r["truth_pitch_deg"]) for r in h)
+    print(
+        f"\nbrake into a full-steer turn: peak demand {pk:.2f} A of {MAX_CURRENT_A:.0f}, "
+        f"peak lean {pl:.2f} deg of {PITCH_CEILING_DEG:.2f}"
+    )
+    assert _inversion_time(rows) is None, "braking into a turn inverted the board"
+    assert pk < MAX_CURRENT_A
+    assert pl < PITCH_CEILING_DEG


### PR DESCRIPTION
From the CEO's play-test of the current build:

> I would say you should be able to stop faster by leaning back. hopefully you
> can tune that up on the input side. but we dont need to overdo it.

## What was wrong

`CMD_ENVELOPE_RESERVE` = 0.80 was derived from a peak-demand slope measured on
the **forward full-stick hold** (ADR-0011). It was then applied to *every*
fore/aft command including braking — which was never derived, only inherited:
the shaping is one multiply and the sign never entered it. The rider was
getting 80% of the lean they asked for when trying to stop, for a reason that
only ever applied to setting off.

`CMD_ENVELOPE_RESERVE_BRAKING` = **0.85**, spent only when the stick opposes
the motion. **Measured: 4.9% quicker to a stop, 4.1% shorter**, from 9.68 m/s.

## The test is opposition, not sign — and there is a speed gate

"Aft stick gets more authority" would reintroduce the ADR-0011 defect in
mirror image: full aft from rest is a *backward standing start* and
over-commands the envelope exactly as the forward one does. Braking is a
relationship between command and motion, so the test is `stick * speed < 0` —
the same one the speed cap already uses.

A **0.25 m/s gate** then excludes the standing start proper. Measured, not
guessed: a full-stick launch rocks the board **backward to −0.085 m/s for six
tenths of a second** before it moves off. Without the gate that transient draws
the braking reserve — silently changing ADR-0011's `full-stick` run, which is
the run **the estimator trim and `PEAK_DEMAND_A_PER_UNIT_STICK` are both
pinned against**. With it, that run is bit-identical across the braking
reserve's entire legal range (asserted at 0.0 vs 1.0). That guard is the most
important test in the PR.

## ⚠️ This moves a number ADR-0011 quotes — COO please note

The worst point in ADR-0011's acceptance matrix (the full reversal at speed)
**is a braking event** by this definition, so it spends this reserve. The two
cannot be separated: braking hard from speed *is* the load case.

| at the worst matrix point | before | after |
|---|---|---|
| peak demand | 35.40 A | **36.01 A** |
| current headroom | 4.60 A | **3.99 A** |
| peak lean | 9.74° | **10.35°** |
| pitch headroom | 1.72° | **1.11°** |

Criterion (b) quotes the measured margin, so **ADR-0011 needs amending to the
new figures.** Raised here rather than absorbed quietly. The sweep is in the
test file: 0.90 leaves 0.47°, **0.95 exceeds the pitch ceiling**, and 1.00
inverts the board. 0.85 was chosen to keep margin, not to maximise braking.

## The finding that matters more than the tuning

**The stop is lean-rate limited, not envelope limited.**

| time into a maximum-effort stop | demand | lean | speed |
|---|---|---|---|
| +0.5 s | **3.75 A of 40 (9%)** | 2.47° | 9.62 m/s |
| +2.0 s | 24.33 A (61%) | 9.06° | — |

The stopping distance is spent in the first second, at almost no braking
effort, at the highest speed. That is why scaling the command buys ~5% and not
~25%: scaling raises the *final* lean, not the time to reach it. The dead time
is structural — the only thing that leans this board is ballast mass being
dragged against a regulator that is holding pitch to zero and has no lean
setpoint.

**The fix is already named in ADR-0011 and deliberately deferred: (f3),
`θ_ref = atan(a_des/g)` as an explicit lean feedforward.** Nothing on the
input side substitutes for it. A test now goes red if the stop ever stops
being rate limited, so the day (f3) lands, this whole trade gets re-derived
instead of silently keeping a constant whose justification has evaporated.

## Trap found and fixed on the way

`--cmd-reserve 0` stopped meaning "no stick": the braking path kept its own
reserve, so a hands-off run on a slope began issuing a **full braking command**
the instant it rolled backwards, and `test_incline_tolerance.py`'s measured
free-roll acceleration changed sign. Caught by the suite. The braking override
now falls back to `--cmd-reserve` before the shipped constant, so every sweep
written before braking had its own reserve still means what it meant.
Regression-tested.

## Also in here

- New scenarios `brake-stop`, `brake-turn`, `cruise-turn` — none of the
  existing ones can measure a stop (`full-stick` only accelerates;
  `stick-reversal` buries the stop under a reverse standing start).
- **`brake-turn` is stable**: no inversion, 33.41 A peak — the same as turning
  at cruise. Braking into a full-steer turn is not a new load case.

## Not addressed here, and it needs a decision

The other half of the report — *"I should be able to cut a tight turn by
braking and turning at the same time while keeping speed"* — is **not a tuning
problem**. Turn radius is `1 / (steer · curvature · roll_authority)`: it has
**no speed term at all**, so braking cannot tighten the turn by any amount, at
any speed. 6.67 m at full steer, always. Changing that is a change to the
declared non-physical yaw channel's behaviour, i.e. a game-feel decision, so it
is not bundled in here.

Full suite: 331 passed, 6 xfailed. `clippy -D warnings`, `fmt --check`,
`xtask gate` clean. ADR-0011's acceptance suite passes unchanged, trim pin
included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)