### PR TITLE
fix(controls): loop-profiler can't print a bare AC-5: PASS anymore (#226)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,10 +135,11 @@ jobs:
             --cycles 1000 --no-rt --json /tmp/loop-profile.json
           test -s /tmp/loop-profile.json
           python3 -c "import json,sys; d=json.load(open('/tmp/loop-profile.json')); \
-            assert d['schema_version']==1, d; \
+            assert d['schema_version']==2, d; \
             assert d['wake_late']['count']==1000, d['wake_late']; \
             assert d['compute']['max_ns']>0, 'control law did not execute'; \
             assert d['ac5']['verdict'] is None, 'a non-RT runner must not return a verdict'; \
+            assert len(d['ac5']['gaps'])>0, 'a withheld verdict must say why (issue #226)'; \
             print('harness ok:', d['platform'])"
 
       # I4 (issue #182): no credential may enter a public repository. Runs in

--- a/crates/loop-profiler/src/bin/overboard-loop-profile.rs
+++ b/crates/loop-profiler/src/bin/overboard-loop-profile.rs
@@ -46,13 +46,19 @@ fn print_help() {
     );
     println!("    --no-rt            Stay at normal priority. Numbers describe a");
     println!("                       fair-share scheduler, not a real-time one.");
+    println!("    --under-load       Attest that stress-ng CPU + network load was running");
+    println!("                       throughout this run. This process cannot observe that");
+    println!("                       about its own machine, so a PASS without this flag is");
+    println!("                       always withheld -- see AC-5's own load requirement.");
     println!("    --json <PATH>      Also write the machine-readable report.");
     println!("    --strict           Exit 1 if an acceptance-grade run fails AC-5.");
     println!("    -h, --help         Print this help and exit.");
     println!();
-    println!("At the default rate a 100000-cycle run takes about 200 seconds.");
-    println!("Run cyclictest alongside this, not instead of it: that measures the");
-    println!("kernel, this measures our loop on it.");
+    println!("At the default rate a 100000-cycle run takes about 200 seconds -- short of");
+    println!("AC-5's own 30-minute floor by design; pass --cycles 900000 (or more) for an");
+    println!("actual AC-5 attempt. Run cyclictest alongside this, not instead of it: that");
+    println!("measures the kernel, this measures our loop on it. This tool is never a");
+    println!("substitute for cyclictest, no matter what flags are passed.");
 }
 
 fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<Args, String> {
@@ -109,6 +115,7 @@ fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<Args, String> {
                 cfg.rt_prio = Some(p);
             }
             "--no-rt" => cfg.rt_prio = None,
+            "--under-load" => cfg.under_load = true,
             "--json" => json_path = Some(next_val(&mut argv, "--json")?),
             "--strict" => strict = true,
             "-h" | "--help" => {
@@ -220,5 +227,11 @@ mod tests {
         let a = parse(&["--json", "/tmp/x.json", "--strict"]).unwrap();
         assert_eq!(a.json_path.as_deref(), Some("/tmp/x.json"));
         assert!(a.strict);
+    }
+
+    #[test]
+    fn under_load_defaults_off_and_the_flag_turns_it_on() {
+        assert!(!parse(&[]).unwrap().cfg.under_load);
+        assert!(parse(&["--under-load"]).unwrap().cfg.under_load);
     }
 }

--- a/crates/loop-profiler/src/profile.rs
+++ b/crates/loop-profiler/src/profile.rs
@@ -43,6 +43,12 @@ pub const DEFAULT_PERIOD_NS: u64 = 2_000_000;
 pub const AC5_P999_LIMIT_NS: u64 = 150_000;
 pub const AC5_MAX_LIMIT_NS: u64 = 500_000;
 
+/// AC-5's duration requirement: `-D 30m`. At the default 500 Hz that is
+/// 900,000 counted cycles, not the 100,000 (200 s) this tool's own `Config`
+/// default runs -- so a default-configured run must never be able to print
+/// `AC-5: PASS` (issue #226 defect 1).
+pub const AC5_MIN_DURATION_NS: u64 = 30 * 60 * 1_000_000_000;
+
 /// Control-law constants, mirroring `sim-host`'s.
 ///
 /// **Duplicated deliberately, and safe to duplicate.** Importing them would
@@ -79,6 +85,12 @@ pub struct Config {
     pub warmup: u64,
     /// `SCHED_FIFO` priority, or `None` to stay at normal priority.
     pub rt_prio: Option<i32>,
+    /// Operator attestation that `stress-ng` CPU + network load was running
+    /// throughout this run, per AC-5's `cyclictest -m -Sp95 -i 2000 -D 30m`
+    /// under load. Not something this process can observe about its own
+    /// machine, so it is a fact the caller supplies rather than one this
+    /// tool measures (issue #226 defect 1).
+    pub under_load: bool,
 }
 
 impl Default for Config {
@@ -88,12 +100,17 @@ impl Default for Config {
             // 10^5 cycles is AC-6's pre-registered run length; at 500 Hz
             // that is 200 s. Matching it here means the two measurements are
             // the same size when they are eventually read side by side.
+            // NOTE: this is well short of AC-5's own 30-minute duration --
+            // see `AC5_MIN_DURATION_NS` -- so a default run is never
+            // acceptance-grade on duration alone; `--cycles 900000` (or
+            // more) is required for an actual AC-5 attempt.
             cycles: 100_000,
             warmup: 500,
             // 80 leaves headroom below the kernel's own RT threads (the
             // mcp251xfd IRQ thread among them) rather than out-prioritising
             // the driver whose latency we care about.
             rt_prio: Some(80),
+            under_load: false,
         }
     }
 }
