### PR TITLE
feat(controls): flash_pi.sh proposes the single removable disk, so a reflash is one command (#182)

### DIFF
--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # Flash an Overboard image to an SD card and stage credentials onto it.
 #
-#     scripts/pi/flash_pi.sh --disk /dev/disk4                 # newest release
-#     scripts/pi/flash_pi.sh --disk /dev/disk4 --image ./x.img.xz
-#     scripts/pi/flash_pi.sh --disk /dev/disk4 --dry-run       # rehearse
+#     scripts/pi/flash_pi.sh                                   # newest release
+#     scripts/pi/flash_pi.sh --disk /dev/disk4                 # explicit target
+#     scripts/pi/flash_pi.sh --image ./x.img.xz                # local image
+#     scripts/pi/flash_pi.sh --dry-run                         # rehearse
+#
+# With no --disk, the one removable disk in the machine is proposed. Zero or
+# more than one is an error, never a guess. Detection only ever REMOVES the
+# lookup step -- the confirmation prompt below still has to be answered by
+# hand, because the failure this script exists to prevent is writing to the
+# wrong disk, and a target the script chose deserves more scrutiny than one
+# you typed, not less.
 #
 # THIS WRITES TO A RAW BLOCK DEVICE. The classic way to lose a laptop's
 # internal disk is a mistyped device path in exactly this kind of script, so
@@ -36,7 +44,12 @@ die() { echo "error: $*" >&2; exit 1; }
 say() { echo "==> $*"; }
 
 usage() {
-  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  # Print the header block, whatever length it happens to be: everything from
+  # line 2 up to (not including) the first line of actual code. The previous
+  # hard-coded '2,30p' silently truncated the moment the header grew, which is
+  # how --help starts lying about a script whose whole job is not to surprise
+  # you.
+  sed -n '2,/^set -/p' "${BASH_SOURCE[0]}" | sed '$d' | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -52,16 +65,55 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$DISK" ] || die "--disk is required. There is no default: a default target
-       for a raw write is a loaded gun. Find yours with:
-         macOS:  diskutil list external
-         Linux:  lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT"
-
 OS="$(uname -s)"
 case "$OS" in
   Darwin|Linux) ;;
   *) die "unsupported platform: $OS" ;;
 esac
+
+# ---------------------------------------------------------------------------
+# Target selection.
+#
+# --disk still wins outright. With no --disk we PROPOSE the single removable
+# disk rather than requiring the operator to go and look it up -- but only
+# when there is exactly one. Zero or several is an error, never a guess: the
+# whole point of this script is that it does not write to the wrong disk, and
+# "pick the first one" is how that promise gets broken.
+#
+# What detection removes is the lookup step, not a safety step. Guard 1
+# (removable-only) and guard 2 (type the identifier back) both still run
+# against whatever lands in $DISK, and they run identically whether a human
+# or this function chose it. A target the script picked deserves the SAME
+# scrutiny as one that was typed, not less.
+# ---------------------------------------------------------------------------
+removable_disks() {
+  if [ "$OS" = "Darwin" ]; then
+    diskutil list external physical 2>/dev/null | awk '/^\/dev\/disk/{print $1}'
+  else
+    # RM=1 is the kernel's own removable flag -- the same bit guard 1 checks.
+    lsblk -dno NAME,RM 2>/dev/null | awk '$2 == 1 { print "/dev/" $1 }'
+  fi
+}
+
+if [ -z "$DISK" ]; then
+  FOUND="$(removable_disks || true)"
+  COUNT="$(printf '%s\n' "$FOUND" | grep -c '^/dev/' || true)"
+  case "$COUNT" in
+    1)
+      DISK="$(printf '%s\n' "$FOUND" | grep '^/dev/')"
+      say "no --disk given; exactly one removable disk present: $DISK"
+      ;;
+    0)
+      die "no --disk given, and no removable disk was found.
+       Insert the card, or name the target explicitly:
+         macOS:  diskutil list external
+         Linux:  lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT" ;;
+    *)
+      die "no --disk given, and $COUNT removable disks are present:
+$(printf '%s\n' "$FOUND" | grep '^/dev/' | sed 's/^/         /')
+       Refusing to choose between them -- pick one with --disk." ;;
+  esac
+fi
 
 # ---------------------------------------------------------------------------
 # Guard 1: the target must be removable. Refused, not warned about.


### PR DESCRIPTION
CEO ask, from the first-boot session: make reloading the Pi "put the SD card in, run a command, done" rather than look-up-the-device-then-run-a-command.

## What changed

`--disk` becomes optional. With no `--disk`, the script proposes the removable disk **when there is exactly one**. Zero or several is an error, never a guess.

```sh
scripts/pi/flash_pi.sh                      # was: diskutil list external, then --disk /dev/diskN
```

## What deliberately did NOT change

**Detection removes the lookup step, not a safety step.** Both guards still run against whatever lands in `$DISK`, identically whether a human or the script chose it:

- Guard 1 (removable-only, internal disks refused outright) runs on the detected disk too — and on Linux detection uses `RM=1`, the same kernel flag guard 1 checks, so they cannot disagree.
- Guard 2 (**type the device identifier back**) is unchanged and still mandatory. A target the script picked deserves the *same* scrutiny as one that was typed, not less — this is the one prompt standing between a flashed card and a flashed laptop, and convenience is not a reason to weaken it.

Refusing to choose when several removable disks are present is the load-bearing part. "Pick the first one" is exactly how a script like this breaks its promise.

## Drive-by fix, caught by making it

`usage()` hard-coded `sed -n '2,30p'` to print the header. Growing the header by nine lines silently truncated `--help` — a script whose entire job is not to surprise you, quietly lying about its own interface. Now it prints from line 2 to the first line of code, so it cannot drift again.

## Testing

- `bash -n` clean; `--help` renders the full header.
- **Zero-disk path exercised on macOS** (no card inserted): errors with the manual lookup instructions.
- Both `awk` parsers verified against real `diskutil list external physical` and `lsblk -dno NAME,RM` output shapes, including the multi-disk case.
- **Not exercised: the one-disk and multi-disk live paths** — no card was in the reader at the time. The parsing is covered above, but the end-to-end single-disk run is unverified until the next real flash. Stated rather than implied.
- Avoids `mapfile`/`readarray` throughout: macOS ships bash 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)