### PR TITLE
feat(controls): put the loss-of-authority warning on the wire (#216)

### DIFF
--- a/crates/sim-host/src/bin/wire-probe.rs
+++ b/crates/sim-host/src/bin/wire-probe.rs
@@ -23,7 +23,9 @@
 //! `sim-host`'s dead-reckoned game path, NOT raw MuJoCo x/y -- see
 //! `sim_host::wire::StateOut::pos`'s doc comment.
 
-use sim_host::wire::{StateOut, STATE_FLAG_FALLEN, STATE_MAGIC, STATE_SCHEMA_VERSION};
+use sim_host::wire::{
+    StateOut, STATE_FLAG_AUTHORITY_WARNING, STATE_FLAG_FALLEN, STATE_MAGIC, STATE_SCHEMA_VERSION,
+};
 use std::net::UdpSocket;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -96,6 +98,11 @@ struct CsvRow {
     /// actually trips means checking what actually went out over the wire,
     /// not re-deriving the same threshold this column is supposed to check.
     fallen: bool,
+    /// Raw `STATE_FLAG_AUTHORITY_WARNING`, decoded off the wire -- ADR-0011
+    /// exit criterion (c) / issue #216. Same "decode, don't re-derive"
+    /// discipline as `fallen` above: this is what a renderer would actually
+    /// see, not the host's own internal `authority_warning_active()` call.
+    authority_warning: bool,
 }
 
 fn percentile(sorted_ms: &[f64], p: f64) -> f64 {
@@ -203,6 +210,7 @@ fn main() {
                             rider_fore_aft_m: rider_fore_aft,
                             rider_lateral_m: rider_lateral,
                             fallen: state.flags & STATE_FLAG_FALLEN != 0,
+                            authority_warning: state.flags & STATE_FLAG_AUTHORITY_WARNING != 0,
                         });
                     }
                 }
@@ -310,11 +318,11 @@ fn main() {
 
     if let Some(path) = &args.csv {
         let mut out = String::from(
-            "seq,sim_time_s,pos_x_m,pos_y_m,pitch_rad,yaw_rad,wheel_rate_rad_s,motor_current_a,rider_fore_aft_m,rider_lateral_m,fallen\n",
+            "seq,sim_time_s,pos_x_m,pos_y_m,pitch_rad,yaw_rad,wheel_rate_rad_s,motor_current_a,rider_fore_aft_m,rider_lateral_m,fallen,authority_warning\n",
         );
         for r in &csv_rows {
             out.push_str(&format!(
-                "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{}\n",
+                "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{},{}\n",
                 r.seq,
                 r.sim_time_s,
                 r.pos_x_m,
@@ -325,7 +333,8 @@ fn main() {
                 r.motor_current_a,
                 r.rider_fore_aft_m,
                 r.rider_lateral_m,
-                r.fallen
+                r.fallen,
+                r.authority_warning
             ));
         }
         match std::fs::write(path, out) {

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -1891,6 +1891,9 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         if fallen {
             flags |= wire::STATE_FLAG_FALLEN;
         }
+        if authority_warning {
+            flags |= wire::STATE_FLAG_AUTHORITY_WARNING;
+        }
 
         if cfg.trace_path.is_some() {
             trace.push(TraceRow {

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -40,6 +40,14 @@ pub const STATE_FLAG_ARMED: u16 = 1 << 0;
 pub const STATE_FLAG_VALID: u16 = 1 << 1;
 /// `StateOut::flags` bit 2.
 pub const STATE_FLAG_FALLEN: u16 = 1 << 2;
+/// `StateOut::flags` bit 3 -- ADR-0011 exit criterion (c): the loss-of-
+/// authority warning, ADR-0011's `authority_warning`, put on the wire so a
+/// renderer can surface the cliff before `STATE_FLAG_FALLEN` trips (issue
+/// #216). A new bit within the existing `flags` field, not a wider wire, so
+/// `STATE_SCHEMA_VERSION` is unchanged -- same precedent as
+/// `INPUT_FLAG_KICK` above: backward compatible with any peer not yet
+/// setting or reading it (reads as 0, no warning).
+pub const STATE_FLAG_AUTHORITY_WARNING: u16 = 1 << 3;
 
 /// `InputIn::flags` bit 0.
 pub const INPUT_FLAG_ARM: u16 = 1 << 0;


### PR DESCRIPTION
## What changed

Adds `STATE_FLAG_AUTHORITY_WARNING` (`StateOut::flags` bit 3) in `crates/sim-host/src/wire.rs`, and sets it in `crates/sim-host/src/host.rs`'s flags composition whenever `authority_warning` (already computed every cycle, previously only reaching `eprintln!` and the trace CSV) is true.

No `schema_version` bump — a new bit inside the existing `flags` field, same precedent `INPUT_FLAG_KICK` already established: backward compatible with any peer not yet setting or reading it (reads as `0`, no warning).

Also threads the flag through `wire-probe`'s `--csv` output as a new `authority_warning` column, decoded straight off the wire alongside the existing `fallen` column (same "decode, don't re-derive" discipline that column's own doc comment states) — without this, `wire-probe`, the CEO-visible tool for verifying this exact wire from the outside, would have no way to confirm the bit actually reached the wire.

## Why

`overboard-game#19`/issue #216 (filed by Game Engineer as a work request, per ADR-0004) found that the loss-of-authority warning never left the host process — it's consumed only by `eprintln!` and the trace CSV, never by `StateOut`. That blocks ADR-0011 exit criterion (c) ("a loss-of-authority warning fires before the outcome is decided, with a stated measured lead time"), which needs both sides of the wire to ship. `overboard-game` PR #21 already decodes this exact bit and is otherwise ready — this is the one commit that was missing.

## Acceptance criteria satisfied

- ADR-0011 exit criterion (c): the warning now reaches the wire, not just stderr/CSV.
- Issue #216's exact ask: `STATE_FLAG_AUTHORITY_WARNING = 1 << 3`, set at the point `flags` is composed, no schema bump.

## Verification

- `cargo test -p sim-host` — 37/37 unit tests pass (wire round-trip, size, and existing `authority_warning_active` logic tests unaffected; compile-time `WIRE_SIZE` assertion confirms `StateOut` is still 80 bytes — this only adds a `const`, not a struct field).
- `cargo clippy -p sim-host --all-targets -- -D warnings` — clean.
- `cargo fmt -p sim-host -- --check` — clean.
- `python3 .github/policy_check.py` — all hard checks pass; no new advisories.

## Deliberately left out

- No new dedicated unit test for the bit's literal value — matches this file's own precedent: `INPUT_FLAG_KICK` (the last bit added the same way) has no such test either, relying on the existing generic round-trip tests plus the game side's decode tests (`overboard-game` PR #21 already covers decode-side round-trip, including the "a host not setting the bit decodes as not-warning" case for both v1 and v2).
- Did not touch `overboard-game` — that repo's half (PR #21) is already merged-ready and out of this repo's turf per ADR-0009's boundary.

Closes #216


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMFowbbipwUocZaP9tK9Tw)_