@@ -114,17 +131,61 @@ pub struct Report {
     /// the run. Reported because it is included in every `compute` sample
     /// and is not negligible at these magnitudes.
     pub clock_overhead_ns: u64,
+    /// Measured wall-clock span of the counted cycles (warmup excluded).
+    /// Because the loop paces to real deadlines this tracks `cycles *
+    /// period_ns` closely, but it is measured rather than assumed so a
+    /// duration gate means what it says.
+    pub elapsed_ns: u64,
 }
 
 impl Report {
+    /// Every AC-5 gate this run fails to clear, checked independently so a
+    /// withheld verdict says exactly what is missing instead of one bare
+    /// "NOT ASSESSED" (issue #226 defect 1).
+    ///
+    /// The `cyclictest` gap is unconditional: this tool is not `cyclictest`
+    /// and can never satisfy that condition of AC-5 by gating anything, so
+    /// it is always named rather than checked.
+    pub fn ac5_gaps(&self) -> Vec<&'static str> {
+        let mut gaps = Vec::new();
+        if !self.rt.is_acceptance_grade() {
+            gaps.push(
+                "platform: not confirmed PREEMPT_RT + mlockall + SCHED_FIFO (see platform line)",
+            );
+        }
+        if self.elapsed_ns < AC5_MIN_DURATION_NS {
+            gaps.push("duration: AC-5 requires >= 30 min measured; this run was shorter");
+        }
+        if !self.config.under_load {
+            gaps.push(
+                "load: not confirmed under CPU + network load (rerun with --under-load once \
+                 stress-ng is confirmed running)",
+            );
+        }
+        gaps.push(
+            "instrument: this tool is not cyclictest, the AC-5 instrument of record -- run \
+             cyclictest alongside it",
+        );
+        gaps
+    }
+
     /// Whether this run clears AC-5's thresholds.
     ///
-    /// `None` when the run was not acceptance-grade (wrong kernel, no
-    /// privileges) -- deliberately not `Some(false)`, because "we could not
+    /// `None` when any gate in [`Self::ac5_gaps`] besides the cyclictest one
+    /// is unmet -- deliberately not `Some(false)`, because "we could not
     /// measure this properly" and "the platform failed" are different
