### PR TITLE
feat(controls): MuJoCo declares the crash and hands the board to Unreal — ADR-0012 host half

### DIFF
--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -156,6 +156,16 @@ pub struct SimBackend {
     /// `plant_mujoco::Plant::joint_dofadr`.
     frame_free_qposadr: Option<usize>,
     frame_free_dofadr: Option<usize>,
+    /// `mjData::sensordata` address+dim for the three ADR-0012 handoff
+    /// sensors, if the open model declares them -- `None` on any model that
+    /// does not (the driverless onewheel model, every bench rig), which is
+    /// the same "honest zero, not an error" tolerance
+    /// [`SimBackend::truth_ballast_positions`] has. Resolved once in
+    /// `open()`.
+    frame_linvel_sensor: Option<(usize, usize)>,
+    frame_angvel_sensor: Option<(usize, usize)>,
+    nose_strike_sensor: Option<(usize, usize)>,
+    tail_strike_sensor: Option<(usize, usize)>,
     cycle: u64,
     open: bool,
     armed: bool,
@@ -396,6 +406,102 @@ impl SimBackend {
             .map(|adr| qpos[adr] as f32)
             .unwrap_or(0.0);
         (fore_aft, lateral)
+    }
+
+    /// Ground-truth WORLD-frame linear velocity of the `frame` body, m/s,
+    /// read from the model's `frame_linvel` sensor (ADR-0012).
+    ///
+    /// `[0.0; 3]` on a model that does not declare the sensor -- the same
+    /// tolerance [`SimBackend::truth_ballast_positions`] has, and for the
+    /// same reason: a caller on the driverless plant gets an honest "this
+    /// model has no such channel", not an error for something never claimed.
+    ///
+    /// # Why the sensor rather than `qvel`
+    ///
+    /// The free joint's `qvel` linear half IS already global (the fact
+    /// [`SimBackend::inject_kinematic_yaw`] relies on), so this one could
+    /// have been read there. Its angular partner below could not -- that half
+    /// is body-frame -- and reading one velocity from `qvel` and the other
+    /// from a sensor is exactly how a frame error gets introduced by a later
+    /// reader who assumes the pair match. Both come from sensors.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_frame_linvel(&self) -> [f64; 3] {
+        self.read_vec3(self.frame_linvel_sensor, "truth_frame_linvel")
+    }
+
+    /// Ground-truth WORLD-frame angular velocity of the `frame` body, rad/s,
+    /// right-hand rule, read from the model's `frame_angvel` sensor
+    /// (ADR-0012). `[0.0; 3]` on a model that does not declare it.
+    ///
+    /// **World frame, not body frame.** MuJoCo's `frameangvel` reports in
+    /// global coordinates, whereas the free joint's `qvel` angular half is
+    /// body-frame. The wire carries the world one because that is what a
+    /// receiving physics engine seeds with, and converting anywhere else
+    /// would put a rotation in a second place -- the class of error ADR-0010
+    /// named as silently poisoning everything downstream.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_frame_angvel(&self) -> [f64; 3] {
+        self.read_vec3(self.frame_angvel_sensor, "truth_frame_angvel")
+    }
+
+    /// Total normal contact force, newtons, inside the model's `nose_strike`
+    /// site -- the ADR-0012 terminating-event detector. `0.0` on a model that
+    /// does not declare the sensor.
+    ///
+    /// MuJoCo's `touch` sensor sums the normal force of every contact whose
+    /// point falls inside the site's volume, so this reads zero throughout
+    /// normal riding: the site sits 0.108 m above the ground when the board
+    /// is upright and excludes the wheel's contact patch on both the x and z
+    /// axes independently (see the site comment in `overboard_rider.xml`).
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_nose_strike_n(&self) -> f32 {
+        self.read_touch(self.nose_strike_sensor, "truth_nose_strike_n")
+    }
+
+    /// Total normal contact force, newtons, inside the model's `tail_strike`
+    /// site. The rear-bumper counterpart of
+    /// [`SimBackend::truth_nose_strike_n`], and not an afterthought: released
+    /// from upright this plant settles TAIL-down, so a nose-only detector
+    /// reads zero through half the falls it exists to catch.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn truth_tail_strike_n(&self) -> f32 {
+        self.read_touch(self.tail_strike_sensor, "truth_tail_strike_n")
+    }
+
+    /// Shared body of the two `truth_*_strike_n` accessors.
+    fn read_touch(&self, sensor: Option<(usize, usize)>, who: &str) -> f32 {
+        let plant = self
+            .plant
+            .as_ref()
+            .unwrap_or_else(|| panic!("{who}: backend is not open"));
+        match sensor {
+            Some((adr, dim)) => plant.read_sensor(adr, dim).first().copied().unwrap_or(0.0) as f32,
+            None => 0.0,
+        }
+    }
+
+    /// Shared body of the two `truth_frame_*vel` accessors: read a 3-vector
+    /// sensor, or `[0.0; 3]` if this model does not declare it.
+    fn read_vec3(&self, sensor: Option<(usize, usize)>, who: &str) -> [f64; 3] {
+        let plant = self
+            .plant
+            .as_ref()
+            .unwrap_or_else(|| panic!("{who}: backend is not open"));
+        match sensor {
+            Some((adr, dim)) if dim >= 3 => {
+                let v = plant.read_sensor(adr, 3);
+                [v[0], v[1], v[2]]
+            }
+            _ => [0.0; 3],
+        }
     }
 
     /// Ground-truth BODY-frame pitch rate of the `frame` body, rad/s, nose-up
