### PR TITLE
Turn radius tightens as the board slows; braking reserve to 0.90 (CEO calls)

### DIFF
--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -231,6 +231,52 @@ const BALLAST_RANGE_M: f32 = 0.05;
 /// measured results for what it produces against the new speed cap.
 const YAW_CURVATURE_PER_STEER_RAD_PER_M: f32 = 0.15;
 
+/// How much tighter the turn gets at a standstill than at top speed, as a
+/// multiple of [`YAW_CURVATURE_PER_STEER_RAD_PER_M`].
+///
+/// # Why this exists
+///
+/// [`YAW_CURVATURE_PER_STEER_RAD_PER_M`]'s own doc comment says the defect it
+/// fixed was a board that "turned equally fast at any speed, backwards from
+/// every real vehicle (**turn radius shrinks as you slow down**, not the other
+/// way round)". It then made yaw RATE proportional to speed, which gives a
+/// radius that is *constant* — better than the original, but still not the
+/// behaviour the comment describes. Radius never shrank.
+///
+/// The CEO found the gap by driving it: *"in general i should be able to cut a
+/// tight turn by breaking and turning at same time while keeping speed."* With
+/// a speed-independent radius, braking into a turn cannot tighten it by any
+/// amount, so the manoeuvre does not exist.
+///
+/// # What it does
+///
+/// Curvature ramps linearly from `1x` at [`YAW_TIGHTEN_REF_SPEED_M_S`] and
+/// above, to this multiple at a standstill. At full steer and
+/// `roll_authority` 1.0 that is a 6.67 m radius at top speed and 3.33 m as the
+/// board comes to rest, passing through ~4.6 m at 5 m/s.
+///
+/// **The stationary board still cannot carve.** Yaw rate keeps its `|v|`
+/// factor, so it remains zero at zero speed however tight the curvature gets
+/// — the property `full_stick_at_zero_ground_speed_does_not_turn_the_board`
+/// pins, and the one the original flat-gain formulation got wrong.
+///
+/// # Status
+///
+/// A FEEL number on a declared non-physical channel, picked for the manoeuvre
+/// the CEO described and not derived from anything. 2x is deliberately modest:
+/// it is a noticeable tightening under braking rather than a pivot. Nothing
+/// here is a physics claim and no control decision may be tuned from it.
+const YAW_LOW_SPEED_TIGHTEN: f32 = 2.0;
+
+/// Speed at or above which the turn is at its widest, m/s — the reference
+/// point [`YAW_LOW_SPEED_TIGHTEN`] ramps down from.
+///
+/// [`MAX_GROUND_SPEED_M_S`], so the ramp spans exactly the board's usable
+/// speed range and the tightening is felt across all of it rather than only
+/// in the last stretch before a stop. Above the cap the curvature simply
+/// stays at its widest.
+const YAW_TIGHTEN_REF_SPEED_M_S: f32 = MAX_GROUND_SPEED_M_S;
+
 /// Ground-speed cap, m/s -- issue #161 follow-up, the CEO's explicit ask:
 /// "look at the top speed of a Onewheel XR and set that limit +10% and cap
 /// that." Future Motion's own widely-published Onewheel XR spec lists a top
@@ -414,15 +460,24 @@ const CMD_ENVELOPE_RESERVE: f32 = 0.80;
 /// Braking authority is not free: it is spent out of the same envelope, and
 /// the worst point in ADR-0011's acceptance matrix — the full reverse-to-
 /// forward stick reversal at speed — is a braking event by this definition.
-/// Raising this constant eats that entry's headroom directly. Measured across
-/// the sweep in `tests/test_braking_authority.py`, and the value here is
-/// chosen to keep the reversal's measured margins clear rather than to
-/// maximise braking.
+/// Raising this constant eats that entry's headroom directly, and the two
+/// cannot be separated, because braking hard from speed IS that load case.
+///
+/// At 0.90 the stop is 9.3% quicker and 7.7% shorter, and the reversal's
+/// pitch headroom falls from 1.72 deg to **0.47 deg** (current headroom 4.60
+/// A to 3.41 A). **That is thin, and it is a deliberate CEO decision taken
+/// with those numbers in front of him**, not a default — recorded here
+/// because a future reader finding 0.47 deg of margin deserves to know it was
+/// chosen rather than stumbled into. The sweep is in
+/// `tests/test_braking_authority.py`: 0.95 exceeds the pitch ceiling outright
+/// and 1.00 inverts the board.
+///
+/// ADR-0011 criterion (b) quotes the pre-change margin and needs amending.
 ///
 /// Deliberately NOT raised to 1.0. At 1.0 the braking command is unshaped,
 /// which reproduces the over-command the reserve exists to remove — the
 /// direction it acts in is the only thing that changed.
