### PR TITLE
ops(decision): rescue the ADR-0011 measurement harnesses from the scratchpad

### DIFF
--- a/docs/decisions/adr-0011-evidence/README.md
+++ b/docs/decisions/adr-0011-evidence/README.md
@@ -1,0 +1,68 @@
+# ADR-0011 evidence — the measurement harnesses, rescued
+
+**These eleven scripts are the derivations behind numbers ADR-0011 and its two ratifications
+already treat as settled.** They lived only in a session-scoped scratchpad under
+`/private/tmp/claude-501/…`, which nothing preserves. The numbers were merged; the working
+that produced them was not. That asymmetry is the reason this directory exists.
+
+Rescued verbatim by the COO on 2026-08-04, from the 2026-08-02 Senior Controls session.
+
+## They do not run as-is, and were not fixed
+
+Each script hardcodes the absolute scratchpad path it wrote to, and several hardcode
+constants of the day — `onewheel_compare.py` opens with `MAX_A, KT, R_EFF, MASS = 40.0, 0.7,
+0.1454, 82.5`, which is the **pre-60 A** figure now under review on
+`feat/controls/realistic-motor-torque`.
+
+They were copied **unmodified on purpose.** Repointing the paths or refreshing the constants
+would be re-deriving another role's evidence under the guise of preserving it, and a rescued
+measurement that has been quietly edited is worth less than no measurement at all. Anyone
+re-running these owns the port, and should say in the commit which constants moved.
+
+## What each one asks
+
+| Script | The question it was written to answer |
+|---|---|
+| `incline_sweep.py` | The authored-terrain incline the board tolerates — **ADR-0011 (f)/condition 2** directly |
+| `incline_wide.py` | The same sweep, widened |
+| `characterise_trim.py` | How far the residual slope/offset move across operating points — what honestly sets a **pinned band** (#207) |
+| `settled.py` | The two candidate instruments for that band, and their spread |
+| `shape.py` | Whether a quasi-steady window exists where residual/unaided specific force settles |
+| `slope_vs_trim.py` | Whether the 42 A/unit peak-demand slope actually depends on the trim |
+| `brake_sweep.py` | What braking authority buys (stop time/distance) and what it costs — the **reserve** derivation (#218, #219) |
+| `hold_limit.py` | Where the speed cap stops bounding a downhill roll, at zero stick |
+| `grade.py` | Free-roll downhill-forward, and the steepest grade held at full stick |
+| `onewheel_compare.py` | *"How far are we from the CEO's cited Onewheel figure, and what sets the gap?"* — **#204** |
+| `analyse.py` | General reader for `sim-host --trace-csv` output |
+
+## `onewheel_compare.py` is the one to read first
+
+It is timestamped **16:06 on 2026-08-02 — after that session's teardown commit**, so it is
+the only artefact of work that was never written up anywhere. It sweeps braking against the
+CEO's cited Onewheel stopping figure. Minutes later the working tree gained an uncommitted
+40 A → 60 A change across every `MAX_CURRENT_A` site, and the session ended.
+
+The apparent chain — *braking is short of the cited figure → the gap is motor authority →
+raise the current limit* — is **inference from timestamps, not a recorded conclusion.** It
+is banked on `feat/controls/realistic-motor-torque` and is unvalidated. 28 → 42 N·m is a 50%
+authority increase against a margin ADR-0011 measured at approximately zero, so if the chain
+holds it is a decision-record question rather than a parameter change.
+
+## The 178 CSVs were deliberately left behind
+
+262 MB of trace output, regenerable by re-running the scripts above. Nothing is checked into
+git that a build can reproduce — the same rule that keeps `sim/out/` out of the repo. The
+naming is systematic and worth knowing if the corpus is ever regenerated:
+
+- `i_*`, `w_*`, `t_*` — estimator trim and window sweeps (`i_hold`, `i_idle`, `i_rev`, …)
+- `s_*`, `b_*`, `g_*` — command-envelope reserve, braking, and grade sweeps
+- `h_*`, `x_*` — hold-limit and the final 16:08 two-parameter sweep
+- `*_shipped` — the as-merged configuration, for comparison against a candidate
+
+Suffixes are parameter values (`b_rev0.9.csv` = reverse case at reserve 0.90).
+
+## Not rescued
+
+Draft PR bodies, issue write-ups and board-doc drafts from 2026-07-31 (`c122.md`, `i137.md`,
+`prgate.md`, `board-coo.md`, `teardown_msg.txt`, …). Every one of them is superseded by the
+merged artefact it was a draft of.

--- a/docs/decisions/adr-0011-evidence/analyse.py
+++ b/docs/decisions/adr-0011-evidence/analyse.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Scratch analysis of sim-host --trace-csv output. Not part of the repo."""
+from __future__ import annotations
+import csv, math, sys
+from pathlib import Path
+
+DT = 0.002
+FALLEN_DEG = 20.0
+MAX_A = 40.0
+KT = 0.7
+KP = 140.0
+PITCH_CEILING_DEG = math.degrees(MAX_A * KT / KP)  # 11.4592
+
+
+def load(path):
+    rows = []
+    with open(path) as f:
+        for r in csv.DictReader(f):
+            rows.append({k: (float(v) if k not in ("seq",) else int(v)) for k, v in r.items()})
+    return rows
+
+
+def first_time(rows, pred):
+    for r in rows:
+        if pred(r):
+            return r["sim_time_s"]
+    return None
+
+
+def summary(path, hold_from=None, hold_to=None):
+    rows = load(path)
+    t_flip = first_time(rows, lambda r: abs(r["truth_pitch_deg"]) > 90.0)
+    t_fallen = first_time(rows, lambda r: abs(r["truth_pitch_deg"]) > FALLEN_DEG)
+    t_warn = first_time(rows, lambda r: r["authority_warning"] > 0.5)
+    t_sat = first_time(rows, lambda r: r["saturated"] > 0.5)
+    # window for "healthy" statistics: before divergence (|pitch|>20) or whole run
+    end = t_fallen if t_fallen is not None else 1e9
+    pre = [r for r in rows if r["sim_time_s"] < end]
+    peak_demand = max((abs(r["proposed_amps"]) for r in pre), default=0.0)
+    peak_pitch = max((abs(r["truth_pitch_deg"]) for r in pre), default=0.0)
+    peak_speed = max((abs(r["forward_speed_m_s"]) for r in pre), default=0.0)
+    peak_est_err = max((abs(r["truth_pitch_deg"] - r["est_pitch_deg"]) for r in pre), default=0.0)
+    # steady window
+    if hold_from is not None:
+        win = [r for r in pre if hold_from <= r["sim_time_s"] <= (hold_to or 1e9)]
+    else:
+        win = pre
+    steady_pitch = (sum(r["truth_pitch_deg"] for r in win) / len(win)) if win else float("nan")
+    steady_demand = (sum(abs(r["proposed_amps"]) for r in win) / len(win)) if win else float("nan")
+    # kinematics
+    dist = 0.0
+    t8 = None
+    for r in rows:
+        dist += r["forward_speed_m_s"] * DT
+        if t8 is None and r["forward_speed_m_s"] >= 8.0:
+            t8 = r["sim_time_s"]
+    dist15 = 0.0
+    for r in rows:
+        if r["sim_time_s"] <= 15.0:
+            dist15 += r["forward_speed_m_s"] * DT
+    return dict(
+        path=Path(path).name, n=len(rows),
+        t_flip=t_flip, t_fallen=t_fallen, t_warn=t_warn, t_sat=t_sat,
+        peak_demand_a=peak_demand, peak_pitch_deg=peak_pitch, peak_speed=peak_speed,
+        steady_pitch_deg=steady_pitch, steady_demand_a=steady_demand,
+        peak_est_err_deg=peak_est_err,
+        t_to_8=t8, dist_15s=dist15, dist_total=dist,
+        current_headroom_a=MAX_A - peak_demand,
+        pitch_headroom_deg=PITCH_CEILING_DEG - peak_pitch,
+    )
+
+
+def fmt(d):
+    def g(k, f="{:.3f}"):
+        v = d[k]
+        return "n/a" if v is None else f.format(v)
+    return (f"{d['path']:<38} n={d['n']:<6} flip@{g('t_flip')} fallen@{g('t_fallen')} "
+            f"warn@{g('t_warn')} sat@{g('t_sat')} peakA={g('peak_demand_a','{:.2f}')} "
+            f"peakPitch={g('peak_pitch_deg','{:.2f}')} steadyPitch={g('steady_pitch_deg','{:.2f}')} "
+            f"steadyA={g('steady_demand_a','{:.2f}')} vmax={g('peak_speed','{:.2f}')} "
+            f"t8={g('t_to_8')} d15={g('dist_15s','{:.2f}')} estErr={g('peak_est_err_deg','{:.2f}')}")
+
+
+if __name__ == "__main__":
+    hf = float(sys.argv[1]) if len(sys.argv) > 1 and sys.argv[1] != "-" else None
+    ht = float(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2] != "-" else None
+    for p in sys.argv[3:]:
+        print(fmt(summary(p, hf, ht)))

--- a/docs/decisions/adr-0011-evidence/brake_sweep.py
+++ b/docs/decisions/adr-0011-evidence/brake_sweep.py
@@ -1,0 +1,89 @@
+"""What does braking authority buy, and what does it cost?
+
+Buys: stopping time and distance from cruise (brake-stop).
+Costs: headroom at ADR-0011's worst matrix point (stick-reversal), which is a
+braking event by the opposition test and therefore spends this same reserve.
+"""
+from __future__ import annotations
+import csv, subprocess
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+MAX_A, KT, KP = 40.0, 0.7, 140.0
+import math
+PITCH_CEIL = math.degrees(MAX_A * KT / KP)
+BRAKE_T0 = 12.5  # ACCEPTANCE_SETTLE_S + BRAKE_BUILD_S
+
+
+def run(name, scenario, **kw):
+    out = OUT / f"b_{name}.csv"
+    argv = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+            "--scripted-scenario", scenario, "--free-run", "--stats-path", "none",
+            "--pitch-source", "estimator",
+            "--state-out-addr", "127.0.0.1:19851", "--input-in-addr", "127.0.0.1:19852",
+            "--trace-csv", str(out)]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+def inverted(rows):
+    return next((r["sim_time_s"] for r in rows if abs(r["truth_pitch_deg"]) > 90.0), None)
+
+
+def healthy(rows):
+    t = inverted(rows)
+    return [r for r in rows if t is None or r["sim_time_s"] < t]
+
+
+def stop_metrics(rows):
+    """Time and distance from brake application to zero forward speed."""
+    dt = rows[1]["sim_time_s"] - rows[0]["sim_time_s"]
+    v0 = next(r["forward_speed_m_s"] for r in rows if abs(r["sim_time_s"] - BRAKE_T0) < 1e-3)
+    dist, t_stop = 0.0, None
+    for r in rows:
+        if r["sim_time_s"] < BRAKE_T0:
+            continue
+        if t_stop is None:
+            if r["forward_speed_m_s"] <= 0.0:
+                t_stop = r["sim_time_s"] - BRAKE_T0
+                break
+            dist += r["forward_speed_m_s"] * dt
+    return v0, t_stop, dist
+
+
+print("BUYS -- brake-stop from cruise")
+print(f"{'braking':>8} {'v0':>7} {'t_stop':>8} {'dist':>8} {'pk A':>7} {'pk lean':>8} {'inv':>6}")
+base = None
+for br in (0.80, 0.85, 0.90, 0.92, 0.95, 1.00):
+    rows = run(f"stop{br}", "brake-stop", cmd_reserve_braking=br)
+    v0, ts, d = stop_metrics(rows)
+    h = healthy(rows)
+    pk = max(abs(r["proposed_amps"]) for r in h)
+    pl = max(abs(r["truth_pitch_deg"]) for r in h)
+    if base is None:
+        base = (ts, d)
+    print(f"{br:8.2f} {v0:7.3f} {ts if ts is None else f'{ts:8.3f}':>8} {d:8.2f} "
+          f"{pk:7.2f} {pl:8.2f} {str(inverted(rows) is not None):>6}")
+print(f"  (baseline 0.80: t_stop {base[0]:.3f} s, distance {base[1]:.2f} m)")
+
+print("\nCOSTS -- ADR-0011 worst matrix point (stick-reversal at speed)")
+print(f"{'braking':>8} {'pk A':>7} {'A left':>7} {'pk lean':>8} {'deg left':>9} {'inv':>6} {'warn':>6}")
+for br in (0.80, 0.85, 0.90, 0.92, 0.95, 1.00):
+    rows = run(f"rev{br}", "stick-reversal", cmd_reserve_braking=br)
+    h = healthy(rows)
+    pk = max(abs(r["proposed_amps"]) for r in h)
+    pl = max(abs(r["truth_pitch_deg"]) for r in h)
+    warn = any(r["authority_warning"] > 0.5 for r in h)
+    print(f"{br:8.2f} {pk:7.2f} {MAX_A-pk:7.2f} {pl:8.2f} {PITCH_CEIL-pl:9.2f} "
+          f"{str(inverted(rows) is not None):>6} {str(warn):>6}")
+
+print("\nREGRESSION GUARD -- full-stick hold must be untouched (accelerating only)")
+a = run("fs080", "full-stick", cmd_reserve_braking=0.80)
+b = run("fs100", "full-stick", cmd_reserve_braking=1.00)
+same = [list(r.values()) for r in a] == [list(r.values()) for r in b]
+print(f"  full-stick identical at braking reserve 0.80 vs 1.00: {same}")

--- a/docs/decisions/adr-0011-evidence/characterise_trim.py
+++ b/docs/decisions/adr-0011-evidence/characterise_trim.py
@@ -1,0 +1,90 @@
+"""Scratch: how much do the residual slope / offset move across operating points?
+
+Answers the only question that sets a pinned band honestly: what is the
+measurement's OWN spread, so the band can be wider than the spread (or the pin
+chatters) and no wider than it has to be (or the pin stops detecting drift).
+"""
+from __future__ import annotations
+
+import csv
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+ACCEL_FF_GAIN = 0.0584
+ONE_RAD_PER_G = math.degrees(1.0) / 9.80665
+
+
+def run(name, scenario, **kw):
+    out = OUT / f"{name}.csv"
+    argv = [
+        "cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+        "--scripted-scenario", scenario, "--free-run", "--stats-path", "none",
+        "--state-out-addr", "127.0.0.1:19701", "--input-in-addr", "127.0.0.1:19702",
+        "--trace-csv", str(out),
+    ]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_', '-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+def fit(rows, t_lo=1.0, t_hi=15.0, half=50):
+    xs, ys = [], []
+    for i in range(half, len(rows) - half):
+        if not t_lo <= rows[i]["sim_time_s"] <= t_hi:
+            continue
+        a_x = (rows[i + half]["forward_speed_m_s"] - rows[i - half]["forward_speed_m_s"]) / (
+            rows[i + half]["sim_time_s"] - rows[i - half]["sim_time_s"]
+        )
+        xs.append(a_x - ACCEL_FF_GAIN * rows[i]["applied_amps"])
+        ys.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
+    n = len(xs)
+    sx, sy = sum(xs), sum(ys)
+    slope = (n * sum(x * y for x, y in zip(xs, ys)) - sx * sy) / (n * sum(x * x for x in xs) - sx * sx)
+    return slope, (sy - slope * sx) / n, n
+
+
+def resting_residual(rows, t_lo, t_hi):
+    """Mean est-truth over a window, degrees -- the trim in its plainest form."""
+    vals = [r["est_pitch_deg"] - r["truth_pitch_deg"] for r in rows
+            if t_lo <= r["sim_time_s"] <= t_hi]
+    return sum(vals) / len(vals), min(vals), max(vals)
+
+
+print(f"1 rad/g = {ONE_RAD_PER_G:.4f} deg per m/s^2\n")
+print(f"{'case':38} {'slope':>8} {'dev%':>7} {'icept':>8} {'n':>6}")
+cases = []
+for u in (0.4, 0.5, 0.6, 0.7, 0.8, 0.9):
+    cases.append((f"full-stick reserve={u}", "full-stick", dict(cmd_reserve=u, pitch_source="estimator")))
+cases.append(("stick-reversal shipped", "stick-reversal", dict(pitch_source="estimator")))
+
+results = {}
+for label, scen, kw in cases:
+    rows = run(label.replace(" ", "_").replace("=", ""), scen, **kw)
+    s, b, n = fit(rows)
+    results[label] = (s, b)
+    print(f"{label:38} {s:8.3f} {100*(s-ONE_RAD_PER_G)/ONE_RAD_PER_G:+7.1f} {b:+8.3f} {n:6d}")
+
+slopes = [s for s, _ in results.values()]
+icepts = [b for _, b in results.values()]
+print(f"\nslope   span {min(slopes):.3f} .. {max(slopes):.3f}  "
+      f"(dev from 1 rad/g: {100*(min(slopes)-ONE_RAD_PER_G)/ONE_RAD_PER_G:+.1f}% .. "
+      f"{100*(max(slopes)-ONE_RAD_PER_G)/ONE_RAD_PER_G:+.1f}%)")
+print(f"intercept span {min(icepts):+.3f} .. {max(icepts):+.3f} deg")
+
+# fit-window sensitivity on the reference case
+print("\nfit-window sensitivity, full-stick reserve=0.6:")
+rows = run("winsens", "full-stick", cmd_reserve=0.6, pitch_source="estimator")
+for lo, hi in ((1.0, 15.0), (2.0, 15.0), (1.0, 12.0), (3.0, 18.0), (1.0, 20.0)):
+    s, b, n = fit(rows, lo, hi)
+    print(f"  [{lo:4.1f},{hi:4.1f}]  slope {s:7.3f}  intercept {b:+7.3f}  n={n}")
+
+print("\nquiescent residual (no stick yet) -- full-stick run, t in [0.2,0.8]:")
+m, lo, hi = resting_residual(rows, 0.2, 0.8)
+print(f"  mean {m:+.4f} deg, range {lo:+.4f} .. {hi:+.4f}")

--- a/docs/decisions/adr-0011-evidence/grade.py
+++ b/docs/decisions/adr-0011-evidence/grade.py
@@ -1,0 +1,44 @@
+"""C: free-roll downhill-forward (no corridor). D: steepest grade held at full stick."""
+from __future__ import annotations
+import csv, subprocess
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+
+
+def run(name, **kw):
+    out = OUT / f"g_{name}.csv"
+    argv = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+            "--scripted-scenario", "full-stick", "--free-run", "--stats-path", "none",
+            "--pitch-source", "estimator",
+            "--state-out-addr", "127.0.0.1:19841", "--input-in-addr", "127.0.0.1:19842",
+            "--trace-csv", str(out)]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+print("C: released downhill-FORWARD (700 m of corridor), stick zero")
+print(f"{'incline':>8} {'v end':>8} {'trend':>8} {'corridor?':>10}")
+for phi in (-0.5, -1.0, -3.0, -5.0, -7.0, -10.0, -15.0):
+    rows = run(f"c{phi}", incline_deg=phi, cmd_reserve=0.0)
+    e, p0 = rows[-1], min(rows, key=lambda r: abs(r["sim_time_s"] - 16.5))
+    braked = any(abs(r["applied_fore_aft"]) > 1e-9 for r in rows)
+    print(f"{phi:8.2f} {e['forward_speed_m_s']:8.3f} "
+          f"{(abs(e['forward_speed_m_s'])-abs(p0['forward_speed_m_s']))/2:+8.3f} {str(braked):>10}")
+
+print("\nD: full stick FORWARD on an uphill -- steepest grade it holds")
+print(f"{'incline':>8} {'v end':>9} {'v min':>9} {'peak A':>8}  verdict")
+for phi in (2.0, 3.0, 4.0, 4.5, 5.0, 5.5, 6.0, 7.0, 8.0):
+    rows = run(f"d{phi}", incline_deg=phi)
+    # forward is -X and forward_speed is positive-forward; climbing = stays > 0
+    end = rows[-1]["forward_speed_m_s"]
+    vmin = min(r["forward_speed_m_s"] for r in rows if r["sim_time_s"] > 2.0)
+    braked = any(abs(r["applied_fore_aft"] - r["shaped_fore_aft"]) > 1e-9 for r in rows)
+    print(f"{phi:8.2f} {end:9.3f} {vmin:9.3f} "
+          f"{max(abs(r['proposed_amps']) for r in rows):8.2f}  "
+          f"{'CLIMBS' if vmin > 0 else 'slides back'}{'  [corridor!]' if braked else ''}")

--- a/docs/decisions/adr-0011-evidence/hold_limit.py
+++ b/docs/decisions/adr-0011-evidence/hold_limit.py
@@ -1,0 +1,48 @@
+"""Where does the speed cap stop bounding a downhill roll?
+
+Zero stick, board simply released on a slope. Two things reported per run:
+ * whether |speed| is still RISING over the last 2 s (runaway) or falling back
+   toward the cap (held);
+ * the free-roll check a = g*sin(phi), taken over the first 4 s while the cap
+   has not yet engaged -- the sanity check that this is really a slope.
+"""
+from __future__ import annotations
+import csv, math, subprocess
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+G_MODEL = 9.81  # overboard_rider.xml's own <option gravity>
+
+
+def run(name, **kw):
+    out = OUT / f"h_{name}.csv"
+    argv = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+            "--scripted-scenario", "full-stick", "--free-run", "--stats-path", "none",
+            "--state-out-addr", "127.0.0.1:19821", "--input-in-addr", "127.0.0.1:19822",
+            "--cmd-reserve", "0.0", "--trace-csv", str(out)]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+def at(rows, t):
+    return min(rows, key=lambda r: abs(r["sim_time_s"] - t))
+
+
+print(f"{'incline':>8} {'a(0.5-4s)':>10} {'g sin phi':>10} {'v@16.5':>8} {'v@18.5':>8} "
+      f"{'d|v|/dt':>9}  verdict")
+for inc in (0.25, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 9.0, 10.0):
+    rows = run(f"{inc}", incline_deg=inc, pitch_source="estimator")
+    v1, v2 = at(rows, 0.5), at(rows, 4.0)
+    a = abs(v2["forward_speed_m_s"] - v1["forward_speed_m_s"]) / (v2["sim_time_s"] - v1["sim_time_s"])
+    e1, e2 = at(rows, 16.5), at(rows, 18.5)
+    d = (abs(e2["forward_speed_m_s"]) - abs(e1["forward_speed_m_s"])) / (
+        e2["sim_time_s"] - e1["sim_time_s"])
+    verdict = "RUNAWAY" if d > 0.02 else "held"
+    print(f"{inc:8.2f} {a:10.3f} {G_MODEL*math.sin(math.radians(inc)):10.3f} "
+          f"{abs(e1['forward_speed_m_s']):8.3f} {abs(e2['forward_speed_m_s']):8.3f} "
+          f"{d:+9.3f}  {verdict}")

--- a/docs/decisions/adr-0011-evidence/incline_sweep.py
+++ b/docs/decisions/adr-0011-evidence/incline_sweep.py
@@ -1,0 +1,71 @@
+"""Measure the authored-terrain incline the board tolerates. ADR-0011 (f)/2."""
+from __future__ import annotations
+import csv, subprocess, sys
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+INVERTED = 90.0
+
+
+def run(name, scenario, **kw):
+    out = OUT / f"i_{name}.csv"
+    argv = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+            "--scripted-scenario", scenario, "--free-run", "--stats-path", "none",
+            "--state-out-addr", "127.0.0.1:19801", "--input-in-addr", "127.0.0.1:19802",
+            "--trace-csv", str(out)]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+def inversion(rows):
+    return next((r["sim_time_s"] for r in rows if abs(r["truth_pitch_deg"]) > INVERTED), None)
+
+
+def healthy(rows):
+    t = inversion(rows)
+    return [r for r in rows if t is None or r["sim_time_s"] < t]
+
+
+def summarise(rows):
+    h = healthy(rows)
+    return (inversion(rows),
+            max(abs(r["truth_pitch_deg"]) for r in h),
+            max(abs(r["proposed_amps"]) for r in h))
+
+
+# 0. positive control: 0 must be a no-op, and the flag must actually do something.
+a = run("zero_a", "full-stick", incline_deg=0.0, pitch_source="estimator")
+b = run("zero_b", "full-stick", pitch_source="estimator")
+same = all(x == y for ra, rb in zip(a, b) for x, y in zip(ra.values(), rb.values()))
+print(f"--incline-deg 0 is bit-identical to omitting it: {same}")
+
+which = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+if which in ("all", "idle"):
+    print("\nIDLE on a slope (zero stick) -- does it just stand there?")
+    print(f"{'incline':>8} {'inverted at':>12} {'peak pitch':>11} {'peak A':>8}")
+    for inc in (0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0):
+        t, p, amps = summarise(run(f"idle{inc}", "full-stick", incline_deg=inc,
+                                   cmd_reserve=0.0, pitch_source="estimator"))
+        print(f"{inc:8.2f} {('-' if t is None else f'{t:.3f}'):>12} {p:11.3f} {amps:8.2f}")
+
+if which in ("all", "hold"):
+    print("\nSHIPPED FULL-STICK HOLD on a slope (uphill positive, downhill negative)")
+    print(f"{'incline':>8} {'inverted at':>12} {'peak pitch':>11} {'peak A':>8}")
+    for inc in (-3.0, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 3.0):
+        t, p, amps = summarise(run(f"hold{inc}", "full-stick", incline_deg=inc,
+                                   pitch_source="estimator"))
+        print(f"{inc:8.2f} {('-' if t is None else f'{t:.3f}'):>12} {p:11.3f} {amps:8.2f}")
+
+if which in ("all", "rev"):
+    print("\nSTICK REVERSAL AT SPEED on a slope -- the matrix's worst point")
+    print(f"{'incline':>8} {'inverted at':>12} {'peak pitch':>11} {'peak A':>8}")
+    for inc in (-2.0, -1.0, -0.5, -0.25, 0.0, 0.25, 0.5, 1.0, 2.0):
+        t, p, amps = summarise(run(f"rev{inc}", "stick-reversal", incline_deg=inc,
+                                   pitch_source="estimator"))
+        print(f"{inc:8.2f} {('-' if t is None else f'{t:.3f}'):>12} {p:11.3f} {amps:8.2f}")

--- a/docs/decisions/adr-0011-evidence/incline_wide.py
+++ b/docs/decisions/adr-0011-evidence/incline_wide.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+import csv, subprocess, sys
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+INVERTED = 90.0
+SPEED_CAP_ONSET = 8.34
+
+
+def run(name, scenario, **kw):
+    out = OUT / f"w_{name}.csv"
+    argv = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+            "--scripted-scenario", scenario, "--free-run", "--stats-path", "none",
+            "--state-out-addr", "127.0.0.1:19801", "--input-in-addr", "127.0.0.1:19802",
+            "--trace-csv", str(out)]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+def report(rows):
+    t_inv = next((r["sim_time_s"] for r in rows if abs(r["truth_pitch_deg"]) > INVERTED), None)
+    h = [r for r in rows if t_inv is None or r["sim_time_s"] < t_inv]
+    sat = next((r["sim_time_s"] for r in h if r["saturated"] > 0.5), None)
+    warn = next((r["sim_time_s"] for r in h if r["authority_warning"] > 0.5), None)
+    sat_low = next((r["sim_time_s"] for r in h
+                    if r["saturated"] > 0.5 and abs(r["forward_speed_m_s"]) < SPEED_CAP_ONSET), None)
+    return (t_inv, max(abs(r["truth_pitch_deg"]) for r in h),
+            max(abs(r["proposed_amps"]) for r in h),
+            max(abs(r["forward_speed_m_s"]) for r in h), sat, sat_low, warn)
+
+
+def sweep(title, scenario, inclines, **kw):
+    print(f"\n{title}")
+    print(f"{'incline':>8} {'invert':>8} {'pk pitch':>9} {'pk A':>7} {'pk m/s':>7} "
+          f"{'sat':>7} {'sat<cap':>8} {'warn':>7}")
+    for inc in inclines:
+        t, p, a, v, sat, satlo, warn = report(run(f"{scenario}{inc}", scenario, incline_deg=inc, **kw))
+        f = lambda x: "-" if x is None else f"{x:.2f}"
+        print(f"{inc:8.2f} {f(t):>8} {p:9.3f} {a:7.2f} {v:7.3f} {f(sat):>7} {f(satlo):>8} {f(warn):>7}")
+
+
+which = sys.argv[1] if len(sys.argv) > 1 else "all"
+if which in ("all", "hold"):
+    sweep("SHIPPED FULL-STICK HOLD (+ uphill / - downhill)", "full-stick",
+          (-12, -10, -8, -6, -5, -4, -3, 0, 3, 4, 5, 6, 8, 10, 12), pitch_source="estimator")
+if which in ("all", "rev"):
+    sweep("STICK REVERSAL AT SPEED", "stick-reversal",
+          (-8, -6, -5, -4, -3, -2, 0, 2, 3, 4, 5, 6, 8), pitch_source="estimator")
+if which in ("all", "idle"):
+    sweep("IDLE (zero stick) -- rolls downhill, nothing holds position", "full-stick",
+          (1, 3, 5, 10, 15, 20, 25, 30), cmd_reserve=0.0, pitch_source="estimator")

--- a/docs/decisions/adr-0011-evidence/onewheel_compare.py
+++ b/docs/decisions/adr-0011-evidence/onewheel_compare.py
@@ -1,0 +1,78 @@
+"""How far are we from the CEO's cited Onewheel figure, and what sets the gap?"""
+from __future__ import annotations
+import csv, math, subprocess
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+
+MAX_A, KT, R_EFF, MASS = 40.0, 0.7, 0.1454, 82.5
+FT = 3.28084
+BRAKE_T0 = 12.5
+
+
+def run(name, scen, **kw):
+    o = OUT / f"ow_{name}.csv"
+    a = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+         "--scripted-scenario", scen, "--free-run", "--stats-path", "none",
+         "--pitch-source", "estimator",
+         "--state-out-addr", "127.0.0.1:19881", "--input-in-addr", "127.0.0.1:19882",
+         "--trace-csv", str(o)]
+    for k, v in kw.items():
+        a += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(a, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(o.open())]
+
+
+def stop_from(rows, v_target):
+    """Distance and time from the moment speed falls past v_target, to zero."""
+    dt = rows[1]["sim_time_s"] - rows[0]["sim_time_s"]
+    started, dist, t0 = False, 0.0, None
+    for r in rows:
+        if r["sim_time_s"] < BRAKE_T0:
+            continue
+        if not started:
+            if r["forward_speed_m_s"] <= v_target:
+                started, t0 = True, r["sim_time_s"]
+            else:
+                continue
+        if r["forward_speed_m_s"] <= 0.0:
+            return dist, r["sim_time_s"] - t0
+        dist += r["forward_speed_m_s"] * dt
+    return dist, None
+
+
+print("THE PHYSICAL CEILING, before any tuning")
+tau = MAX_A * KT
+force = tau / R_EFF
+a_max = force / MASS
+print(f"  motor torque at the 40 A envelope : {tau:.1f} N*m")
+print(f"  contact force (r_eff {R_EFF} m)   : {force:.1f} N")
+print(f"  on {MASS} kg                       : {a_max:.2f} m/s^2 = {a_max/9.80665:.3f} g")
+for v in (5.4, 6.7, 9.34):
+    d = v * v / (2 * a_max)
+    print(f"  ideal stop from {v:4.2f} m/s        : {d:5.1f} m = {d*FT:5.1f} ft "
+          f"(at the ceiling, instantly, which the board cannot do)")
+
+print("\nWHAT WE ACTUALLY DO (braking reserve 0.90)")
+rows = run("stop", "brake-stop")
+for v in (9.68, 6.7, 5.4):
+    d, t = stop_from(rows, v)
+    print(f"  measured stop from {v:4.2f} m/s   : {d:5.1f} m = {d*FT:5.1f} ft"
+          + (f", {t:.2f} s" if t else ""))
+
+peak_a = max(abs(r["proposed_amps"]) for r in rows if r["sim_time_s"] >= BRAKE_T0
+             and r["forward_speed_m_s"] > 0)
+print(f"\n  peak demand used during the stop  : {peak_a:.1f} A of {MAX_A:.0f} "
+      f"({100*peak_a/MAX_A:.0f}% of envelope)")
+print(f"  so peak decel achieved            : {peak_a*KT/R_EFF/MASS:.2f} m/s^2 "
+      f"= {peak_a*KT/R_EFF/MASS/9.80665:.3f} g")
+
+print("\nTHE CEO'S CITED REFERENCE (not independently verified here)")
+print("  Onewheel quick stop: ~14 ft from cruise (12-15 mph = 5.4-6.7 m/s)")
+for v in (5.4, 6.7):
+    print(f"    implies {v*v/(2*4.27):.2f} m/s^2 = {v*v/(2*4.27)/9.80665:.2f} g from {v} m/s")
+print("  NOTE: that figure is quoted for the TAIL-DRAG maneuver -- scraping the")
+print("  bumper on the pavement. That is friction braking we do not model at all,")
+print("  in addition to motor braking.")