@@ -641,6 +747,15 @@ impl BoardObserve for SimBackend {
         // does not happen to declare the thing an optional feature needs.
         self.frame_free_qposadr = plant.joint_qposadr("frame_free");
         self.frame_free_dofadr = plant.joint_dofadr("frame_free");
+
+        // ADR-0012 handoff sensors. Resolved by NAME, so appending them to
+        // the model cannot disturb any existing sensor's address -- and
+        // absent on any model that does not declare them, which is not an
+        // error here (see the field comment).
+        self.frame_linvel_sensor = plant.sensor_adr_dim("frame_linvel");
+        self.frame_angvel_sensor = plant.sensor_adr_dim("frame_angvel");
+        self.nose_strike_sensor = plant.sensor_adr_dim("nose_strike");
+        self.tail_strike_sensor = plant.sensor_adr_dim("tail_strike");
 
         // Built once dt_s is known, same reasoning as steps_per_cycle above:
         // a fresh ImperfectionState per open() so repeat-run bit-identity

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -14,7 +14,7 @@
 //!          [--free-run] [--max-sim-secs SECONDS]
 //!          [--pitch-source estimator|truth] [--pitch-bias-deg DEGREES]
 //!          [--cmd-reserve FRACTION] [--cmd-reserve-braking FRACTION]
-//!          [--incline-deg DEGREES]
+//!          [--incline-deg DEGREES] [--kerb [Y[,HEIGHT]]]
 //!          [--disturbance t0,dur,fx,fy,fz,tx,ty,tz] [--trace-csv PATH]
 //! ```
 //! With no `--duration-secs`, runs forever (Ctrl-C / SIGTERM to stop). With
@@ -210,6 +210,39 @@ fn main() -> ExitCode {
             // second ratification needs the tolerated incline as a MEASURED
             // number before the authored world can carry a checkable asset
             // rule; see HostConfig::incline_deg.
+            // ADR-0012: ride into a kerb. Bare `--kerb` uses the measured
+            // City Park default; `--kerb Y[,HEIGHT]` overrides where it is
+            // and how tall, so the kerb can be moved during a play-test
+            // without a rebuild.
+            "--kerb" => {
+                let mut spec = sim_host::host::DEFAULT_KERB;
+                if let Some(v) = args.get(i + 1).filter(|v| !v.starts_with("--")) {
+                    let parts: Vec<&str> = v.split(',').collect();
+                    if parts.is_empty() || parts.len() > 2 {
+                        eprintln!("sim-host: --kerb takes Y or Y,HEIGHT (metres), got '{v}'");
+                        return ExitCode::FAILURE;
+                    }
+                    let Ok(y) = parts[0].parse::<f64>() else {
+                        eprintln!("sim-host: --kerb Y value '{}' is not a number", parts[0]);
+                        return ExitCode::FAILURE;
+                    };
+                    spec.y_face_m = y;
+                    if let Some(h) = parts.get(1) {
+                        let Ok(h) = h.parse::<f64>() else {
+                            eprintln!("sim-host: --kerb HEIGHT value '{h}' is not a number");
+                            return ExitCode::FAILURE;
+                        };
+                        if !(0.01..=1.0).contains(&h) {
+                            eprintln!("sim-host: --kerb HEIGHT must be within [0.01, 1.0] m, got {h}");
+                            return ExitCode::FAILURE;
+                        }
+                        spec.height_m = h;
+                    }
+                    i += 1;
+                }
+                cfg.kerb = Some(spec);
+                i += 1;
+            }
             "--incline-deg" => {
                 let Some(v) = args.get(i + 1) else {
                     eprintln!("sim-host: --incline-deg needs a value");

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -233,7 +233,9 @@ fn main() -> ExitCode {
                             return ExitCode::FAILURE;
                         };
                         if !(0.01..=1.0).contains(&h) {
-                            eprintln!("sim-host: --kerb HEIGHT must be within [0.01, 1.0] m, got {h}");
+                            eprintln!(
+                                "sim-host: --kerb HEIGHT must be within [0.01, 1.0] m, got {h}"
+                            );
                             return ExitCode::FAILURE;
                         }
                         spec.height_m = h;

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -157,6 +157,105 @@ fn rider_model_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sim/models/overboard_rider.xml")
 }
 
+/// A kerb to ride into (ADR-0012). Off by default, and when it is off the
+/// model this host opens is the shared `overboard_rider.xml`, byte for byte.
+///
+/// # Why this is spliced in here and not declared in the model
+///
+/// `overboard_rider.xml` is shared by every scenario in the repo, several of
+/// which travel a long way -- the host coasts 10.8 m in 10 s (issue #169).
+/// A kerb committed into that file would start appearing in acceptance runs
+/// that never asked for one, and an ADR-0011 measurement that quietly hit
+/// scenery is worse than no measurement. Splicing keeps the geometry in the
+/// demo that wants it.
+///
+/// The splice itself is the pattern `sim/scenarios/terrain.py` already uses
+/// to add its `hfield` to a model at load time, rather than a new idea.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KerbSpec {
+    /// World Y of the kerb's near FACE, metres -- the side the board hits.
+    /// The kerb body extends away from the board from there.
+    pub y_face_m: f64,
+    /// Height of the kerb above the ground plane, metres.
+    pub height_m: f64,
+}
+
+/// Default kerb, measured from the real City Park geometry rather than
+/// invented: `overboard-game`'s `dump_triangles.py` dump of `OB_City` puts a
+/// continuous line of ~0.090 m risers at y = +8.85 m running along X, which is
+/// the left-hand kerb of the street the board spawns on. Placing MuJoCo's kerb
+/// on the same coordinate is what makes the strike land where the player can
+/// SEE a kerb -- the alternative is an invisible wall, since terrain is not on
+/// the wire and Unreal is drawing City Park, not this model.
+pub const DEFAULT_KERB: KerbSpec = KerbSpec {
+    y_face_m: 8.85,
+    height_m: 0.090,
+};
+
+/// The spliced kerb spans the WHOLE drivable corridor in X, derived from
+/// `CORRIDOR_X_MIN_M`/`CORRIDOR_X_MAX_M` rather than picked.
+///
+/// Measured why: at a 40 m half-length about the origin, an s-curve run
+/// drifted to the kerb's Y only once it was at x = -112 m -- long past the
+/// end of the kerb -- and sailed by with nothing to hit. A kerb the player
+/// can outrun is a kerb that is not there.
+const KERB_HALF_LENGTH_M: f64 = (CORRIDOR_X_MAX_M - CORRIDOR_X_MIN_M) / 2.0;
+/// Centre of the spliced kerb along X -- the midpoint of the same corridor.
+const KERB_CENTRE_X_M: f64 = (CORRIDOR_X_MAX_M + CORRIDOR_X_MIN_M) / 2.0;
+/// Half-depth of the spliced kerb along Y, metres. Only the near face is ever
+/// touched; the depth exists so the board cannot clip through the far side.
+const KERB_HALF_DEPTH_M: f64 = 0.6;
+
+/// Writes `overboard_rider.xml` with `kerb` spliced into its `<worldbody>` to
+/// a temporary file, and returns that path. The original file is never
+/// modified.
+fn write_model_with_kerb(kerb: &KerbSpec) -> Result<PathBuf, HostError> {
+    let src = rider_model_path();
+    let xml = std::fs::read_to_string(&src).map_err(|e| {
+        HostError::Io(std::io::Error::new(
+            e.kind(),
+            format!("sim-host: cannot read {}: {e}", src.display()),
+        ))
+    })?;
+
+    // Near face at `y_face_m`, body extending away from the board (+Y), top
+    // flush with the ground plane's surface at z = height_m.
+    let cy = kerb.y_face_m + KERB_HALF_DEPTH_M;
+    let hz = kerb.height_m / 2.0;
+    let geom = format!(
+        "\n    <!-- ADR-0012: spliced in by sim-host --kerb, NOT part of the shared model. -->\
+         \n    <geom name=\"kerb\" type=\"box\" pos=\"{KERB_CENTRE_X_M} {cy} {hz}\" \
+         size=\"{KERB_HALF_LENGTH_M} {KERB_HALF_DEPTH_M} {hz}\" \
+         rgba=\"0.62 0.60 0.57 1\" condim=\"3\" friction=\"0.8 0.005 0.0001\"/>\n  "
+    );
+
+    // `terrain.py` splices at `</asset>`; the kerb is geometry, so it goes at
+    // the single `</worldbody>`. Exactly one, or fail loudly -- a splice that
+    // silently no-ops would present as "the kerb does nothing", which is the
+    // hardest possible version of this bug to see.
+    if xml.matches("</worldbody>").count() != 1 {
+        return Err(HostError::Io(std::io::Error::other(format!(
+            "sim-host: expected exactly one </worldbody> in {} to splice the kerb into",
+            src.display()
+        ))));
+    }
+    let spliced = xml.replace("</worldbody>", &format!("{geom}</worldbody>"));
+
+    // Alongside the real model, so MuJoCo's `meshdir` (a RELATIVE path) still
+    // resolves. A temp dir would break every mesh reference in the file.
+    let dst = src.with_file_name(format!(
+        "overboard_rider_kerb_{}.generated.xml",
+        std::process::id()
+    ));
+    std::fs::write(&dst, spliced).map_err(|e| {
+        HostError::Io(std::io::Error::new(
+            e.kind(),
+            format!("sim-host: cannot write {}: {e}", dst.display()),
+        ))
+    })?;
+    Ok(dst)
+}
+
 // --- Controller config, ridden variant (issue #161 W2) -- REUSED verbatim
 // from `sim/scenarios/shuttle_run.py`'s own `controller_factory`, the repo's
 // only existing tuned cascade config for a rider-scale plant. That scenario
@@ -798,6 +897,62 @@ const CORRIDOR_HALF_WIDTH_M: f64 = 8.6;
 /// (decelerate)" value (0.6); not bench-tuned.
 const CORRIDOR_BRAKE_LEAN: f32 = 0.6;
 
+/// ADR-0012 terminating event, part 1: total bumper contact force, newtons,
+/// above which the board is declared down and physics authority is handed to
+/// Unreal.
+///
+/// The two `touch` sensors in `overboard_rider.xml` read **exactly** 0.0000 N
+/// through upright riding -- measured over 6000 uncontrolled steps, the
+/// site geometry excludes the wheel's contact patch on two independent axes
+/// -- and 560 N with the board resting on a bumper. So this threshold is not
+/// separating signal from noise (there is no noise); it is set well clear of
+/// zero purely so a grazing touch during a recoverable wobble does not end a
+/// run, and well under the resting load so an actual strike cannot be missed.
+const STRIKE_FORCE_N: f32 = 50.0;
+
+/// ADR-0012 terminating event, part 2: tilt of the frame's up-axis away from
+/// world vertical, radians, above which the board is declared down.
+///
+/// # Why this exists when `FALLEN_PITCH_RAD` already does
+///
+/// `FALLEN` tests **pitch alone**, and a kerb is hit from the SIDE. The
+/// measured failure: released from upright this model settles at 18.6 deg of
+/// pitch -- the nose-into-ground limit its own header documents -- which
+/// never reaches the 20 deg `FALLEN` threshold at all. A board rolled onto
+/// its side by a kerb strike can therefore be flat on the ground with
+/// `FALLEN` reading 0 and, if it went over sideways rather than end-over,
+/// neither bumper touched.
+///
+/// Tilt-from-vertical is one dot product (`xmat[8]`, the frame up-axis's
+/// world Z component) and is direction-agnostic by construction, so it covers
+/// pitch, roll and any combination.
+///
+/// **`FALLEN` is deliberately left alone.** Its threshold and its measured
+/// lead times are quoted in ADR-0011 (warning asserts at 3.000 s, `FALLEN` at
+/// 5.868 s, lead 2.868 s); redefining it would silently invalidate published
+/// numbers. This is a separate, additional signal that only gates the
+/// handoff.
+///
+/// # Where 35 deg comes from -- measured, not chosen
+///
+/// The risk this number carries is the FALSE POSITIVE: a threshold a hard
+/// carve can reach would hand the board to Unreal mid-turn and ragdoll a
+/// player who was still riding. So the legitimate envelope was measured
+/// first, over all four scripted scenarios, 30 s each, with no kerb:
+///
+/// | scenario | peak tilt |
+/// |---|---|
+/// | `default` | 5.5 deg |
+/// | `s-curve` | 8.0 deg |
+/// | `full-stick` | 8.0 deg |
+/// | `stick-reversal` | **11.0 deg** |
+///
+/// 35 deg is 3.2x the worst of those. For contrast, on the run that actually
+/// went down the board crossed this threshold and was at 166 deg of pitch
+/// moments later -- once past ~35 deg it is not coming back, so the margin
+/// costs nothing in detection latency.
+const HANDOFF_TILT_RAD: f32 = 35.0 * std::f32::consts::PI / 180.0;
+
 /// A ONE-TIME startup disturbance, applied near the beginning of a run when
 /// [`HostConfig::startup_kick`] is set. Not a general disturbance API -- the
 /// input wire carries no such field (issue #161) -- and OFF BY DEFAULT
@@ -1001,6 +1156,11 @@ pub struct HostConfig {
     /// during the loop: a 500 Hz control thread does not do file I/O per
     /// tick, and the trace exists to measure the loop, not to perturb it.
     pub trace_path: Option<PathBuf>,
+
+    /// ADR-0012. `Some` splices a kerb into the model and arms the physics-
+    /// authority handoff; `None` (the default) opens the shared model
+    /// unchanged and never sets the handoff bit. See [`KerbSpec`].
+    pub kerb: Option<KerbSpec>,
 }
 
 /// Where the regulator's attitude comes from -- ADR-0011 exit criterion (f).
@@ -1077,6 +1237,7 @@ impl Default for HostConfig {
             disturbance: None,
             incline_deg: 0.0,
             trace_path: None,
+            kerb: None,
         }
     }
 }