-const CMD_ENVELOPE_RESERVE_BRAKING: f32 = 0.85;
+const CMD_ENVELOPE_RESERVE_BRAKING: f32 = 0.90;
 
 /// Ground speed below which no command counts as braking, m/s.
 ///
@@ -1236,6 +1291,25 @@ fn speed_capped_fore_aft(stick: f32, last_forward_speed_m_s: f32) -> f32 {
 /// already unloading the board when it happens -- and every run in ADR-0011's
 /// data that saturated above the onset survived. A warning without the speed
 /// term would fire on all of those, which is a warning nobody reads.
+/// Curvature per unit steer at this ground speed, rad/m — widest at
+/// [`YAW_TIGHTEN_REF_SPEED_M_S`] and above, tightening toward a standstill by
+/// [`YAW_LOW_SPEED_TIGHTEN`]. See that constant for why.
+fn yaw_curvature_per_steer(forward_speed_m_s: f32) -> f32 {
+    let slowness = 1.0 - (forward_speed_m_s.abs() / YAW_TIGHTEN_REF_SPEED_M_S).clamp(0.0, 1.0);
+    YAW_CURVATURE_PER_STEER_RAD_PER_M * (1.0 + (YAW_LOW_SPEED_TIGHTEN - 1.0) * slowness)
+}
+
+/// The whole yaw law, in one place.
+///
+/// Extracted so the unit tests exercise the SHIPPED expression rather than a
+/// copy of it — the same reason [`speed_capped_fore_aft`] is a function. The
+/// zero-speed property below is the one this crate got wrong once already,
+/// and a test asserting it against a re-typed formula would not have caught
+/// it.
+fn yaw_rate_rad_s(steer: f32, forward_speed_m_s: f32, roll_authority: f32) -> f32 {
+    steer * yaw_curvature_per_steer(forward_speed_m_s) * forward_speed_m_s.abs() * roll_authority
+}
+
 fn authority_warning_active(utilisation_filtered: f32, forward_speed_m_s: f32) -> bool {
     utilisation_filtered > AUTHORITY_UTILISATION_WARN
         && forward_speed_m_s.abs() < SPEED_CAP_ONSET_M_S
@@ -1930,8 +2004,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // `forward_speed_m_s`, so turn radius stops depending on speed (as a
         // real vehicle's does). At a standstill this is exactly zero, and the
         // gate below then makes the whole injection a literal no-op.
-        let yaw_rate_rad_s =
-            steer * YAW_CURVATURE_PER_STEER_RAD_PER_M * forward_speed_m_s.abs() * roll_authority;
+        let yaw_rate_rad_s = yaw_rate_rad_s(steer, forward_speed_m_s, roll_authority);
         let dyaw_rad = -yaw_rate_rad_s * DT_S as f32;
         // GATED ON EXACT ZERO, deliberately. With no steer (or no ground
         // speed) the plant must evolve bit-identically to the pre-#163 code:
@@ -2464,13 +2537,72 @@ mod tests {
     /// curvature formulation exists to give: full stick at zero ground speed
     /// produces EXACTLY zero heading change, so the injection guarded by it is
     /// a literal no-op. You cannot carve a stationary onewheel.
+    ///
+    /// Through the SHIPPED `yaw_rate_rad_s` rather than a re-typed copy of the
+    /// expression: the low-speed tightening below multiplies curvature up as
+    /// speed falls, and a test that re-typed the formula could not tell you
+    /// whether the `|v|` factor that makes this zero had survived it.
     #[test]
     fn full_steer_at_a_standstill_injects_nothing() {
         for &steer in &[1.0f32, -1.0, 0.6] {
-            let roll_authority = 1.0f32;
-            let yaw_rate = steer * YAW_CURVATURE_PER_STEER_RAD_PER_M * 0.0f32 * roll_authority;
-            let dyaw = -yaw_rate * DT_S as f32;
+            let dyaw = -yaw_rate_rad_s(steer, 0.0, 1.0) * DT_S as f32;
             assert_eq!(dyaw, 0.0, "steer={steer} at rest must not turn the board");
         }
+    }
+
+    /// The turn tightens as the board slows -- the CEO's "cut a tight turn by
+    /// braking and turning at the same time".
+    ///
+    /// Asserted as the ORDERING plus the two endpoints, not as a table of
+    /// radii: the magnitude is a feel number and pinning it would turn a
+    /// tuning knob into a threshold, but the direction is the whole point and
+    /// a sign error here would be invisible in play until someone tried to
+    /// carve.
+    #[test]
+    fn the_turn_radius_shrinks_as_the_board_slows() {
+        let radius = |v: f32| 1.0 / (yaw_curvature_per_steer(v) * 1.0);
+        let top = radius(YAW_TIGHTEN_REF_SPEED_M_S);
+        let rest = radius(0.0);
+        assert!(
+            (top - 1.0 / YAW_CURVATURE_PER_STEER_RAD_PER_M).abs() < 1e-4,
+            "at and above the reference speed the turn must be the width it always was, \
+             or this change is a general steering retune wearing a low-speed label"
+        );
+        assert!(
+            (rest - top / YAW_LOW_SPEED_TIGHTEN).abs() < 1e-4,
+            "the standstill radius must be exactly the tighten factor, got {rest} vs {top}"
+        );
+        // Monotone all the way down, with no step. Walked from the reference
+        // speed DOWN to rest, which is the direction the property is stated
+        // in: each slower sample must turn at least as tightly as the one
+        // before it.
+        let mut previous = f32::INFINITY;
+        for i in (0..=20).rev() {
+            let v = YAW_TIGHTEN_REF_SPEED_M_S * (i as f32) / 20.0;
+            let r = radius(v);
+            assert!(r <= previous + 1e-6, "radius grew as speed fell at v={v}");
+            previous = r;
+        }
+        // Above the reference speed it stays at its widest rather than
+        // inverting into an ever-wider turn.
+        assert!((radius(YAW_TIGHTEN_REF_SPEED_M_S * 2.0) - top).abs() < 1e-4);
+    }
+
+    /// Tightening the low-speed turn must not resurrect the spin-in-place the
+    /// speed-proportional formulation was introduced to kill. Yaw RATE must
+    /// still fall to zero with speed, even though curvature is rising.
+    #[test]
+    fn yaw_rate_still_falls_to_zero_with_speed_despite_the_tightening() {
+        let mut previous = 0.0f32;
+        for i in 0..=20 {
+            let v = YAW_TIGHTEN_REF_SPEED_M_S * (i as f32) / 20.0;
+            let rate = yaw_rate_rad_s(1.0, v, 1.0);
+            assert!(
+                rate >= previous - 1e-6,
+                "yaw rate is not monotone in speed at v={v}"
+            );
+            previous = rate;
+        }
+        assert_eq!(yaw_rate_rad_s(1.0, 0.0, 1.0), 0.0);
     }
 }

--- a/tests/test_braking_authority.py
+++ b/tests/test_braking_authority.py
@@ -16,6 +16,22 @@ the **forward full-stick hold** (ADR-0011). It was then applied to every
 fore/aft command including braking, which was never derived -- the shaping was
 one multiply and the sign never entered it. `CMD_ENVELOPE_RESERVE_BRAKING`
 gives braking its own number, spent only when the stick opposes the motion.
+Measured at the shipped 0.90: **9.3% quicker to a stop and 7.7% shorter** than
+the old symmetric reserve, from 9.68 m/s.
+
+WHAT IT COSTS, AND WHO CHOSE TO SPEND IT
+-----------------------------------------
+Braking authority is bought straight out of ADR-0011's worst matrix point --
+the full reversal at speed is a braking event by the opposition test, and the
+two cannot be separated because braking hard from speed IS the load case.
+Pitch headroom there falls from 1.72 deg to **0.47 deg**, current headroom
+from 4.60 A to 3.41 A.
+
+That is thin, and it was the **CEO's explicit call with those numbers in front
+of him**, not a default. The sweep it was chosen from is below: 0.95 exceeds
+the pitch ceiling outright and 1.00 inverts the board, so 0.90 is near the
+edge of what the envelope allows at all. **ADR-0011 criterion (b) quotes the
+old margin and needs amending to the new one.**
 
 WHY THE OPPOSITION TEST AND THE SPEED GATE BOTH MATTER
 -------------------------------------------------------
@@ -35,10 +51,9 @@ guard, and it is the most important test in this file.
 THE FINDING THAT MATTERS MORE THAN THE TUNING
 ----------------------------------------------
 **The stop is lean-rate limited, not envelope limited.** Half a second after
-the stick is slammed to full aft from 9.68 m/s, the board has produced about
-3 A of braking out of 40 available; it takes ~2 s to reach 57% of the
-envelope, and the peak demand of the whole schedule occurs 8 s later during
-the reverse standing start, not during the stop at all.
+the stick is slammed to full aft from 9.68 m/s, the board has produced 4.17 A
+of braking out of 40 available -- 10% of envelope, still doing 9.63 m/s. It
+takes ~2 s to reach 65%.
 
 That is why scaling the command buys so little: scaling raises the FINAL
 lean, and the stopping distance is spent in the first second, at nearly zero

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -703,14 +703,87 @@ def test_criterion_f_full_stick_holds_with_the_estimator_bias_removed(tmp_path):
         "therefore about a quarter of a degree, which is the number that "
         "matters most for hardware: an IMU mounted half a degree out flips "
         "this board. Both readings of criterion (f) fail, so the conclusion "
-        "does not depend on which one is right."
+        "does not depend on which one is right.\n\n"
+        "NOSE-UP ONLY. The nose-DOWN side of this band was parametrised here "
+        "too until the braking reserve landed and turned -0.5 deg into an "
+        "XPASS. Sweeping it showed why, and it is not an improvement: outcome "
+        "is NOT MONOTONIC in nose-down bias. See "
+        "test_the_nose_down_static_bias_band_is_not_monotonic. +0.5 deg "
+        "inverts the board hard and stably (6.71 s, unchanged by the braking "
+        "reserve), so the criterion's failure is recorded on the side where a "
+        "single value means something."
     ),
 )