-    /// findings and only one of them is about the platform.
+    /// findings and only one of them is about the platform. The cyclictest
+    /// gap alone does not withhold a verdict: this tool can still say
+    /// whether ITS OWN measurement passed the pre-registered thresholds,
+    /// which `ac5_gaps` reports as a caveat next to any verdict.
     pub fn ac5_verdict(&self) -> Option<bool> {
         if !self.rt.is_acceptance_grade() {
+            return None;
+        }
+        if self.elapsed_ns < AC5_MIN_DURATION_NS {
+            return None;
+        }
+        if !self.config.under_load {
             return None;
         }
         Some(
@@ -230,8 +291,12 @@ pub fn run(cfg: Config) -> Report {
     let period = Duration::from_nanos(cfg.period_ns);
     let start = Instant::now();
     let mut deadline = start + period;
+    let mut counted_start: Option<Instant> = None;
 
     for i in 0..(cfg.warmup + cfg.cycles) {
+        if i == cfg.warmup {
+            counted_start = Some(Instant::now());
+        }
         // Built outside the timed span: synthesising an observation is this
         // harness's cost, not the control law's.
         let obs = synth_observation(i, cfg.period_ns);
@@ -284,6 +349,13 @@ pub fn run(cfg: Config) -> Report {
         deadline += period;
     }
 
+    // `unwrap_or(0)` covers `cfg.cycles == 0` only: the loop body above
+    // always sets `counted_start` on its first iteration whenever there is
+    // at least one cycle to run, counted or warmup.
+    let elapsed_ns = counted_start
+        .map(|s| s.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
+
     Report {
         config: cfg,
         rt: status,
@@ -291,6 +363,7 @@ pub fn run(cfg: Config) -> Report {
         compute: summarise(&mut compute_ns),
         overruns,
         clock_overhead_ns,
+        elapsed_ns,
     }
 }
 
@@ -306,6 +379,7 @@ mod tests {
             // Never request RT in a test: on a privileged CI runner it would
             // actually succeed and pin a test thread at FIFO 80.
             rt_prio: None,
+            under_load: false,
         }
     }
 
@@ -333,6 +407,75 @@ mod tests {
         let r = run(short_run());
         assert!(!r.rt.is_acceptance_grade());
         assert_eq!(r.ac5_verdict(), None);
+    }
+
+    /// A `Report` built directly rather than via `run()`, so the AC-5 gating
+    /// tests below don't need a real 30-minute timed loop to exercise the
+    /// duration/load gates (issue #226 defect 1).
+    fn full_platform_report() -> Report {
+        Report {
+            config: Config {
+                under_load: true,
+                ..short_run()
+            },
+            rt: RtStatus {
+                memory_locked: Some(true),
+                sched_fifo_prio: Some(80),
+                preempt_rt: Some(true),
+                ..Default::default()
+            },
+            wake_late: Percentiles {
+                p999_ns: AC5_P999_LIMIT_NS,
+                max_ns: AC5_MAX_LIMIT_NS,
+                ..Percentiles::EMPTY
+            },
+            compute: Percentiles::EMPTY,
+            overruns: 0,
+            clock_overhead_ns: 0,
+            elapsed_ns: AC5_MIN_DURATION_NS,
+        }
+    }
+
+    #[test]
+    fn a_default_configured_run_is_too_short_to_pass_ac5_by_duration_alone() {
+        // The exact bug issue #226 reported: an idle 200 s run must not be
+        // able to print AC-5: PASS.
+        let d = Config::default();
+        assert!(
+            d.cycles * d.period_ns < AC5_MIN_DURATION_NS,
+            "default cycles*period must stay short of AC-5's 30-minute floor"
+        );
+    }
+
+    #[test]
+    fn full_platform_and_duration_but_no_load_withholds_the_verdict() {
+        let mut r = full_platform_report();
+        r.config.under_load = false;
+        assert_eq!(r.ac5_verdict(), None);
+        assert!(r.ac5_gaps().iter().any(|g| g.starts_with("load:")));
+    }
+
+    #[test]
+    fn full_platform_and_load_but_short_duration_withholds_the_verdict() {
+        let mut r = full_platform_report();
+        r.elapsed_ns = AC5_MIN_DURATION_NS - 1;
+        assert_eq!(r.ac5_verdict(), None);
+        assert!(r.ac5_gaps().iter().any(|g| g.starts_with("duration:")));
+    }
+
+    #[test]
+    fn every_gate_met_yields_a_real_verdict_with_the_cyclictest_gap_still_named() {
+        let r = full_platform_report();
+        assert_eq!(r.ac5_verdict(), Some(true));
+        // The one gap that gating can never close: this tool is not the
+        // instrument AC-5 names, so it is always disclosed alongside a PASS.
+        assert!(r.ac5_gaps().iter().any(|g| g.starts_with("instrument:")));
+        assert_eq!(
+            r.ac5_gaps().len(),
+            1,
+            "only the unconditional gap should remain: {:?}",
+            r.ac5_gaps()
+        );
     }
 
     #[test]

--- a/crates/loop-profiler/src/report.rs
+++ b/crates/loop-profiler/src/report.rs
@@ -7,11 +7,16 @@
 //! `serde_json` -- the schema is flat, it is the only JSON this crate emits,
 //! and a dependency is a poor trade for twenty lines.
 
-use crate::profile::{Report, AC5_MAX_LIMIT_NS, AC5_P999_LIMIT_NS};
+use crate::profile::{Report, AC5_MAX_LIMIT_NS, AC5_MIN_DURATION_NS, AC5_P999_LIMIT_NS};
 use crate::stats::Percentiles;
 
 /// Bump on any incompatible field change.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// v2 (issue #226): `ac5.verdict` now also gates on measured duration and
+/// operator-attested load, not platform alone -- a `true` under v1 semantics
+/// can now be `null` under v2 for the same platform, so a consumer diffing
+/// across schema versions needs to know that changed.
+pub const SCHEMA_VERSION: u32 = 2;
 
 fn us(ns: u64) -> f64 {
     ns as f64 / 1_000.0
@@ -67,16 +72,23 @@ pub fn render_text(r: &Report) -> String {
         us(AC5_MAX_LIMIT_NS),
     ));
     match r.ac5_verdict() {
-        Some(true) => s.push_str("  AC-5: PASS\n"),
+        // A bare PASS is exactly what issue #226 found gets pasted into the
+        // acceptance record as if it were the full criterion -- so the gaps
+        // this run still cannot close (load self-attestation, cyclictest
+        // itself) print immediately underneath every verdict, pass or fail.
+        Some(true) => s.push_str("  AC-5: PASS (this tool's own measurement only -- see gaps below)\n"),
         Some(false) => {
             s.push_str("  AC-5: FAIL - escalate as an architecture finding, do not tune it away\n")
         }
         // The distinction the whole report is built around: not measurable
         // and failed are different findings, and only one is about the Pi.
         None => s.push_str(
-            "  AC-5: NOT ASSESSED - this run was not acceptance-grade, so these numbers\n         \
+            "  AC-5: NOT ASSESSED - this run does not clear every AC-5 gate, so these numbers\n         \
              exercise the harness and describe this machine. They are not an AC-5 result.\n",
         ),
+    }
+    for gap in r.ac5_gaps() {
+        s.push_str(&format!("    - {gap}\n"));
     }
 
     for w in &r.rt.warnings {
@@ -133,6 +145,12 @@ pub fn render_json(r: &Report, git_sha: &str) -> String {
         Some(p) => p.to_string(),
         None => "null".to_string(),
     };
+    let gaps = r
+        .ac5_gaps()
+        .iter()
+        .map(|g| format!("\"{}\"", esc(g)))
+        .collect::<Vec<_>>()
+        .join(", ");
 
     format!(
         "{{\n  \"schema_version\": {SCHEMA_VERSION},\n  \
@@ -147,8 +165,10 @@ pub fn render_json(r: &Report, git_sha: &str) -> String {
          \"compute\": {},\n  \
          \"overruns\": {},\n  \
          \"clock_overhead_ns\": {},\n  \
+         \"elapsed_ns\": {},\n  \
          \"ac5\": {{\"p999_limit_ns\": {AC5_P999_LIMIT_NS}, \"max_limit_ns\": {AC5_MAX_LIMIT_NS}, \
-         \"verdict\": {}}},\n  \
+         \"min_duration_ns\": {AC5_MIN_DURATION_NS}, \"under_load\": {}, \
+         \"verdict\": {}, \"gaps\": [{}]}},\n  \
          \"warnings\": [{}]\n}}\n",
         esc(git_sha),
         r.config.period_ns,
@@ -164,7 +184,10 @@ pub fn render_json(r: &Report, git_sha: &str) -> String {
         pct_json(&r.compute),
         r.overruns,
         r.clock_overhead_ns,
+        r.elapsed_ns,
+        r.config.under_load,
         opt_bool(r.ac5_verdict()),
+        gaps,
         warnings,
     )
 }
@@ -210,6 +233,7 @@ mod tests {
             cycles: 20,
             warmup: 2,
             rt_prio: None,
+            under_load: false,
         })
     }
 
@@ -226,15 +250,27 @@ mod tests {
     #[test]
     fn json_is_parseable_and_carries_provenance() {
         let j = render_json(&a_report(), "abc1234");
-        assert!(j.contains("\"schema_version\": 1"));
+        assert!(j.contains("\"schema_version\": 2"));
         assert!(j.contains("\"git_sha\": \"abc1234\""));
         assert!(j.contains("\"verdict\": null"));
         assert!(j.contains("\"acceptance_grade\": false"));
-        // Balanced braces is a cheap structural check on hand-rolled JSON.
+        assert!(j.contains("\"under_load\": false"));
+        // Balanced braces/brackets is a cheap structural check on hand-rolled JSON.
         assert_eq!(
             j.chars().filter(|&c| c == '{').count(),
             j.chars().filter(|&c| c == '}').count(),
         );
+        assert_eq!(
+            j.chars().filter(|&c| c == '[').count(),
+            j.chars().filter(|&c| c == ']').count(),
+        );
+    }
+
+    #[test]
+    fn a_platform_gap_and_the_cyclictest_gap_are_always_named_off_rt() {
+        let j = render_json(&a_report(), "abc1234");
+        assert!(j.contains("not confirmed PREEMPT_RT"));
+        assert!(j.contains("this tool is not cyclictest"));
     }
 
     #[test]

--- a/crates/loop-profiler/src/rt.rs
+++ b/crates/loop-profiler/src/rt.rs
@@ -70,6 +70,16 @@ impl RtStatus {
     }
 }
 
+/// Whether a `uname -v` string names a PREEMPT_RT build, e.g.
+/// `#1 SMP PREEMPT_RT Debian 1:6.12.34-1 (2025-06-xx)`.
+///
+/// A free function at module scope, not inside the Linux-only `imp` module,
+/// so it is unit-testable on every platform this crate builds on without a
+/// subprocess or a cfg-gate.
+fn detect_preempt_rt_from_uname_v(v: &str) -> bool {
+    v.contains("PREEMPT_RT")
+}
+
 #[cfg(target_os = "linux")]
 mod imp {
     use super::RtStatus;
@@ -81,9 +91,22 @@ mod imp {
     /// value of the no-Pi coverage rule (AC-12) is that this harness is
     /// exercised long before the numbers matter.
     pub fn acquire(prio: Option<i32>) -> RtStatus {
+        let mut preempt_rt = read_trimmed("/sys/kernel/realtime").map(|v| v == "1");
+        if preempt_rt.is_none() {
+            // `/sys/kernel/realtime` is the primary source, but its absence
+            // is not itself evidence of a non-RT kernel -- it is evidence
+            // the file was not there to read (issue #226 defect 2: this
+            // branch has never once been exercised on a real RT kernel, so
+            // an unexpectedly missing file must not silently make AC-5
+            // unmeasurable forever). `uname -v` is a second, independent
+            // source: Debian/Raspberry Pi OS RT kernels stamp `PREEMPT_RT`
+            // into it.
+            preempt_rt = uname_v().map(|v| super::detect_preempt_rt_from_uname_v(&v));
+        }
+
         let mut status = RtStatus {
             kernel_release: read_trimmed("/proc/sys/kernel/osrelease"),
-            preempt_rt: read_trimmed("/sys/kernel/realtime").map(|v| v == "1"),
+            preempt_rt,
             ..Default::default()
         };
 
@@ -136,6 +159,17 @@ mod imp {
         std::fs::read_to_string(path)
             .ok()
             .map(|s| s.trim().to_string())
+    }
+
+    /// `uname -v` output, or `None` if the command could not be run at all --
+    /// which leaves the caller with no second opinion, not a false one.
+    fn uname_v() -> Option<String> {
+        std::process::Command::new("uname")
+            .arg("-v")
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
     }
 }
 
@@ -214,5 +248,21 @@ mod tests {
         // Runs on whatever the CI runner is, privileged or not.
         let status = acquire(None);
         assert!(!status.summary().is_empty());
+    }
+
+    #[test]
+    fn uname_v_fallback_recognises_a_real_pi_rt_string() {
+        // The actual string this fallback exists for (issue #226 defect 2),
+        // reported from the CEO's Pi 5 Rev 1.1.
+        assert!(detect_preempt_rt_from_uname_v(
+            "#1 SMP PREEMPT_RT Debian 1:6.12.34-1 (2025-06-xx)"
+        ));
+    }
+
+    #[test]
+    fn uname_v_fallback_does_not_see_rt_in_a_stock_kernel_string() {
+        assert!(!detect_preempt_rt_from_uname_v(
+            "#1 SMP Debian 1:6.12.34-1 (2025-06-xx)"
+        ));
     }
 }


### PR DESCRIPTION
## What changed

Two defects found running `loop-profiler` on real Pi 5 hardware for the first time (#226):

**Defect 1 — `ac5_verdict()` only checked platform, not AC-5's other two conditions.**
AC-5 reads `cyclictest -m -Sp95 -i 2000 -D 30m` under `stress-ng` CPU + network load. The old
`is_acceptance_grade()` gate checked `mlockall` + `SCHED_FIFO` + `PREEMPT_RT` only — nothing
checked duration (≥30 min) or load, and nothing ever disclosed that this tool is not
`cyclictest`, the instrument of record. A default-configured 200 s idle run could print
`AC-5: PASS` and be quoted as the full acceptance record.

Now:
- `Report::elapsed_ns` measures actual wall-clock span of the counted cycles; `ac5_verdict()`
  withholds unless it clears `AC5_MIN_DURATION_NS` (30 min). The tool's own `Config::default()`
  (100k cycles ≈ 200 s) is asserted in a test to always stay short of that floor.
- A new `--under-load` flag records operator attestation that `stress-ng` was running
  throughout — this process cannot observe load on its own machine, so it's a supplied fact,
  not a measured one.
- `Report::ac5_gaps()` reports exactly which AC-5 gate(s) are unmet instead of one bare
  "NOT ASSESSED". The cyclictest-instrument gap is unconditional (this tool is never a
  substitute) and is always printed next to the verdict line, pass or fail, in both the text
  and JSON report.

**Defect 2 — `preempt_rt` detection had never been exercised on a real RT kernel.**
It depended solely on `/sys/kernel/realtime`, and if that file is ever absent for any reason
the tool reports `rt:unknown` forever with no fallback. Added a `uname -v` fallback (Debian /
Raspberry Pi OS RT builds stamp `PREEMPT_RT` into it) as a second, independent source when the
sysfs read fails.

**Schema bump.** `SCHEMA_VERSION` 1 → 2: `ac5.verdict`'s semantics changed (a v1 `true` is not
necessarily a v2 `true` for the same platform), plus new `elapsed_ns`/`under_load`/`gaps`
JSON fields. Updated CI's harness self-test assertion accordingly and added a check that a
withheld verdict's `gaps` array is non-empty.

## Acceptance criteria satisfied

Both defects from #226 fixed: a PASS can no longer be printed without duration/load having
been checked, and the cyclictest-instrument caveat is now inseparable from the verdict. The
RT-detection fallback covers the "sysfs file is absent" failure mode defect 2 flagged.

## Deliberately left out

- **AC-11's first-boot checklist line** (assert `cat /sys/kernel/realtime` reads `1`) —
  `docs/runbook-pi-first-boot.md` is COO turf (`docs/` in CODEOWNERS), and this PR is code-only.
- **Auto-detecting "under load"** from measured system state (e.g. `/proc/loadavg`) instead of
  an operator flag — more fragile and gameable than attestation, and the issue's own
  cheapest-first fix list treats attestation-or-naming as sufficient.
- **`docs/runbook-pi-first-boot.md` §6's example command** isn't updated to
  `--cycles 900000 --under-load`: #230 (thermal throttling on the current cooling solution)
  blocks any real 30-minute attempt regardless, so updating the example now would invite a
  run nobody can actually complete yet.

## Verification

- `cargo test --workspace` — all green (installed `mujoco==3.10.0` per `requirements-sim.txt`
  to unblock `plant-mujoco`'s build script, matching what CI does).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo run -p xtask -- gate` — clean.
- `python3 .github/policy_check.py` — all hard checks pass (a `DOC-OK:` commit covers the
  `ci.yml`-touches-two-manifested-docs advisory; neither doc describes the loop-profiler step).

Closes #226.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UM5Cr9mr34HeVtBpgMM5rQ)_