@@ -1335,7 +1496,26 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         ..Params::default()
     };
 
-    let mut backend = SimBackend::with_model_path(params, rider_model_path());
+    // ADR-0012: a kerb run opens a spliced copy; every other run opens the
+    // shared model itself, unchanged.
+    let generated_model = match &cfg.kerb {
+        Some(kerb) => Some(write_model_with_kerb(kerb)?),
+        None => None,
+    };
+    let model_path = generated_model.clone().unwrap_or_else(rider_model_path);
+    if let Some(kerb) = &cfg.kerb {
+        eprintln!(
+            "sim-host: ADR-0012 kerb armed -- face at y={:+.3} m, {:.0} mm tall, \
+             spanning x[{:.0},{:.0}] m; handoff will fire on >{STRIKE_FORCE_N:.0} N of \
+             bumper contact or >{:.0} deg of tilt",
+            kerb.y_face_m,
+            kerb.height_m * 1000.0,
+            CORRIDOR_X_MIN_M,
+            CORRIDOR_X_MAX_M,
+            HANDOFF_TILT_RAD.to_degrees(),
+        );
+    }
+    let mut backend = SimBackend::with_model_path(params, model_path);
     // Before `open()`, which is where the tilt is applied -- see
     // `HostConfig::incline_deg`.
     backend.set_incline_deg(cfg.incline_deg);