-@pytest.mark.parametrize("bias_deg", [-0.5, 0.5])
+@pytest.mark.parametrize("bias_deg", [0.5])
 def test_criterion_f_the_matrix_holds_under_a_worst_case_static_pitch_bias(tmp_path, bias_deg):
     rows = _run(tmp_path, f"f2{bias_deg}", "stick-reversal", pitch_source="estimator", pitch_bias_deg=bias_deg)
     t = _inversion_time(rows)
     assert t is None, f"a {bias_deg:+} deg static pitch bias inverted the board at {t:.3f} s"
+
+
+def test_the_nose_down_static_bias_band_is_not_monotonic(tmp_path):
+    """A correction to how the +-0.25 / +-0.5 characterisation reads.
+
+    That pair was recorded as though the board simply survives a quarter of a
+    degree and inverts at a half. On the NOSE-UP side it behaves that way. On
+    the nose-down side it does not, and this is the measurement that says so:
+
+        bias      reserve 0.80    reserve 0.90
+        -0.70 deg     held            held
+        -0.60 deg     INVERTED        held
+        -0.55 deg     INVERTED        held
+        -0.50 deg     INVERTED        held
+        -0.45 deg     INVERTED        INVERTED
+        -0.40 deg     INVERTED        held
+
+    A larger bias surviving where a smaller one inverts is not a tolerance,
+    it is a knife-edge, and **it is pre-existing** -- visible at reserve 0.80
+    in the column that predates the braking change. The braking reserve did
+    not create it, it moved which side of the edge -0.5 deg lands on, which
+    is how it was noticed at all (a strict xfail turned XPASS).
+
+    Recorded rather than resolved, and deliberately NOT bisected: this repo
+    has met exactly this shape once before, in the nose-strike disturbance
+    envelope, and concluded that bisecting to a boundary that moves with any
+    small upstream change manufactures precision the measurement does not
+    have.
+
+    **What must not be done with this:** the -0.5 deg XPASS must not be
+    promoted into "the board is now robust to nose-down bias". It is one
+    trajectory landing on the lucky side of a chaotic band. Asserting it
+    would be deriving acceptance from whatever happened to pass, which is the
+    precise move ADR-0011 criterion (f) exists to forbid.
+
+    Asserted here is only the part that is stable and that criterion (f)
+    actually turns on: somewhere in the +-0.5 deg band the board still goes
+    over, so the robustness reading still fails.
+    """
+    band = (-0.60, -0.50, -0.45, -0.40)
+    outcomes = {}
+    for bias in band:
+        rows = _run(
+            tmp_path, f"nm{bias}", "stick-reversal",
+            pitch_source="estimator", pitch_bias_deg=bias,
+        )
+        outcomes[bias] = _inversion_time(rows)
+    print("\nnose-down static bias, shipped configuration:")
+    for bias, t in outcomes.items():
+        print(f"  {bias:+.2f} deg: {'held' if t is None else f'INVERTED at {t:.2f} s'}")
+
+    inverted = [b for b, t in outcomes.items() if t is not None]
+    assert inverted, (
+        "no nose-down bias in the +-0.5 deg band inverts the board any more. "
+        "If that is real it is a genuine robustness change and ADR-0011 "
+        "criterion (f) needs revisiting -- but check the monotonicity above "
+        "first, because this band has a knife-edge in it and a clean sweep is "
+        "more likely to mean the harness stopped working."
+    )
+    held = [b for b, t in outcomes.items() if t is None]
+    if held and min(inverted) < min(held):
+        print(
+            f"  NON-MONOTONIC as recorded: {min(held):+.2f} deg holds while "
+            f"{min(inverted):+.2f} deg inverts."
+        )
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Both play-test calls, taken with the measured tradeoffs in hand.

