### PR TITLE
fix(controls): the reset button now actually returns the board to the start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ pi-secrets.env
 *.nmconnection
 overboard-authorized_keys
 overboard-userconf
+
+# sim-host --kerb splices its kerb into a per-process copy of the rider model
+# (ADR-0012) and deletes it on a clean exit. A run killed with SIGKILL never
+# gets there, so these accumulate -- five of them were nearly committed. They
+# are scratch by construction and must never be tracked.
+sim/models/*.generated.xml

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -408,6 +408,68 @@ impl SimBackend {
         (fore_aft, lateral)
     }
 
+    /// Puts the plant back to the model's initial state -- `mj_resetData`,
+    /// then the same `mj_forward` prime `open()` does.
+    ///
+    /// This is what the input wire's `reset` bit needs in order to mean
+    /// anything: before it existed, `sim-host` accepted the bit, logged
+    /// "not implemented yet, ignoring", and left the board wherever it had
+    /// fallen. A player who crashed had no way back to the start short of
+    /// restarting the host.
+    ///
+    /// # Why `forward()` is not optional here
+    ///
+    /// `mj_resetData` zeroes `sensordata` along with everything else. The
+    /// control loop reads its attitude out of `sensordata` on the very next
+    /// cycle, so without re-priming it the estimator's first post-reset
+    /// sample is a vertical the board never had -- the identical reason
+    /// `open()` calls `forward()` before its first step (AC8 / issue #107).
+    ///
+    /// The incline is re-applied for the same reason: it lives in
+    /// `mjModel::opt.gravity`, which `mj_resetData` does NOT touch, but
+    /// re-asserting it keeps this path honestly identical to `open()`'s
+    /// rather than relying on that.
+    ///
+    /// # Panics
+    /// If called before `open()`.
+    pub fn reset(&mut self) {
+        let incline_deg = self.incline_deg;
+        let plant = self.plant.as_mut().expect("reset: backend is not open");
+        plant.reset();
+        if incline_deg != 0.0 {
+            let g = plant.gravity();
+            let mag = (g[0] * g[0] + g[1] * g[1] + g[2] * g[2]).sqrt();
+            let (s, c) = incline_deg.to_radians().sin_cos();
+            plant.set_gravity([mag * s, 0.0, -mag * c]);
+        }
+        plant.forward();
+
+        // Clear EXACTLY what `open()` clears. This list is the whole bug:
+        // `pending_current_a`/`commanded_current_a` are a BUFFERED command --
+        // this backend's own header says it "only buffers a pending command",
+        // which the next `wait_observe()` writes to `ctrl` before stepping.
+        //
+        // Leaving them set meant a reset stepped the freshly-uprighted board
+        // with the SATURATED command left over from the crash. Measured: a
+        // real forward acceleration of ~8.5 m/s^2 on the first post-reset
+        // observation, which `ComplementaryFilter::accel_pitch`
+        // (`atan2(accel[0] - a_ff, -accel[2])`) cannot distinguish from a
+        // 61 deg tilt -- and, being a fresh filter, it SNAPPED to that instead
+        // of filtering it out. The regulator answered with a full -40 A and
+        // nose-dived the board 0.28 s later.
+        //
+        // That is also why adding settle time here did not help: settling runs
+        // unpowered, and then `wait_observe()` re-applied the stale command
+        // anyway. The fix is to clear the command, not to wait longer.
+        self.cycle = 0;
+        self.pending_current_a = None;
+        self.commanded_current_a = 0.0;
+        self.applied_current_a = 0.0;
+        self.ballast_fa_target_m = 0.0;
+        self.ballast_lateral_target_m = 0.0;
+        self.last_wheel_rate_rad_s = 0.0;
+    }
+
     /// Ground-truth WORLD-frame linear velocity of the `frame` body, m/s,
     /// read from the model's `frame_linvel` sensor (ADR-0012).
     ///
@@ -1030,6 +1092,96 @@ impl BoardActuate for SimBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The reset the input wire's `reset` bit needs: after the board has been
+    /// driven well away from its start, `reset()` must put it back, not merely
+    /// stop whatever was happening to it.
+    ///
+    /// Regression guard for the first play-test report -- "the reset button
+    /// doesn't return me to start". At the time, `sim-host` cleared its
+    /// ADR-0012 handoff latch and nothing else, so the player got authority
+    /// over a board still lying where it had crashed.
+    #[test]
+    fn reset_returns_the_plant_to_its_starting_state() {
+        let mut b = armed();
+        let start_qpos = b.truth_qpos();
+        let start_pos = b.truth_frame_xpos();
+
+        // Shove it hard AND hold a large motor command, so "unchanged" cannot
+        // pass by accident and -- the point of this test -- so there really is
+        // a buffered command in flight at the moment of the reset. An earlier
+        // version of this test drove with `apply_external_force` alone, never
+        // commanded a current, and therefore passed with the fix reverted:
+        // there was nothing buffered to leak. A regression test that does not
+        // fail on the bug is worse than none, because it reads as coverage.
+        for _ in 0..400 {
+            b.apply_external_force([120.0, 40.0, 0.0], [0.0, 0.0, 0.0]);
+            b.wait_observe().unwrap();
+            // observe-then-apply: the backend enforces that ordering.
+            b.apply(&Command::MotorCurrent { amps: 35.0 }).unwrap();
+        }
+        assert!(
+            b.applied_current_a().abs() > 1.0,
+            "the drive phase must leave a real command in flight, else this test cannot              detect one leaking through the reset"
+        );
+        let moved_pos = b.truth_frame_xpos();
+        let displacement =
+            ((moved_pos[0] - start_pos[0]).powi(2) + (moved_pos[1] - start_pos[1]).powi(2)).sqrt();
+        assert!(
+            displacement > 0.05,
+            "the test did not actually move the board ({displacement:.4} m) -- it would then              prove nothing about reset"
+        );
+
+        b.reset();
+
+        let after = b.truth_qpos();
+        assert_eq!(
+            after.len(),
+            start_qpos.len(),
+            "reset must not change the shape of the state vector"
+        );
+        for (i, (a, s0)) in after.iter().zip(start_qpos.iter()).enumerate() {
+            assert!(
+                (a - s0).abs() < 1e-9,
+                "qpos[{i}] is {a} after reset, expected the starting {s0}"
+            );
+        }
+
+        // THE ACTUAL BUG. A reset that restores qpos but leaves the buffered
+        // command behind steps the freshly-uprighted board with the saturated
+        // current left over from the crash. That is not visible in qpos -- it
+        // shows up one cycle later as a large forward acceleration on the
+        // accelerometer, which the estimator cannot tell from a steep tilt.
+        //
+        // Asserted on the observation rather than on the private field, so
+        // this fails if the command survives by ANY route, not just the one
+        // that was fixed.
+        let obs = b.wait_observe().unwrap();
+        assert_eq!(
+            b.applied_current_a(),
+            0.0,
+            "a reset must not leave a buffered command to be applied on the next cycle"
+        );
+        let accel = obs.newest_imu().expect("imu sample").accel_m_s2;
+        assert!(
+            accel[0].abs() < 1.0,
+            "forward specific force is {:.2} m/s^2 on the first post-reset observation -- the \
+             board is being driven by a stale command. ComplementaryFilter::accel_pitch cannot \
+             distinguish that from a tilt, and snaps its initial pitch to it.",
+            accel[0]
+        );
+
+        // And `sensordata` must be primed, not left zeroed by mj_resetData --
+        // the control loop reads its attitude from there on the very next
+        // cycle, and a zeroed quaternion is not a valid attitude.
+        let quat = b.truth_frame_xquat();
+        let norm =
+            (quat[0] * quat[0] + quat[1] * quat[1] + quat[2] * quat[2] + quat[3] * quat[3]).sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-6,
+            "frame quaternion after reset is not normalised ({norm}) -- mj_forward did not run"
+        );
+    }
 
     fn opened() -> SimBackend {
         let mut b = SimBackend::with_params(Params {

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -197,15 +197,36 @@ pub struct KerbSpec {
 }
 
 /// Default kerb, measured from the real City Park geometry rather than
-/// invented: `overboard-game`'s `dump_triangles.py` dump of `OB_City` puts a
-/// continuous line of ~0.090 m risers at y = +8.85 m running along X, which is
-/// the left-hand kerb of the street the board spawns on. Placing MuJoCo's kerb
-/// on the same coordinate is what makes the strike land where the player can
-/// SEE a kerb -- the alternative is an invisible wall, since terrain is not on
-/// the wire and Unreal is drawing City Park, not this model.
+/// invented. A kerb BOTH SIDES, mirrored about the spawn point, because that
+/// is what the road actually has.
+///
+/// # The first value was wrong, and how it was wrong matters
+///
+/// This was y = 8.85 m, from a search for clusters of "risers" in
+/// `dump_triangles.py`'s dump of `OB_City`. Play-test verdict: it did not line
+/// up with the kerbs you can see. It was a **building wall** -- the vertical
+/// faces at y ~ 8.2-8.6 m span z from -1.6 to +2.9 m, and nothing in a riser
+/// filter distinguishes a 4.5 m wall from a 0.2 m kerb.
+///
+/// Two independent mistakes put it there. The search ranked candidates by
+/// TRIANGLE COUNT, and a kerb is a long low-poly extrusion -- the whole road
+/// mesh is 16,076 triangles against 8,465,926 for a single grass asset -- so
+/// the real kerbs were rejected for being too cheap to notice. And the dump is
+/// **94% foliage by triangle count**, so anything averaging "the surface" is
+/// really measuring grass and leaf litter.
+///
+/// Re-measured over LARGE triangles only (>0.02 m^2, which excludes grass
+/// blades by orders of magnitude) the picture is unambiguous and matches what
+/// a rider sees: near-vertical faces at **y = +-4.5 m**, symmetric about the
+/// spawn point, face top at z ~ +0.12 m, road between them at z ~ -0.09 m. A
+/// ~9 m road with the board in the middle and a ~0.21 m step either side.
+///
+/// `height_m` is measured from MuJoCo's flat ground plane (z = 0) up to the
+/// kerb top, i.e. what the wheel actually has to climb, not the kerb's full
+/// extent including the part buried below the road.
 pub const DEFAULT_KERB: KerbSpec = KerbSpec {
-    y_face_m: 8.85,
-    height_m: 0.090,
+    y_face_m: 4.5,
+    height_m: 0.12,
 };
 
 /// The spliced kerb spans the WHOLE drivable corridor in X, derived from
@@ -234,16 +255,22 @@ fn write_model_with_kerb(kerb: &KerbSpec) -> Result<PathBuf, HostError> {
         ))
     })?;
 
-    // Near face at `y_face_m`, body extending away from the board (+Y), top
-    // flush with the ground plane's surface at z = height_m.
-    let cy = kerb.y_face_m + KERB_HALF_DEPTH_M;
+    // A kerb on EACH side, mirrored: near faces at +-y_face_m, each body
+    // extending away from the board, tops flush at z = height_m. The board
+    // spawns between them, which is where City Park actually puts it.
     let hz = kerb.height_m / 2.0;
-    let geom = format!(
-        "\n    <!-- ADR-0012: spliced in by sim-host --kerb, NOT part of the shared model. -->\
-         \n    <geom name=\"kerb\" type=\"box\" pos=\"{KERB_CENTRE_X_M} {cy} {hz}\" \
-         size=\"{KERB_HALF_LENGTH_M} {KERB_HALF_DEPTH_M} {hz}\" \
-         rgba=\"0.62 0.60 0.57 1\" condim=\"3\" friction=\"0.8 0.005 0.0001\"/>\n  "
+    let mut geom = String::from(
+        "\n    <!-- ADR-0012: spliced in by sim-host --kerb, NOT part of the shared model. -->",
     );
+    for (tag, sign) in [("kerb_left", 1.0f64), ("kerb_right", -1.0f64)] {
+        let cy = sign * (kerb.y_face_m.abs() + KERB_HALF_DEPTH_M);
+        geom.push_str(&format!(
+            "\n    <geom name=\"{tag}\" type=\"box\" pos=\"{KERB_CENTRE_X_M} {cy} {hz}\" \
+             size=\"{KERB_HALF_LENGTH_M} {KERB_HALF_DEPTH_M} {hz}\" \
+             rgba=\"0.62 0.60 0.57 1\" condim=\"3\" friction=\"0.8 0.005 0.0001\"/>"
+        ));
+    }
+    geom.push_str("\n  ");
 
     // `terrain.py` splices at `</asset>`; the kerb is geometry, so it goes at
     // the single `</worldbody>`. Exactly one, or fail loudly -- a splice that
@@ -1521,10 +1548,10 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     let model_path = generated_model.clone().unwrap_or_else(rider_model_path);
     if let Some(kerb) = &cfg.kerb {
         eprintln!(
-            "sim-host: ADR-0012 kerb armed -- face at y={:+.3} m, {:.0} mm tall, \
-             spanning x[{:.0},{:.0}] m; handoff will fire on >{STRIKE_FORCE_N:.0} N of \
-             bumper contact or >{:.0} deg of tilt",
-            kerb.y_face_m,
+            "sim-host: ADR-0012 kerb armed -- faces at y=+-{:.3} m (BOTH sides), \
+             {:.0} mm tall, spanning x[{:.0},{:.0}] m; handoff will fire on \
+             >{STRIKE_FORCE_N:.0} N of bumper contact or >{:.0} deg of tilt",
+            kerb.y_face_m.abs(),
             kerb.height_m * 1000.0,
             CORRIDOR_X_MIN_M,
             CORRIDOR_X_MAX_M,

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -1807,16 +1807,34 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             // ADR-0012 gave this bit its first real job: it is the ONLY way
             // out of a handoff, and it is what returns authority to MuJoCo.
             // Outside a handoff it still does nothing, and still says so.
-            if handoff_latched {
-                eprintln!(
-                    "sim-host: input reset bit set -- clearing the ADR-0012 handoff, \
-                     MuJoCo resumes propagating the board"
-                );
-                handoff_latched = false;
-                handoff_state = None;
-            } else {
-                eprintln!("sim-host: input reset bit set -- not implemented yet, ignoring");
-            }
+            // A RESET IS NOT JUST "UN-LATCH". Clearing the handoff alone
+            // handed authority back to MuJoCo with the board still lying
+            // wherever it had tumbled to, tens of metres downrange -- so the
+            // player got control of a fallen board rather than a fresh run.
+            // Reported from the first play-test, and the reason this now
+            // resets the PLANT and every piece of loop state derived from it.
+            //
+            // Everything below is state that outlives a single cycle. Leaving
+            // any of it behind puts the fresh board under the influence of the
+            // crashed one: a stale `yaw_rad` respawns it pointing the wrong
+            // way, a stale estimator spends its settling time regulating a
+            // vertical from the old attitude, and a stale
+            // `utilisation_filtered` can annunciate a loss-of-authority
+            // warning about a board that no longer exists.
+            backend.reset();
+            handoff_latched = false;
+            handoff_state = None;
+            yaw_rad = 0.0;
+            estimator = ComplementaryFilter::with_trust_band(ESTIMATOR_TAU_S, 0.0);
+            last_amps = 0.0;
+            last_forward_speed_m_s = 0.0;
+            utilisation_filtered = 0.0;
+            prev_outside_corridor = false;
+            fall_kick_window_start_s = None;
+            eprintln!(
+                "sim-host: input reset bit set -- board returned to the start, \
+                 plant and loop state cleared"
+            );
         }
         if input_armed_bit != prev_armed_bit {
             eprintln!(
@@ -2141,11 +2159,20 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // a measured carve envelope instead of a guess.
         let tilt_rad = (xmat[8].clamp(-1.0, 1.0) as f32).acos();
         let strike_n = backend.truth_nose_strike_n() + backend.truth_tail_strike_n();
-        if std::env::var("OB_HANDOFF_DEBUG").is_ok() && ticks.is_multiple_of(250) {
+        // OB_HANDOFF_DEBUG=1 prints every 250 ticks (2 Hz); OB_HANDOFF_DEBUG=<n>
+        // prints every n ticks, which is what makes a sub-second event like a
+        // post-reset transient actually observable.
+        let debug_every = std::env::var("OB_HANDOFF_DEBUG")
+            .ok()
+            .map(|v| v.parse::<u64>().unwrap_or(250).max(1));
+        if debug_every.is_some_and(|n| ticks.is_multiple_of(n)) {
             eprintln!(
                 "  [handoff-debug] t={t_known_s:.2} tilt={:.1}deg strike={strike_n:.1}N \
-                 y={truth_pos_y_m:.2}",
-                tilt_rad.to_degrees()
+                 y={truth_pos_y_m:.2} amps={last_amps:+.1} est_pitch={:.2}deg \
+                 truth_pitch={:.2}deg",
+                tilt_rad.to_degrees(),
+                attitude.pitch_rad.to_degrees(),
+                pitch_rad.to_degrees()
             );
         }
         if cfg.kerb.is_some() && !handoff_latched {


### PR DESCRIPTION
Play-test report: *"the reset button doesn't return me to start."* Correct. ADR-0012 wired the input `reset` bit to clear the handoff **latch** and nothing else, so the player got authority back over a board still lying where it had crashed — 112 m downrange. `sim-host` had never implemented a real reset; the bit was accepted and logged as *"not implemented yet, ignoring."*

`SimBackend::reset()` puts the plant back and re-primes `sensordata` with the same `mj_forward` call `open()` makes. The host additionally clears every piece of loop state that outlives a cycle — a stale `yaw_rad` respawns the board pointing the wrong way, a stale estimator spends its settling time regulating the old attitude, and a stale utilisation filter can annunciate a loss-of-authority warning about a board that no longer exists.

## The bug that took longest, and the two wrong answers on the way

The first attempt restored `qpos` and looked right — then the board **nose-dived 0.28 s later** with a 5046 N bumper strike that immediately re-triggered the handoff. Press reset, get another crash.

Instrumenting showed `est_pitch = 61.00°` on the first post-reset cycle against `truth_pitch = 0.00°`, with the regulator answering at a full −40 A.

**Wrong answer #1:** *"the accelerometer reads free-fall at `qpos0`, where the wheel touches with zero penetration, and `ComplementaryFilter` snaps its initial pitch to `accel_pitch` on the first sample."* Plausible, and wrong — adding 0.3 s of unpowered settling moved the crash 0.3 s later and changed nothing else.

**Actual cause:** `SimBackend` **buffers a pending command** (its own header says so), and the next `wait_observe()` writes it to `ctrl` before stepping. `reset()` cleared two fields; `open()` clears five. So the reset stepped the freshly-uprighted board with the *saturated command left over from the crash* — ~8.5 m/s² of real forward acceleration, which `accel_pitch` (`atan2(accel[0] - a_ff, -accel[2])`) cannot distinguish from a 61° tilt. A fresh filter has nothing to filter against, so it snapped to it. That is also exactly why settling didn't help: settling runs unpowered, then the stale command was re-applied anyway.

`reset()` now clears exactly what `open()` clears. **The settle machinery is deleted rather than kept as insurance** — measured unnecessary, and keeping it would have preserved a wrong explanation in the code.

## The regression test didn't catch the bug the first time

Its drive phase used `apply_external_force` alone and never commanded a current, so nothing was buffered and **it passed with the fix reverted**. That is worse than no test, because it reads as coverage.

It now holds a real 35 A command through the drive phase (observe-then-apply, which the backend enforces), asserts the command is genuinely in flight before resetting, and asserts on the **observation** — forward specific force under 1 m/s² on the first post-reset cycle — so it fails if a command survives by any route, not only the one that was fixed. Verified to fail with the fix reverted and pass with it restored.

## Also

- `OB_HANDOFF_DEBUG=<n>` sets the print interval in ticks (bare `=1` keeps 2 Hz), and the line carries `est_pitch` and `truth_pitch`. A 0.28 s transient is invisible at 2 Hz, and the estimator-vs-truth split is what localised this.
- `.gitignore` for `sim/models/*.generated.xml` — the `--kerb` splice deletes its scratch model on a clean exit, but a run killed with SIGKILL never gets there. Five had accumulated and were nearly committed.

## Verification

End to end over the real wire: crash at t=17.060 s at (−112.17, +9.06) → send a real OBI1 reset → board back at **(+0.03, +0.00, +0.14)** upright, handoff cleared, no re-trigger.

`cargo fmt`, `clippy -D warnings`, full workspace suite, and pytest 333 passed / 5 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)