### PR TITLE
fix(controls): pin the bootloader EEPROM version alongside the kernel (#222)

### DIFF
--- a/scripts/pi/pins.env
+++ b/scripts/pi/pins.env
@@ -64,3 +64,25 @@ PINNED_PACKAGES="
 rt-tests=2.6-1.1
 can-utils=2023.03-1+b2
 "
+
+# ---------------------------------------------------------------------------
+# BOOTLOADER EEPROM -- held, not tracked, same reasoning as the kernel pin,
+# for a variable this file cannot actually enforce.
+#
+# The bootloader lives in EEPROM on the Pi itself, not on the SD card (issue
+# #222). Flashing a fresh, fully-pinned image does not reset it, and the
+# provenance manifest baked into the card (design section 1) cannot see it
+# either -- it describes the card, and this is not on the card. So unlike
+# every other pin above, nothing in this repo can verify a Pi actually has
+# this version; it is recorded here so a number is attributable, not so a
+# build can assert it.
+#
+# `rpi-eeprom-update` resolves the "latest" release differently per channel,
+# so the channel is pinned alongside the hash -- a hash without its channel
+# is not reproducible (#222, fed back from #223's first-boot run).
+#
+# Observed on the CEO's Pi 5 Rev 1.1, 2026-08-05, via
+# docs/runbook-pi-first-boot.md Sec.4 (`vcgencmd bootloader_version`):
+BOOTLOADER_VERSION="086b83e3332dfc8927c56762771d082f3077a1ae"
+BOOTLOADER_BUILD_TIMESTAMP="1779807685"  # 2026-05-26T15:01:25Z
+BOOTLOADER_RELEASE_CHANNEL="default"     # NOT "latest" -- see above


### PR DESCRIPTION
## What

Issue #222 pointed out that `scripts/pi/pins.env` pins the kernel on the grounds that it "invalidates every latency number Stage 0B produces," but the bootloader — which lives in EEPROM on the Pi itself, not on the SD card — was unpinned. Flashing a fresh, fully-pinned image does not reset it, and the provenance manifest baked into the card (`/etc/overboard-image.json`) cannot capture it either, since it describes the card and the bootloader isn't on the card.

Adds three fields to `pins.env`, "held, not tracked" in the same style and for the same reason as the kernel pin: `BOOTLOADER_VERSION`, `BOOTLOADER_BUILD_TIMESTAMP`, `BOOTLOADER_RELEASE_CHANNEL`. Values are the ones actually observed on the CEO's Pi 5 Rev 1.1 first-boot run and recorded in #223 (`vcgencmd bootloader_version` / `rpi-eeprom-update`): version `086b83e...`, built `2026-05-26T15:01:25Z`, channel `default`. The channel is pinned alongside the hash deliberately — `rpi-eeprom-update` resolves "latest" differently per channel, so a hash without its channel isn't reproducible, a finding #223 already surfaced.

## Which acceptance criteria this satisfies

Closes #222's proposal item 1 ("Add `BOOTLOADER_VERSION` to `pins.env` with the same 'held, not tracked' comment the kernel pin carries").

## What I deliberately left out

- **Item 2** ("have the Stage-0B run record `vcgencmd bootloader_version` into the run log, alongside `git_sha`"). I looked for the mechanism this would attach to and didn't find one that fits: `scripts/stage0b_runbook.py`'s JSON log (the only place that already records `git_sha`) explicitly has no hardware mode yet — `run(dry_run=False, ...)` raises, by design, because there's no way to exercise a hardware path yet without unverifiable code. The provenance manifest is the other candidate, and the issue itself already rules that out ("the manifest describes the card, and this is not on the card"). Wiring a bootloader-version hook into a hardware run mode that doesn't exist yet would be exactly the kind of code-with-nothing-to-execute-it-against this project's conventions rule out. Flagging rather than inventing a new logging mechanism the issue didn't ask for.
- **Item 3** ("decide whether AC-11 should assert it"). The issue explicitly frames this as "the part worth a considered call rather than a default," not a default action — leaving it open rather than deciding it here.
- Not touched: `docs/runbook-pi-first-boot.md` and `docs/design-pi-image-stage0b-reference.md` (both COO turf under `/docs/`) — this PR is scoped to the `scripts/pi/pins.env` pin itself.

## Verification

- `bash -n scripts/pi/pins.env` — syntax OK; sourced and spot-checked the new variables resolve.
- `python3 scripts/pi/check_image_pin.py` — still passes (kernel-only check, unaffected by this addition).
- `python3 .github/policy_check.py` — all hard checks pass (pre-existing advisories only, none touched by this change).

Closes #222.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015zTcSYaLCwYUqt1J1H72zz)_