## Turn radius now has a speed term — it had none

Radius was `1 / (steer · curvature · roll_authority)`: **6.67 m at full steer
whether doing 9 m/s or 1 m/s.** So braking could not tighten a turn by any
amount, and "cut a tight turn by braking and turning at the same time" was not
a manoeuvre that existed.

Worth noting where the gap came from: `YAW_CURVATURE_PER_STEER`'s own doc
comment says the defect it fixed was a board that turned "backwards from every
real vehicle (**turn radius shrinks as you slow down**, not the other way
round)" — and then made yaw *rate* proportional to speed, which gives a
*constant* radius. Better than the flat gain it replaced, but not what the
comment claims.

Curvature now ramps from 1× at `MAX_GROUND_SPEED_M_S` to **2× at rest**:

| speed | turn radius at full steer |
|---|---|
| 9.34 m/s | 6.67 m (unchanged) |
| 5 m/s | ~4.6 m |
| coming to a stop | 3.33 m |

**A stationary board still cannot carve.** Yaw rate keeps its `|v|` factor, so
it stays exactly zero at rest — the property the original flat-gain
formulation got wrong. It is now asserted through the *shipped* expression:
`yaw_rate_rad_s` and `yaw_curvature_per_steer` are extracted so the test
cannot pass against a re-typed copy of a formula that has since changed.

