### PR TITLE
fix(controls): flash_pi.sh hardcoded xz and the builder emits zst — it cannot flash our own image (#182)

### DIFF
--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -5,7 +5,7 @@ covers:
   - scripts/pi/flash_pi.sh
   - scripts/pi/pins.env
   - crates/loop-profiler/src/lib.rs
-reconciled: 1618e9f
+reconciled: 3251993
 -->
 
 **Owned by: Senior Controls.** **Executed by: the CEO**, at a desk, with a monitor and a
@@ -222,6 +222,17 @@ resolver; the exercise validates the removable-media guard, the confirmation pro
 `mk_boot_config.py`'s output against a real secrets file. It is **not** a way to produce a
 usable card: the staged credentials assume `firstboot_install.sh`, which stock Raspberry Pi OS
 does not ship. Use Imager's own customisation (§1) for the card you actually boot.
+
+**Compression is detected, not assumed.** `flash_pi.sh` picks its decompressor from the
+extension — `.img.xz` → `xz`, `.img.zst` → `zstd`, bare `.img` → straight through — and resolves
+it **before** unmounting the card, so an unsupported format or a missing tool fails while the
+card is still intact rather than half-written.
+
+This matters because the two formats genuinely differ in the wild: **rpi-image-gen deploys
+`.img.zst`**, which is what the CI artefact contains, while design §2 specifies `.img.xz` for the
+*published* release because that is what Raspberry Pi Imager consumes. Until those two agree the
+script has to accept both. On macOS, `zstd` is not installed by default — `brew install zstd` if
+the script says so.
 
 ---
 

--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -118,10 +118,13 @@ if [ -z "$IMAGE" ]; then
   command -v gh >/dev/null || die "no --image given and `gh` is not installed"
   say "downloading the '$IMAGE_RELEASE' release"
   ( cd "$STAGING" && gh release download "$IMAGE_RELEASE" --repo MikePaNtZ/overboard \
-      --pattern '*.img.xz' --pattern '*.img.xz.sha256' ) \
+      --pattern '*.img.xz' --pattern '*.img.zst' --pattern '*.sha256' ) \
     || die "could not download release '$IMAGE_RELEASE'.
-       If the image pipeline has not landed yet (issue #182 I1), pass --image."
-  IMAGE="$(ls -1 "$STAGING"/*.img.xz)"
+       No release is published yet (#182). Until one is, flash the CI artefact:
+         gh run download <run-id> -n overboard-image-<sha> -D ./img
+         scripts/pi/flash_pi.sh --image ./img/overboard-stage0b.img.zst"
+  IMAGE="$(ls -1 "$STAGING"/*.img.xz "$STAGING"/*.img.zst 2>/dev/null | head -1 || true)"
+  [ -n "$IMAGE" ] || die "release '$IMAGE_RELEASE' held no .img.xz or .img.zst"
 fi
 [ -f "$IMAGE" ] || die "image not found: $IMAGE"
 
@@ -136,6 +139,33 @@ else
   echo "WARNING: no $(basename "$IMAGE").sha256 alongside the image."
   echo "         Flashing UNVERIFIED. AC-11's restore test assumes a checked artefact."
 fi
+
+# ---------------------------------------------------------------------------
+# Decompression: chosen by extension, and resolved BEFORE the card is touched.
+#
+# This used to hardcode `xz -dc`, which was wrong in a way that only shows up
+# on the machine that matters. rpi-image-gen deploys **.zst** today
+# (build_image.sh globs rather than names the extension for exactly this
+# reason), while design section 2 calls for **.img.xz** to be PUBLISHED. Both
+# formats are therefore in circulation, and will be until those two agree.
+#
+# Resolved here rather than at the write, so an unsupported format or a
+# missing decompressor fails while the card is still mounted and intact --
+# the same ordering rule the credential staging above follows. Discovering
+# `xz: unsupported file format` after `diskutil unmountDisk` means a
+# half-erased card and a repeat 273 MB download.
+# ---------------------------------------------------------------------------
+case "$IMAGE" in
+  *.img.xz)  DECOMP="xz -dc" ;;
+  *.img.zst) DECOMP="zstd -dc" ;;
+  *.img)     DECOMP="cat" ;;
+  *) die "unrecognized image format: $(basename "$IMAGE")
+       Expected .img, .img.xz or .img.zst." ;;
+esac
+command -v "${DECOMP%% *}" >/dev/null || die "${DECOMP%% *} is not installed, and
+       $(basename "$IMAGE") needs it.
+         macOS:  brew install ${DECOMP%% *}
+         Debian: sudo apt install ${DECOMP%% *}"
 
 # ---------------------------------------------------------------------------
 # Guard 2: type the identifier back.
@@ -163,7 +193,7 @@ if [ "$OS" = "Darwin" ]; then
     say "unmounting $DISK"
     diskutil unmountDisk "$DISK"
     say "writing (sudo; ctrl-T shows progress)"
-    xz -dc "$IMAGE" | sudo dd of="$RAW" bs=4m
+    $DECOMP "$IMAGE" | sudo dd of="$RAW" bs=4m
     sync
     say "waiting for the boot partition to mount"
     sleep 3
@@ -176,7 +206,7 @@ else
     say "unmounting any mounted partitions of $DISK"
     for part in "$DISK"?*; do umount "$part" 2>/dev/null || true; done
     say "writing (sudo)"
-    xz -dc "$IMAGE" | sudo dd of="$DISK" bs=4M conv=fsync status=progress
+    $DECOMP "$IMAGE" | sudo dd of="$DISK" bs=4M conv=fsync status=progress
     sync
   fi
   BOOT_MNT="$(mktemp -d)"


### PR DESCRIPTION
**This blocks the first AC-11 restore test tonight.** The CEO's active cooler arrived early, so the image is being flashed today rather than Thursday, and it would have failed at the write.

## The bug

`flash_pi.sh` hardcoded `xz -dc "$IMAGE"`. `build_image.sh` deliberately does **not** hardcode an extension — its own comment says *"the compression format is rpi-image-gen's choice (it deploys .zst today), and hardcoding an extension here is how the"* — and the green master artefact is a **`.img.zst`**.

So the builder produces zst, the flasher demands xz, and design §2 says publish xz. Three-way disagreement, and it was going to surface as `xz: unsupported file format` **after** `diskutil unmountDisk` — half-erased card, 273 MB re-download.

## Fix

Pick the decompressor by extension (`.img.xz` → `xz -dc`, `.img.zst` → `zstd -dc`, `.img` → `cat`), and **resolve it before the card is touched**, alongside the existing rule that credential staging fails before the write rather than after. An unsupported format or a missing decompressor now fails while the card is still intact, with the `brew install` / `apt install` line.

Also: the release-download path globbed `*.img.xz` only, so it would have found nothing in a zst release. Now accepts both, and its error names the CI-artefact fallback verbatim, since no release is published yet.

## What this does NOT do

**It does not settle the artefact-format question**, and deliberately so. Design §2's `.img.xz` is the right *published* format — Raspberry Pi Imager consumes xz — and the builder should be moved to xz for publication. That is a separate change with a 90-minute rebuild behind it, and it must not sit between the CEO and tonight's test.

Tolerating both formats is correct regardless of how that lands: CI artefacts and published releases can legitimately differ, and a flasher that only accepts one is brittle either way.

## Testing

`bash -n` clean. Extension dispatch and the `command -v` guard exercised for all four branches. `zstd` 1.5.7 and `xz` 5.8.3 both confirmed present on the CEO's machine, so tonight needs no install. **End-to-end write not exercised** — that happens tonight, and it is the first real flash this script has ever done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)