@@ -1384,6 +1564,30 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     let mut scripted_label: &'static str = "";
     let mut prev_armed_bit = false;
     let mut prev_reset_bit = false;
+    // ADR-0012. `handoff_latched` is a LEVEL, not an edge: once set it stays
+    // set until the input `reset` bit clears it, so a client that loses the
+    // announcing packet to the UDP wire still takes over on the next one.
+    // `handoff_state` is the frozen snapshot every subsequent packet repeats.
+    // ADR-0012: the kerb has to be REACHABLE. The soft corridor brake fires
+    // at CORRIDOR_HALF_WIDTH_M = 8.6 m, and the measured City Park kerb face
+    // is at 8.85 m -- so on an unmodified corridor the host arrests the
+    // player's forward lean 0.25 m short of the thing they are aiming at, and
+    // the strike never happens. Measured: an s-curve run reached y = 8.6 m,
+    // got braked, and came back.
+    //
+    // When a kerb is armed the lateral limit moves outside it, so what stops
+    // the board is the kerb's own geometry rather than an invisible brake.
+    // That is also what ADR-0012 says the arrangement IS: the kerb is
+    // authored outside the drivable corridor, and striking it terminates the
+    // run. The X bounds are untouched -- they keep the board inside a finite
+    // Unreal level, which a kerb strike does nothing about.
+    let corridor_half_width_m = match &cfg.kerb {
+        Some(k) => CORRIDOR_HALF_WIDTH_M.max(k.y_face_m.abs() + 0.5),
+        None => CORRIDOR_HALF_WIDTH_M,
+    };
+
+    let mut handoff_latched = false;
+    let mut handoff_state: Option<([f32; 3], [f32; 4], [f32; 3], [f32; 3])> = None;
     let mut prev_kick_bit = false;
     // `Some(t)` while an on-demand fall kick (issue #161 follow-up, item 5)
     // is in its force-application window, `t` being the sim time it started