Feel numbers on a declared non-physical channel. 2× is deliberately modest —
a noticeable tightening under braking, not a pivot.

## Braking reserve 0.85 → 0.90

Your call, with the sweep in front of you. **9.3% quicker to a stop, 7.7%
shorter.**

| at ADR-0011's worst matrix point | before | now |
|---|---|---|
| pitch headroom | 1.72° | **0.47°** |
| current headroom | 4.60 A | **3.41 A** |

That is thin and it is recorded in the constant's doc comment as *chosen*, so
a future reader finding 0.47° knows it was deliberate. For context on how
close to the wall this is: 0.95 exceeds the pitch ceiling outright, 1.00
inverts the board. **ADR-0011 criterion (b) quotes the old margin and needs
amending** — COO.

## ⚠️ A characterisation this repo was relying on turns out to be too clean

The reserve change turned criterion (f)'s −0.5° static-bias strict xfail into
an **XPASS**. Rather than accept a free win, I swept it:

| nose-down bias | reserve 0.80 | reserve 0.90 |
|---|---|---|
| −0.70° | held | held |
| −0.60° | INVERTED | held |
| −0.55° | INVERTED | held |
| −0.50° | INVERTED | held |
| −0.45° | INVERTED | **INVERTED** |
| −0.40° | INVERTED | held |

A larger bias surviving where a smaller one inverts is not a tolerance, it is
a knife-edge — and **it is pre-existing**, visible in the 0.80 column that
predates this change. The braking reserve only moved which side −0.5° lands
on, which is how it got noticed at all.

So the familiar "survives ±0.25°, inverts at ±0.5°" pair reads cleanly **only
on the nose-up side**. The −0.5° XPASS is *not* promoted into "the board is
now robust to nose-down bias" — that would be deriving acceptance from
whatever happened to pass, the precise move criterion (f) exists to forbid.
The strict xfail stays on +0.5° (inverts hard at 6.71 s, unchanged by the
reserve), and the non-monotonic band is recorded as its own characterisation
asserting only the stable part: somewhere in ±0.5° the board still goes over,
so the robustness reading still fails.

Deliberately **not bisected** — this repo met the same shape in the
nose-strike disturbance envelope and concluded that a boundary which moves
with any small upstream change manufactures precision the measurement does not
have.

Full suite: 333 passed, 5 xfailed. `clippy -D warnings`, `fmt --check`,
`xtask gate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)