--- a/docs/decisions/adr-0011-evidence/settled.py
+++ b/docs/decisions/adr-0011-evidence/settled.py
@@ -1,0 +1,73 @@
+"""The two candidate instruments, and their spread.
+
+A. STATIC OFFSET -- zero commanded stick, late window. No acceleration, filter
+   fully settled: whatever is left is the trim itself.
+B. THE 1-rad/g IDENTITY -- settled tail of an accelerating hold: mean residual
+   against mean atan(a_unaided/g). Ratio should be 1.00.
+"""
+from __future__ import annotations
+import csv, math, subprocess
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+G = 9.80665
+ACCEL_FF_GAIN = 0.0584
+
+
+def run(name, scenario, **kw):
+    out = OUT / f"s_{name}.csv"
+    argv = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+            "--scripted-scenario", scenario, "--free-run", "--stats-path", "none",
+            "--state-out-addr", "127.0.0.1:19701", "--input-in-addr", "127.0.0.1:19702",
+            "--trace-csv", str(out)]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+def settled(rows, t_lo, t_hi, half=50):
+    res, pred = [], []
+    for i in range(half, len(rows) - half):
+        t = rows[i]["sim_time_s"]
+        if not t_lo <= t <= t_hi:
+            continue
+        a = (rows[i+half]["forward_speed_m_s"] - rows[i-half]["forward_speed_m_s"]) / (
+            rows[i+half]["sim_time_s"] - rows[i-half]["sim_time_s"])
+        au = a - ACCEL_FF_GAIN * rows[i]["applied_amps"]
+        res.append(rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"])
+        pred.append(math.degrees(math.atan(au / G)))
+    return sum(res)/len(res), sum(pred)/len(pred), min(res), max(res)
+
+
+print("A. STATIC OFFSET -- zero stick")
+rows0 = run("zero", "full-stick", cmd_reserve=0.0, pitch_source="estimator")
+print(f"   run length {rows0[-1]['sim_time_s']:.1f} s")
+for lo, hi in ((3, 8), (5, 10), (8, 15), (10, 18), (3, 18)):
+    m, p, mn, mx = settled(rows0, lo, hi)
+    print(f"   [{lo:2d},{hi:2d}]  residual mean {m:+.4f}  min {mn:+.4f}  max {mx:+.4f}  (pred {p:+.4f})")
+
+print("\nB. THE IDENTITY -- settled tail, ratio residual/atan(a_unaided/g)")
+print(f"   {'case':30} {'resid':>9} {'pred':>9} {'ratio':>7}")
+ratios = []
+cases = [(f"full-stick r={u}", "full-stick", dict(cmd_reserve=u, pitch_source="estimator"))
+         for u in (0.4, 0.6, 0.8, 1.0)]
+cases += [("stick-reversal shipped", "stick-reversal", dict(pitch_source="estimator"))]
+for label, scen, kw in cases:
+    rows = run(label.replace(" ", "_").replace("=", "").replace(".", ""), scen, **kw)
+    for lo, hi in ((12, 18),):
+        m, p, _, _ = settled(rows, lo, hi)
+        r = m / p if abs(p) > 1e-6 else float("nan")
+        ratios.append(r)
+        print(f"   {label:30} {m:+9.4f} {p:+9.4f} {r:7.4f}")
+
+print(f"\n   ratio span {min(ratios):.4f} .. {max(ratios):.4f}")
+
+print("\n   window sensitivity, full-stick r=0.8:")
+rows = run("full-stick_r08", "full-stick", cmd_reserve=0.8, pitch_source="estimator")
+for lo, hi in ((11, 15), (12, 18), (13, 19), (12, 16), (14, 20)):
+    m, p, _, _ = settled(rows, lo, hi)
+    print(f"     [{lo:2d},{hi:2d}]  resid {m:+.4f}  pred {p:+.4f}  ratio {m/p:.4f}")

--- a/docs/decisions/adr-0011-evidence/shape.py
+++ b/docs/decisions/adr-0011-evidence/shape.py
@@ -1,0 +1,22 @@
+"""Is there a quasi-steady window where residual/unaided-specific-force settles?"""
+import csv, math
+from pathlib import Path
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+ACCEL_FF_GAIN = 0.0584
+ONE = math.degrees(1.0) / 9.80665
+
+for tag in ("full-stick_reserve0.6", "full-stick_reserve0.8", "stick-reversal_shipped"):
+    rows = [{k: float(v) for k, v in r.items()} for r in csv.DictReader((OUT / f"{tag}.csv").open())]
+    half = 50
+    print(f"\n=== {tag} ===")
+    print(f"{'t':>6} {'speed':>7} {'a_unaid':>8} {'resid':>7} {'ratio':>7} {'pred':>7}")
+    for i in range(half, len(rows) - half, 250):
+        t = rows[i]["sim_time_s"]
+        if t > 22: break
+        a = (rows[i+half]["forward_speed_m_s"] - rows[i-half]["forward_speed_m_s"]) / (
+            rows[i+half]["sim_time_s"] - rows[i-half]["sim_time_s"])
+        au = a - ACCEL_FF_GAIN * rows[i]["applied_amps"]
+        res = rows[i]["est_pitch_deg"] - rows[i]["truth_pitch_deg"]
+        pred = math.degrees(math.atan(au / 9.80665))
+        print(f"{t:6.2f} {rows[i]['forward_speed_m_s']:7.3f} {au:8.4f} {res:7.4f} "
+              f"{res/au if abs(au)>1e-3 else float('nan'):7.3f} {pred:7.4f}")

--- a/docs/decisions/adr-0011-evidence/slope_vs_trim.py
+++ b/docs/decisions/adr-0011-evidence/slope_vs_trim.py
@@ -1,0 +1,45 @@
+"""Does the 42 A/unit peak-demand slope actually depend on the trim?"""
+from __future__ import annotations
+import csv, subprocess
+from pathlib import Path
+
+REPO = Path("/Users/mike/projects/overboard")
+OUT = Path("/private/tmp/claude-501/-Users-mike-projects-overboard/94162fbe-f42c-4c5a-98c3-d48ab1fac1dc/scratchpad")
+INVERTED = 90.0
+FRACTIONS = (0.30, 0.50, 0.70, 0.90)
+
+
+def run(name, **kw):
+    out = OUT / f"t_{name}.csv"
+    argv = ["cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+            "--scripted-scenario", "full-stick", "--free-run", "--stats-path", "none",
+            "--state-out-addr", "127.0.0.1:19831", "--input-in-addr", "127.0.0.1:19832",
+            "--pitch-source", "estimator", "--trace-csv", str(out)]
+    for k, v in kw.items():
+        argv += [f"--{k.replace('_','-')}", str(v)]
+    p = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr[-3000:]
+    with out.open() as f:
+        return [{k: float(v) for k, v in r.items()} for r in csv.DictReader(f)]
+
+
+def peak(rows):
+    t = next((r["sim_time_s"] for r in rows if abs(r["truth_pitch_deg"]) > INVERTED), None)
+    h = [r for r in rows if t is None or r["sim_time_s"] < t]
+    return max(abs(r["proposed_amps"]) for r in h), t
+
+
+print(f"{'bias':>7} {'slope':>8} {'d%':>7}  per-point peaks / inverted")
+base = None
+for bias in (-0.30, -0.20, -0.10, 0.0, 0.10, 0.20, 0.30):
+    peaks, inv = [], []
+    for u in FRACTIONS:
+        pk, t = peak(run(f"{bias}_{u}", cmd_reserve=u, pitch_bias_deg=bias))
+        peaks.append(pk)
+        inv.append("-" if t is None else f"{t:.1f}")
+    slope = sum(u * a for u, a in zip(FRACTIONS, peaks)) / sum(u * u for u in FRACTIONS)
+    if bias == 0.0:
+        base = slope
+    d = "" if base is None else f"{100*(slope-base)/base:+7.2f}"
+    print(f"{bias:7.2f} {slope:8.3f} {d:>7}  " +
+          " ".join(f"{p:.2f}" for p in peaks) + "   inv: " + " ".join(inv))


### PR DESCRIPTION
## What

Adds `docs/decisions/adr-0011-evidence/` — eleven measurement scripts, rescued verbatim from a session-scoped scratchpad, plus a README that maps each one to the decision it supports.

## Why

ADR-0011, its two ratifications, #207, #218 and #219 all rest on numbers produced by scripts that existed **only** in `/private/tmp/claude-501/…`. The conclusions were merged; the working that produced them was not, and nothing preserves that directory. This closes that asymmetry for the one decision currently gating the launch.

Copied **unmodified on purpose** — none of them run as-is (hardcoded scratchpad paths, and `onewheel_compare.py` still opens at `MAX_A = 40.0`). Repointing them would be re-deriving another role's evidence while calling it preservation. The README states this and hands the port to whoever re-runs them.

The 178 CSVs (262 MB) are deliberately **not** rescued — regenerable from the scripts, and the repo does not carry what a build can reproduce. Their naming scheme is documented instead.

## The find worth reading

`onewheel_compare.py` is timestamped **16:06 on 2026-08-02 — after that session's teardown commit**, making it the only surviving artefact of work that was never written up. It asks "How far are we from the CEO's cited Onewheel figure, and what sets the gap?" (#204). Minutes later the working tree gained an uncommitted 40 A → 60 A sweep, now banked unvalidated on `feat/controls/realistic-motor-torque`.

That chain is **inference from timestamps, not a recorded conclusion**, and the README says so. But 28 → 42 N·m is a 50% authority increase against a margin ADR-0011 measured at ~zero — so if it survives validation it is an ADR-0011 question, not a parameter change. Routing that separately.

## Acceptance criteria

None moved. This is inert: no test, no build step and no code path references the directory, and CI collects pytest from `tests/` only.

## Turf

`/docs/decisions/` is COO by CODEOWNERS (line 54). No crossing.