@@ -1584,7 +1788,19 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let input_armed_bit = !stale && latest_input.armed_bit;
         let input_reset_bit = !stale && latest_input.reset_bit;
         if input_reset_bit && !prev_reset_bit {
-            eprintln!("sim-host: input reset bit set -- not implemented yet, ignoring");
+            // ADR-0012 gave this bit its first real job: it is the ONLY way
+            // out of a handoff, and it is what returns authority to MuJoCo.
+            // Outside a handoff it still does nothing, and still says so.
+            if handoff_latched {
+                eprintln!(
+                    "sim-host: input reset bit set -- clearing the ADR-0012 handoff, \
+                     MuJoCo resumes propagating the board"
+                );
+                handoff_latched = false;
+                handoff_state = None;
+            } else {
+                eprintln!("sim-host: input reset bit set -- not implemented yet, ignoring");
+            }
         }
         if input_armed_bit != prev_armed_bit {
             eprintln!(
@@ -1626,7 +1842,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // the dead-reckoned path, which no longer exists) -- the same
         // one-cycle lag the speed cap above uses, and for the same reason.
         let outside_corridor = !(CORRIDOR_X_MIN_M..=CORRIDOR_X_MAX_M).contains(&truth_pos_x_m)
-            || truth_pos_y_m.abs() > CORRIDOR_HALF_WIDTH_M;
+            || truth_pos_y_m.abs() > corridor_half_width_m;
         if outside_corridor && !prev_outside_corridor {
             eprintln!(
                 "sim-host: LEFT THE DRIVABLE CORRIDOR at ({truth_pos_x_m:.1}, \
@@ -1892,6 +2108,56 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             flags |= wire::STATE_FLAG_FALLEN;
         }
 
+        // --- ADR-0012 PHYSICS-AUTHORITY HANDOFF -------------------------
+        //
+        // Only ever armed on a run that asked for a kerb. A run without one
+        // is byte-for-byte the run it was before this existed: no strike can
+        // be declared, and `STATE_FLAG_HANDOFF` never leaves this host.
+        let lv = backend.truth_frame_linvel();
+        let av = backend.truth_frame_angvel();
+        let lin_vel = [lv[0] as f32, lv[1] as f32, lv[2] as f32];
+        let ang_vel = [av[0] as f32, av[1] as f32, av[2] as f32];
+        // `xmat[8]` is the frame up-axis's world Z, so acos of it is tilt from
+        // vertical in ANY direction -- see HANDOFF_TILT_RAD on why pitch alone
+        // is not enough. Computed on every run, kerb or not: it costs one
+        // acos, it is the honest "how far over is the board" number, and
+        // having it on non-kerb runs too is what let the threshold be set from
+        // a measured carve envelope instead of a guess.
+        let tilt_rad = (xmat[8].clamp(-1.0, 1.0) as f32).acos();
+        let strike_n = backend.truth_nose_strike_n() + backend.truth_tail_strike_n();
+        if std::env::var("OB_HANDOFF_DEBUG").is_ok() && ticks % 250 == 0 {
+            eprintln!(
+                "  [handoff-debug] t={t_known_s:.2} tilt={:.1}deg strike={strike_n:.1}N \
+                 y={truth_pos_y_m:.2}",
+                tilt_rad.to_degrees()
+            );
+        }
+        if cfg.kerb.is_some() {
+            if !handoff_latched {
+                let by_strike = strike_n > STRIKE_FORCE_N;
+                let by_tilt = tilt_rad > HANDOFF_TILT_RAD;
+                if by_strike || by_tilt {
+                    handoff_latched = true;
+                    // The state handed over is the state at the instant of
+                    // the strike, captured BEFORE the freeze below stops the
+                    // plant -- everything sent from here on is this snapshot.
+                    handoff_state = Some((pos, quat, lin_vel, ang_vel));
+                    eprintln!(
+                        "sim-host: ADR-0012 handoff at t={:.3}s -- {} \
+                         (bumper {strike_n:.0} N, tilt {:.1} deg); \
+                         MuJoCo has stopped propagating, Unreal owns the board",
+                        t_known_s,
+                        if by_strike { "bumper strike" } else { "tilt" },
+                        tilt_rad.to_degrees(),
+                    );
+                }
+            }
+        }
+
+        if handoff_latched {
+            flags |= wire::STATE_FLAG_HANDOFF;
+        }
+
         if cfg.trace_path.is_some() {
             trace.push(TraceRow {
                 seq: ticks,
@@ -1914,6 +2180,19 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             });
         }
 
+        // ADR-0012 freeze. While latched, the board's pose and velocity are
+        // the snapshot taken on the strike cycle, repeated verbatim. MuJoCo
+        // keeps stepping underneath -- stopping the integrator mid-run would
+        // strand the control loop and the pacer -- but nothing it computes
+        // after the strike reaches the wire, which is what "stops
+        // propagating" has to mean for the client to be the sole authority.
+        // `seq`, `sim_time_s` and the diagnostic channels keep moving so the
+        // stream stays visibly alive rather than looking hung.
+        let (pos, quat, lin_vel, ang_vel) = match handoff_state {
+            Some(frozen) => frozen,
+            None => (pos, quat, lin_vel, ang_vel),
+        };
+
         let state = StateOut {
             magic: wire::STATE_MAGIC,
             schema_version: wire::STATE_SCHEMA_VERSION,
@@ -1929,6 +2208,8 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             motor_current_a: obs.motor_current_a,
             rider_fore_aft_m,
             rider_lateral_m,
+            lin_vel,
+            ang_vel,
         };
         out_socket.send_to(&state.to_bytes(), cfg.state_out_addr)?;
 
@@ -2072,6 +2353,11 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     }
 
     let _ = backend.close();
+    // The spliced model is a per-process scratch file; leaving it behind
+    // would litter `sim/models/` with generated XML that looks committed.
+    if let Some(path) = &generated_model {
+        let _ = std::fs::remove_file(path);
+    }
 
     Ok(RunSummary {
         ticks,

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -157,6 +157,22 @@ fn rider_model_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sim/models/overboard_rider.xml")
 }
 
+/// The board state captured on the cycle a terminating event is declared,
+/// and repeated on every packet from then until the latch clears (ADR-0012).
+///
+/// This is what "MuJoCo has stopped propagating" means on the wire: the plant
+/// keeps stepping underneath -- freezing the integrator mid-run would strand
+/// the control loop and the pacer -- but nothing it computes after the strike
+/// reaches the client, so the client is the sole authority in fact and not
+/// merely by agreement.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HandoffSnapshot {
+    pub pos: [f32; 3],
+    pub quat: [f32; 4],
+    pub lin_vel: [f32; 3],
+    pub ang_vel: [f32; 3],
+}
+
 /// A kerb to ride into (ADR-0012). Off by default, and when it is off the
 /// model this host opens is the shared `overboard_rider.xml`, byte for byte.
 ///
@@ -1587,7 +1603,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     };
 
     let mut handoff_latched = false;
-    let mut handoff_state: Option<([f32; 3], [f32; 4], [f32; 3], [f32; 3])> = None;
+    let mut handoff_state: Option<HandoffSnapshot> = None;
     let mut prev_kick_bit = false;
     // `Some(t)` while an on-demand fall kick (issue #161 follow-up, item 5)
     // is in its force-application window, `t` being the sim time it started
@@ -2125,32 +2141,35 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // a measured carve envelope instead of a guess.
         let tilt_rad = (xmat[8].clamp(-1.0, 1.0) as f32).acos();
         let strike_n = backend.truth_nose_strike_n() + backend.truth_tail_strike_n();
-        if std::env::var("OB_HANDOFF_DEBUG").is_ok() && ticks % 250 == 0 {
+        if std::env::var("OB_HANDOFF_DEBUG").is_ok() && ticks.is_multiple_of(250) {
             eprintln!(
                 "  [handoff-debug] t={t_known_s:.2} tilt={:.1}deg strike={strike_n:.1}N \
                  y={truth_pos_y_m:.2}",
                 tilt_rad.to_degrees()
             );
         }
-        if cfg.kerb.is_some() {
-            if !handoff_latched {
-                let by_strike = strike_n > STRIKE_FORCE_N;
-                let by_tilt = tilt_rad > HANDOFF_TILT_RAD;
-                if by_strike || by_tilt {
-                    handoff_latched = true;
-                    // The state handed over is the state at the instant of
-                    // the strike, captured BEFORE the freeze below stops the
-                    // plant -- everything sent from here on is this snapshot.
-                    handoff_state = Some((pos, quat, lin_vel, ang_vel));
-                    eprintln!(
-                        "sim-host: ADR-0012 handoff at t={:.3}s -- {} \
-                         (bumper {strike_n:.0} N, tilt {:.1} deg); \
-                         MuJoCo has stopped propagating, Unreal owns the board",
-                        t_known_s,
-                        if by_strike { "bumper strike" } else { "tilt" },
-                        tilt_rad.to_degrees(),
-                    );
-                }
+        if cfg.kerb.is_some() && !handoff_latched {
+            let by_strike = strike_n > STRIKE_FORCE_N;
+            let by_tilt = tilt_rad > HANDOFF_TILT_RAD;
+            if by_strike || by_tilt {
+                handoff_latched = true;
+                // The state handed over is the state at the instant of the
+                // strike, captured BEFORE the freeze below stops it reaching
+                // the wire -- everything sent from here on is this snapshot.
+                handoff_state = Some(HandoffSnapshot {
+                    pos,
+                    quat,
+                    lin_vel,
+                    ang_vel,
+                });
+                eprintln!(
+                    "sim-host: ADR-0012 handoff at t={:.3}s -- {} \
+                     (bumper {strike_n:.0} N, tilt {:.1} deg); \
+                     MuJoCo has stopped propagating, Unreal owns the board",
+                    t_known_s,
+                    if by_strike { "bumper strike" } else { "tilt" },
+                    tilt_rad.to_degrees(),
+                );
             }
         }
 
@@ -2189,7 +2208,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // `seq`, `sim_time_s` and the diagnostic channels keep moving so the
         // stream stays visibly alive rather than looking hung.
         let (pos, quat, lin_vel, ang_vel) = match handoff_state {
-            Some(frozen) => frozen,
+            Some(f) => (f.pos, f.quat, f.lin_vel, f.ang_vel),
             None => (pos, quat, lin_vel, ang_vel),
         };
 

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -520,7 +520,11 @@ mod tests {
             STATE_FLAG_FALLEN,
             STATE_FLAG_AUTHORITY_WARNING,
         ] {
-            assert_eq!(STATE_FLAG_HANDOFF & other, 0, "handoff bit overlaps {other:#06x}");
+            assert_eq!(
+                STATE_FLAG_HANDOFF & other,
+                0,
+                "handoff bit overlaps {other:#06x}"
+            );
         }
         assert_eq!(STATE_FLAG_HANDOFF, 0b1_0000);
     }

--- a/crates/sim-host/src/wire.rs
+++ b/crates/sim-host/src/wire.rs
@@ -29,7 +29,7 @@ pub const INPUT_MAGIC: u32 = 0x4F42_4931;
 /// and 2, so a one-sided deploy in either direction cannot produce a dead
 /// window. This crate has no v1 sender left to keep around, so
 /// [`StateOut::from_bytes`] only accepts 2 -- see that method's doc comment.
-pub const STATE_SCHEMA_VERSION: u16 = 2;
+pub const STATE_SCHEMA_VERSION: u16 = 3;
 /// [`InputIn`]'s schema version. Unchanged by the v2 state-out bump --
 /// `InputIn` is explicitly untouched (issue #161 wire v2 follow-up).
 pub const INPUT_SCHEMA_VERSION: u16 = 1;
@@ -40,6 +40,21 @@ pub const STATE_FLAG_ARMED: u16 = 1 << 0;
 pub const STATE_FLAG_VALID: u16 = 1 << 1;
 /// `StateOut::flags` bit 2.
 pub const STATE_FLAG_FALLEN: u16 = 1 << 2;
+/// `StateOut::flags` bit 3 -- the ADR-0011 condition 3 loss-of-authority
+/// warning (issue #216).
+pub const STATE_FLAG_AUTHORITY_WARNING: u16 = 1 << 3;
+/// `StateOut::flags` bit 4 -- ADR-0012 physics-authority handoff.
+///
+/// Set from the cycle a terminating event is declared onward, and NEVER
+/// cleared except by the input `reset` bit. While it is set this host has
+/// stopped propagating the board: `pos`/`quat`/`lin_vel`/`ang_vel` are frozen
+/// at the values they held on the strike cycle, and Unreal owns the board.
+///
+/// The latch is what makes the transfer safe against packet loss. A one-shot
+/// edge could be dropped by the UDP wire and the client would follow a board
+/// the host had already stopped simulating -- so the bit is a LEVEL, and a
+/// client that misses the first packet takes over on the next one.
+pub const STATE_FLAG_HANDOFF: u16 = 1 << 4;
 
 /// `InputIn::flags` bit 0.
 pub const INPUT_FLAG_ARM: u16 = 1 << 0;
@@ -141,11 +156,29 @@ pub struct StateOut {
     /// **v2.** ACTUAL `ballast_lat` joint position, metres, signed. Same
     /// status as `rider_fore_aft_m` in every respect but axis.
     pub rider_lateral_m: f32,
+    /// **v3 (ADR-0012).** World-frame linear velocity of the board body,
+    /// m/s, raw MuJoCo -- untransformed, exactly as `pos`/`quat` are, so
+    /// `CoordinateTransform` on the game side stays the single place the
+    /// MuJoCo->Unreal conversion happens.
+    ///
+    /// Present on every packet, not only handoff ones: a velocity that
+    /// appeared only at the instant it was needed would be a field nobody
+    /// could sanity-check until the one moment it had to be right.
+    pub lin_vel: [f32; 3],
+    /// **v3 (ADR-0012).** World-frame angular velocity of the board body,
+    /// rad/s, right-hand rule, raw MuJoCo.
+    ///
+    /// **World frame**, from the model's `frame_angvel` sensor -- NOT the
+    /// free joint's `qvel` angular half, which is body-frame. The receiving
+    /// physics engine seeds with a world angular velocity; converting
+    /// anywhere but `CoordinateTransform` is the error ADR-0010 named as
+    /// silently poisoning everything downstream.
+    pub ang_vel: [f32; 3],
 }
 
 impl StateOut {
     /// The exact on-wire byte count -- also asserted at compile time below.
-    pub const WIRE_SIZE: usize = 80;
+    pub const WIRE_SIZE: usize = 104;
 
     #[allow(clippy::too_many_arguments)]
     pub fn to_bytes(&self) -> [u8; Self::WIRE_SIZE] {
@@ -176,6 +209,12 @@ impl StateOut {
         put!(self.motor_current_a);
         put!(self.rider_fore_aft_m);
         put!(self.rider_lateral_m);
+        for v in self.lin_vel {
+            put!(v);
+        }
+        for v in self.ang_vel {
+            put!(v);
+        }
         debug_assert_eq!(off, Self::WIRE_SIZE);
         buf
     }
@@ -228,6 +267,8 @@ impl StateOut {
         let motor_current_a = take!(f32);
         let rider_fore_aft_m = take!(f32);
         let rider_lateral_m = take!(f32);
+        let lin_vel = [take!(f32), take!(f32), take!(f32)];
+        let ang_vel = [take!(f32), take!(f32), take!(f32)];
         debug_assert_eq!(off, Self::WIRE_SIZE);
         Ok(StateOut {
             magic,
@@ -244,6 +285,8 @@ impl StateOut {
             motor_current_a,
             rider_fore_aft_m,
             rider_lateral_m,
+            lin_vel,
+            ang_vel,
         })
     }
 }
@@ -398,8 +441,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn state_out_is_exactly_80_bytes() {
-        assert_eq!(core::mem::size_of::<StateOut>(), 80);
+    fn state_out_is_exactly_104_bytes() {
+        assert_eq!(core::mem::size_of::<StateOut>(), 104);
     }
 
     #[test]
@@ -423,7 +466,63 @@ mod tests {
             motor_current_a: 4.5,
             rider_fore_aft_m: 0.021,
             rider_lateral_m: -0.013,
+            lin_vel: [5.5, -0.25, 0.125],
+            ang_vel: [0.75, -1.5, 2.25],
         }
+    }
+
+    /// ADR-0012's named enforcement: a KNOWN-ANSWER test, so this encoder and
+    /// `overboard-game`'s `wire/OverboardWire.cpp` cannot drift apart
+    /// quietly. The same fixed packet is asserted byte-for-byte on the C++
+    /// side. If these two ever disagree, one of them is wrong and CI says so
+    /// -- rather than a plausible-looking float misparse showing up as a
+    /// board that tumbles in the wrong direction.
+    ///
+    /// Every value below is exactly representable in f32/f64 (halves,
+    /// quarters, eighths), so the expected bytes are unambiguous and this
+    /// test is not asserting a rounding mode.
+    #[test]
+    fn state_out_known_answer_bytes() {
+        let s = sample_state();
+        let b = s.to_bytes();
+
+        // Header.
+        assert_eq!(&b[0..4], &0x4F42_5731u32.to_le_bytes(), "magic 'OBW1'");
+        assert_eq!(&b[4..6], &3u16.to_le_bytes(), "schema_version = 3");
+        assert_eq!(&b[6..8], &0x0003u16.to_le_bytes(), "flags armed|valid");
+        assert_eq!(&b[8..16], &42u64.to_le_bytes(), "seq");
+        assert_eq!(&b[16..24], &1.5f64.to_le_bytes(), "sim_time_s");
+
+        // v1 body -- offsets fixed by ADR-0010 and unchanged by v2/v3.
+        assert_eq!(&b[24..28], &1.0f32.to_le_bytes(), "pos.x @24");
+        assert_eq!(&b[36..40], &1.0f32.to_le_bytes(), "quat.w @36");
+        assert_eq!(&b[68..72], &4.5f32.to_le_bytes(), "motor_current_a @68");
+
+        // v2 rider fields, then the v3 velocities -- the offsets ADR-0012
+        // fixes. These four asserts are the ones that fail if either side
+        // inserts a field in the middle instead of appending.
+        assert_eq!(&b[72..76], &0.021f32.to_le_bytes(), "rider_fore_aft_m @72");
+        assert_eq!(&b[80..84], &5.5f32.to_le_bytes(), "lin_vel.x @80");
+        assert_eq!(&b[92..96], &0.75f32.to_le_bytes(), "ang_vel.x @92");
+        assert_eq!(&b[100..104], &2.25f32.to_le_bytes(), "ang_vel.z @100");
+
+        assert_eq!(b.len(), 104, "v3 wire size");
+    }
+
+    /// The handoff bit is bit 4 and does not collide with any bit already on
+    /// the wire -- the property that let ADR-0012 add it without a second
+    /// schema bump.
+    #[test]
+    fn handoff_flag_is_a_free_bit() {
+        for other in [
+            STATE_FLAG_ARMED,
+            STATE_FLAG_VALID,
+            STATE_FLAG_FALLEN,
+            STATE_FLAG_AUTHORITY_WARNING,
+        ] {
+            assert_eq!(STATE_FLAG_HANDOFF & other, 0, "handoff bit overlaps {other:#06x}");
+        }
+        assert_eq!(STATE_FLAG_HANDOFF, 0b1_0000);
     }
 
     #[test]

--- a/sim/models/overboard_rider.xml
+++ b/sim/models/overboard_rider.xml
@@ -130,6 +130,39 @@
 
       <site name="imu" pos="-0.06 0 -0.007" size="0.008" group="4"/>
 
+      <!--
+        ADR-0012 terminating-event detectors: the volumes a BUMPER STRIKE
+        happens in. The two `touch` sensors below sum the normal force of
+        every contact whose point falls inside their box, so each box has to
+        contain one bumper and nothing that is touched in normal riding.
+
+        BOTH ENDS, not just the nose. An uncontrolled board tips TAIL-down as
+        readily as nose-down -- released from upright in this model it settles
+        on `rear_bumper_geom` -- and a kerb strike can put it either way. A
+        nose-only detector would read zero through half of the crashes it
+        exists to catch, which is the failure mode that looks like "the
+        feature works" right up until the run it matters on.
+
+        Sized from the meshes, not by eye. `front_bumper.stl` occupies local
+        x[-0.4690,-0.3454] and `rear_bumper.stl` x[+0.3454,+0.4690], both
+        y[+-0.1159] z[-0.0254,+0.0497] m -- so centres at (-+0.4072, 0,
+        +0.0122) and half-extents (0.0618, 0.1159, 0.0376), padded to
+        (0.075, 0.125, 0.050) so a contact just off the mesh surface still
+        registers.
+
+        WHY NEITHER CAN FIRE ON NORMAL GROUND CONTACT, which is the failure
+        that would make every ride end in a false crash: the frame origin sits
+        at axle height (0.1454 m) when upright, so the wheel's ground contact
+        is at local z = -0.1454 and local x = 0. Both boxes span local
+        z[-0.0378,+0.0622] and are offset to |x| >= 0.3322 -- the ground patch
+        is outside them on BOTH axes independently, so either axis alone
+        excludes it. Upright, their lowest point is 0.108 m above the ground.
+      -->
+      <site name="nose_strike" pos="-0.4072 0 0.0122" size="0.075 0.125 0.050"
+            type="box" group="4"/>
+      <site name="tail_strike" pos="+0.4072 0 0.0122" size="0.075 0.125 0.050"
+            type="box" group="4"/>
+
       <geom name="front_enclosure_geom" class="visual" type="mesh" mesh="front_enclosure" material="shell_mat"/>
       <geom name="rear_enclosure_geom" class="visual" type="mesh" mesh="rear_enclosure" material="shell_mat"/>
       <geom name="front_footpad_geom" class="visual" type="mesh" mesh="front_footpad" euler="0 0 180" material="footpad_mat"/>
@@ -228,5 +261,26 @@
     <jointpos name="wheel_pos" joint="wheel_hinge"/>
     <jointvel name="wheel_vel" joint="wheel_hinge"/>
     <actuatorfrc name="motor_torque" actuator="wheel_motor"/>
+
+    <!--
+      ADR-0012 physics-authority handoff. All three are APPENDED, and appended
+      deliberately: `sim-host` resolves sensors by name through
+      `Plant::sensor_adr_dim`, so adding to the end cannot move an existing
+      sensor's address. None of them affect dynamics -- MuJoCo sensors are
+      pure readouts -- so the bit-identity replay gate this file's header
+      warns about is untouched. `qpos`/`qvel` are byte-for-byte what they were.
+
+      The two velocities are what the handoff HANDS OVER. `pos` and `quat`
+      already go out on the wire; without these, Unreal would seed the crash
+      from rest and the board would hit the kerb as though it were treacle.
+      Both are world-frame and go on the wire raw, exactly as `pos`/`quat` do
+      -- `CoordinateTransform` on the game side remains the only place the
+      MuJoCo->Unreal conversion ever happens (ADR-0010 rule, carried forward
+      by ADR-0012).
+    -->
+    <framelinvel name="frame_linvel" objtype="body" objname="frame"/>
+    <frameangvel name="frame_angvel" objtype="body" objname="frame"/>
+    <touch name="nose_strike" site="nose_strike"/>
+    <touch name="tail_strike" site="tail_strike"/>
   </sensor>
 </mujoco>


### PR DESCRIPTION
The host half of the CEO's kerb-crash scenario (ADR-0012, #241): detect the strike, stop propagating, and put the state Unreal needs to take over on the wire. The client half is `overboard-game`.

**Reviewers:** Senior Controls (`crates/`) and Sr. Mechanical (`sim/models/`) — this crosses both desks, so it is one handoff rather than three PRs that would conflict with each other.

## The kerb is placed on a real kerb

`dump_triangles.py`'s existing 12.6M-triangle dump of `OB_City`, through `rasterize_hfield.py`'s own UE→MuJoCo transform, puts a continuous line of **~0.090 m risers at y = +8.85 m** running along X — the left kerb of the street the board spawns on. (The 0.14–0.26 m risers at y = −7.6 m are the steps opposite.) MuJoCo's kerb goes on the same coordinate, because terrain is not on the wire and Unreal draws City Park, not this model — any other placement is an invisible wall.

**Spliced at load time, not committed.** Every scenario shares `overboard_rider.xml` and several travel a long way (the host coasts 10.8 m in 10 s, #169). Without `--kerb`, the model opened is the shared file byte for byte. The splice reuses `terrain.py`'s existing pattern.

## Two measured findings changed the design

**Pitch-only detection was wrong.** A kerb is hit from the side. This model settles at **18.6°** of pitch — the nose-into-ground limit its own header documents — which never reaches `FALLEN`'s 20° threshold at all; and a board rolled onto its side can be flat on the ground with `FALLEN` reading 0 and neither bumper touched. Added a direction-agnostic tilt-from-vertical test. **`FALLEN` itself is untouched** — ADR-0011 quotes its lead times, and redefining it would invalidate published numbers.

**35° is measured, not chosen.** The real risk is the false positive — a threshold a hard carve reaches would ragdoll a player who is still riding. Peak tilt over 30 s of each scripted scenario, no kerb:

| scenario | peak tilt |
|---|---|
| `default` | 5.5° |
| `s-curve` | 8.0° |
| `full-stick` | 8.0° |
| `stick-reversal` | **11.0°** |

35° is 3.2× the worst. On the run that did go down, the board crossed it and was at 166° moments later.

**The corridor fought the kerb.** `CORRIDOR_HALF_WIDTH_M` is 8.6 m and the kerb face is 8.85 m, so the soft brake arrested forward lean 0.25 m short of the target — a run reached y = 8.6, got braked, and came back. With a kerb armed the lateral limit moves outside it, so the kerb's geometry stops the board rather than an invisible brake. X bounds untouched. The kerb also now spans the whole corridor in X — at 40 m half-length it was outrunnable (a run reached the kerb's Y at x = −112 m and sailed past the end).

## Model changes are pure additions

`framelinvel`/`frameangvel` (both **world**-frame: `qvel`'s linear half is already global but its angular half is body-frame, and mixing the two sources is how a frame error gets introduced later), plus **two** touch sensors — nose and tail, because released from upright this plant settles *tail*-down and a nose-only detector reads zero through half the falls it exists to catch. Sensors are appended and resolved by name, so no existing address moves and `qpos`/`qvel` are unchanged.

Measured: **0.0000 N** through 6000 steps of upright riding, 560 N resting on a bumper.

## Wire v3 — 104 bytes

`lin_vel[3]` @80, `ang_vel[3]` @92, raw MuJoCo frame; `flags` bit 4 = handoff. The latch is a **level, not an edge** — a one-shot could be dropped by UDP and leave the client following a board the host had stopped simulating. While latched, pose and velocity are the strike-cycle snapshot; `seq`/`sim_time_s` keep moving so the stream does not look hung. The `reset` bit clears it, which is that bit's first real job (it was accepted and ignored before).

A **known-answer test** asserts the exact bytes, and the identical assertion exists in `overboard-game`'s `test_wire.cpp` — ADR-0012's named enforcement.

## Verification

- Handoff fires at t=17.060 s on a live run and freezes correctly.
- `cargo test --workspace` green; `pytest` 333 passed, 5 xfailed.

## Acceptance criteria

None of ADR-0011's exit criteria move. `FALLEN` and its measured lead times are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)