### PR TITLE
fix(controls): the removable-media guard refused the CEO's actual card reader (#182)

### DIFF
--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -5,7 +5,7 @@ covers:
   - scripts/pi/flash_pi.sh
   - scripts/pi/pins.env
   - crates/loop-profiler/src/lib.rs
-reconciled: 3251993
+reconciled: 05f5c6b
 -->
 
 **Owned by: Senior Controls.** **Executed by: the CEO**, at a desk, with a monitor and a
@@ -213,9 +213,17 @@ $EDITOR ~/.overboard/pi-secrets.env       # real SSID/passphrase/pubkey; keep PI
 scripts/pi/flash_pi.sh --disk /dev/diskN --image ~/Downloads/<stock-raspios>.img.xz --dry-run
 ```
 
-`--dry-run` runs every guard and generates the boot payload, skipping only the write. Find the
-disk with `diskutil list external` (macOS) or `lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT` (Linux)
-first.
+`--dry-run` runs every guard and generates the boot payload, skipping only the write.
+
+**Finding the disk on macOS: use `diskutil list`, not `diskutil list external`.** A MacBook's
+built-in SDXC slot reports `Device Location: Internal` — it hangs off an internal bus — while the
+card in it is `Removable Media: Removable`. So the card does **not** appear under `external`, and
+the obvious command silently shows you everything except the disk you want. On Linux,
+`lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT`.
+
+**Match the size.** `flash_pi.sh` refuses the system disk and refuses non-removable media, but it
+cannot tell one removable device from another — a USB stick is as valid a target as your card.
+Size is what distinguishes them, and it is the operator's job.
 
 **What this does and does not do.** `--image` points at the stock image purely to satisfy the
 resolver; the exercise validates the removable-media guard, the confirmation prompt and

--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -71,19 +71,40 @@ assert_removable() {
   [ -e "$disk" ] || die "$disk does not exist"
 
   if [ "$OS" = "Darwin" ]; then
-    local info removable internal
+    local info removable virtual this_whole root_whole
     info="$(diskutil info "$disk" 2>/dev/null)" || die "diskutil could not read $disk"
     removable="$(echo "$info" | awk -F': *' '/Removable Media/{print $2}' | xargs)"
-    internal="$(echo "$info" | awk -F': *' '/Device Location/{print $2}' | xargs)"
+    virtual="$(echo "$info"   | awk -F': *' '/^ *Virtual:/{print $2}' | xargs)"
+    this_whole="$(echo "$info" | awk -F': *' '/Part of Whole/{print $2}' | xargs)"
     echo "$info" | grep -E 'Device / Media Name|Disk Size|Device Location|Removable Media|Volume Name' \
       | sed 's/^ */    /'
-    if [ "$internal" = "Internal" ]; then
-      die "$disk is an INTERNAL disk. Refusing.
-       This is almost certainly your system drive. Re-read `diskutil list external`."
+
+    # Refuse the disk the running system is on, BY IDENTITY.
+    #
+    # This replaces a `Device Location: Internal` test that was simply wrong
+    # about the world. A MacBook's built-in SDXC slot reports **Internal**
+    # (it hangs off an internal bus) while holding **Removable** media, so
+    # the old check refused the CEO's actual card reader and would have sent
+    # him looking for a way around a safety guard -- the worst possible
+    # outcome for one. "Which bus is it on" was never the question; "is this
+    # the system disk, and is the media removable" is.
+    root_whole="$(diskutil info / 2>/dev/null | awk -F': *' '/Part of Whole/{print $2}' | xargs)"
+    if [ -n "$root_whole" ] && [ -n "$this_whole" ] && [ "$root_whole" = "$this_whole" ]; then
+      die "$disk holds the volume this Mac is booted from. Refusing.
+       There is no --force. The only reason to want one here is a mistake."
     fi
+
+    # Removability is now the load-bearing test, so it must be exact. An
+    # internal NVMe reports 'Not removable' or 'Fixed' and is refused here.
     case "$removable" in
-      Removable|"Yes") ;;
+      Removable|Yes) ;;
       *) die "$disk does not report as removable media (got: '${removable:-unknown}'). Refusing." ;;
+    esac
+
+    # Synthesized APFS containers are Virtual: Yes and are not raw targets.
+    case "$virtual" in
+      No|"") ;;
+      *) die "$disk is a virtual/synthesized device (Virtual: $virtual), not physical media. Refusing." ;;
     esac
   else
     local base rm_flag


### PR DESCRIPTION
**Blocking the first AC-11 restore test right now.** Found live, mid-flash.

## The bug

Guard 1 refused any disk reporting `Device Location: Internal`. A MacBook's **built-in SDXC slot reports `Internal`** — it hangs off an internal bus — while the card in it is `Removable Media: Removable`. The CEO's card:

```
Device Node:      /dev/disk7
Disk Size:        128.0 GB
Device Location:  Internal      <-- guard refused on this
Removable Media:  Removable     <-- what actually matters
Virtual:          No
```

So the script refused the only card reader he has. **That is the worst failure mode a safety guard can have:** not a missed catch, but a false refusal on the correct target, which sends the operator looking for a way around the guard. A guard that cries wolf gets disabled, and then it is not there on the day it matters.

"Which bus is the reader on" was never the question. "Is this the system disk, and is the media removable" is.

## The fix — same strictness, correct predicate

1. **Refuse the system disk by identity**, comparing `Part of Whole` against `diskutil info /`. This is the check that actually expresses the intent the old one was groping at.
2. **Removability becomes load-bearing** and must be exact (`Removable`/`Yes`). Internal NVMe reports `Fixed` and is refused here.
3. **Refuse `Virtual: Yes`** — synthesized APFS containers are not raw targets.

Still no `--force`. Guard 2 (type the identifier back) is untouched.

## Verified against the CEO's real disks

| Disk | Reports | Result |
|---|---|---|
| `/dev/disk7` (his SD card) | Removable, Internal | **ACCEPTED** — the fix |
| `/dev/disk0` (internal NVMe) | Fixed, Internal | REFUSED — *"does not report as removable media (got: 'Fixed')"* |
| `/dev/disk3` (root APFS container) | Fixed, Internal | REFUSED — *"holds the volume this Mac is booted from"* (the new check firing) |
| `/dev/disk4` (240 MB USB stick) | Removable, External | ACCEPTED |

That last row is correct and worth stating plainly: **the guards do not protect against picking the wrong removable device.** A USB stick is as valid a target as an SD card. Only size-matching distinguishes them, and that is the operator's job — now said out loud in the runbook rather than left implied.

## Knock-on: PR #231's auto-detect has the same bug

`removable_disks()` there enumerates via `diskutil list external physical`, which **will not list this card either**. #231 is still open; its detector needs the same correction before it merges, or the convenience feature will silently fail to find the CEO's only reader. Flagged, not fixed here — this PR is the one standing between him and tonight's measurement.

## Doc

The runbook told the reader to find the disk with `diskutil list external`, which cannot work on this hardware. Now says use `diskutil list`, explains why, and states the size-matching responsibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)