### PR TITLE
fix(image): the RT kernel installs as kernel8_rt.img — config.txt named a file that was never on the card (#182)

### DIFF
--- a/scripts/pi/build_image.sh
+++ b/scripts/pi/build_image.sh
@@ -70,6 +70,36 @@ section "BUILD"
 cd "$WORK"
 ./rpi-image-gen build -S "$SRC" -c overboard.yaml
 
+section "kernel selection matches what was built"
+
+# config.txt names a kernel FILE, and firmware loads that exact name. If the
+# file is not in the boot partition the card is a brick -- and NOTHING else in
+# this build would notice. The image is well-formed, every pin resolves, the
+# manifest is accurate, the checksum matches. It fails only at 3am on a Pi
+# with a dark screen.
+#
+# This is not hypothetical. The line said kernel8.img while the RT package
+# installs kernel8_rt.img, on the strength of a spike that built a DIFFERENT
+# kernel. It reached a real card and was caught by hand minutes before the
+# first AC-11 attempt. The assertion below is what makes that a build failure
+# instead of a bench evening.
+KCFG="$SRC/device/overboard-pi5/config.txt"
+[ -f "$KCFG" ] || { echo "FATAL: $KCFG not found"; exit 1; }
+kname="$(awk -F= '/^kernel=/{print $2}' "$KCFG" | tail -1 | tr -d '[:space:]')"
+[ -n "$kname" ] || { echo "FATAL: $KCFG has no kernel= line to verify"; exit 1; }
+
+if [ -n "$(find "$WORK/work" -name "$kname" -print -quit 2>/dev/null)" ]; then
+  echo "OK: config.txt names kernel=$kname, and that file is in the build"
+else
+  echo "FATAL: config.txt names kernel=$kname, but no such file was built."
+  echo "       The card would not boot. Kernel images actually present:"
+  find "$WORK/work" -name 'kernel*.img' 2>/dev/null \
+    | sed 's|.*/|         |' | sort -u
+  echo "       Point kernel= at one of those, or work out why the expected"
+  echo "       kernel package did not install."
+  exit 1
+fi
+
 section "collect artefacts"
 mkdir -p "$OUT"
 rm -f "$OUT"/*

--- a/scripts/pi/image/device/overboard-pi5/config.txt
+++ b/scripts/pi/image/device/overboard-pi5/config.txt
@@ -35,17 +35,28 @@ BOOT_UART=1
 # OVERBOARD: kernel selection  (issue #182 I2, design Q12)
 # ===========================================================================
 # Pi 5 firmware defaults to loading kernel_2712.img. There is NO rpt-2712-rt
-# package, so the real-time kernel we install is the generic v8 one, which
-# ships as kernel8.img -- confirmed present in the spike's build output.
+# package, so the real-time kernel we install is the generic v8 one.
 # Without this line the firmware would load a kernel we did not install, or
 # fail to boot.
 #
-# ⚠️ UNVERIFIED ON HARDWARE. This is the design's own Q12, described there as
-# "operational, not architectural -- but it is the difference between a card
-# that boots and one that does not". It is a reasoned first attempt, not a
-# confirmed answer, and the restore test (AC-11) is what settles it. If the
-# board does not boot, THIS LINE IS THE FIRST THING TO CHANGE.
-kernel=kernel8.img
+# ✅ VERIFIED ON HARDWARE 2026-08-06. The previous note here said this line
+# was unverified and would be "THE FIRST THING TO CHANGE" if the board did not
+# boot. It was exactly that, and it was wrong:
+#
+# The RT kernel package installs as **kernel8_rt.img**, not kernel8.img. The
+# earlier value rested on "confirmed present in the spike's build output", but
+# the spike built rpi-image-gen's STOCK config, not our RT kernel, so that
+# confirmation never covered this package. The first real card carried
+# kernel8_rt.img and initramfs8_rt and no kernel8.img at all -- it would not
+# have booted. Caught by inspecting the boot partition minutes before the
+# first AC-11 attempt, rather than by a dark screen.
+#
+# The _rt suffix is the kernel package's own, and auto_initramfs=1 derives the
+# initramfs name from it: kernel8_rt.img pairs with initramfs8_rt, which is
+# precisely what shipped. build_image.sh now asserts that whatever this line
+# names actually exists in the built boot partition, so the config and the
+# package cannot drift apart again unnoticed.
+kernel=kernel8_rt.img
 
 # ===========================================================================
 # OVERBOARD: CAN  (issue #182 I3)


### PR DESCRIPTION
**Found on the CEO's boot partition minutes before the first AC-11 attempt, 2026-08-06. The card would not have booted.**

## What was on the card

    kernel8_rt.img      9,735,197
    initramfs8_rt      15,075,647

No `kernel8.img`. No `kernel_2712.img`. And config.txt said `kernel=kernel8.img`.

Firmware loads the name it is given. That name was not on the card.

## Why it got through every gate we have

**Nothing in the build was wrong except this.** The image was well-formed, every pin resolved, `verify-pins` / `check-pin` / `verify-kernel` / `build-image` were all green, the manifest was accurate, the SHA256 matched, and the card flashed and ejected cleanly. It fails only at the very end, on a Pi, with a dark screen and no diagnostic.

The line rested on *"ships as kernel8.img -- confirmed present in the spike's build output"*. The spike built rpi-image-gen's **stock** config, not our RT kernel, so that confirmation never covered this package. Exactly the residual recorded when Q12 closed (#224): mechanism proven, filename assumed.

Credit where due: the file's own `UNVERIFIED ON HARDWARE ... THIS LINE IS THE FIRST THING TO CHANGE` warning is why this cost four minutes instead of an evening.

## Confirmed on hardware after the fix

    Linux overboard 6.12.75+rpt-rpi-v8-rt #1 SMP PREEMPT_RT aarch64

The pinned kernel, booting, genuinely PREEMPT_RT. **Q11 is answered too** -- no Pi-5-specific RT regression prevents boot.

## Fix

1. `kernel=kernel8_rt.img`, comment rewritten from unverified guess to verified fact.
2. **build_image.sh now asserts it**: parse `kernel=` from our own config.txt, fail the build unless a file of that name exists in the built tree, and list the kernel images that *are* present.

Checks the invariant ("config.txt names a file that exists") rather than a hardcoded name, so it survives another naming change. Would have turned a dark screen into a red build.

Not added to `KERNEL_REQUIRED_FILES`: that list is asserted against the .deb, and this filename is produced by the install, so the built artefact is the honest place.

## Corroboration

`auto_initramfs=1` derives the initramfs name from the kernel name, and the package shipped `initramfs8_rt` -- consistent with `kernel8_rt.img`, inconsistent only with our config.txt. The two files agreed with each other; only we disagreed with them.

## Testing

`bash -n` clean. Assertion exercised both ways against a synthetic tree. `awk` parse verified against the real config.txt. Not yet run in a full CI build -- the next `pi-image` run on master is its first outing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
