### PR TITLE
fix(controls): first boot no longer deadlocks, can retry, and ships a route in (#249)

### DIFF
--- a/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-firstboot.service
+++ b/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-firstboot.service
@@ -18,14 +18,23 @@ RequiresMountsFor=/boot/firmware
 # but must not be RUNNING first -- the installer reloads it afterwards.
 Before=NetworkManager.service
 Wants=NetworkManager.service
-# Idempotent, but the unit still guards on the marker so a normal boot does
-# not pay for a script that will immediately no-op.
-ConditionPathExists=/boot/firmware/overboard-userconf
+# Idempotent, but the unit still guards on a marker so a normal boot does not
+# pay for a script that will immediately no-op. Gated on the ABSENCE of a
+# completion marker the script writes on success -- not on the presence of
+# the staged credential files, which the script itself deletes as its last
+# step. Gating on those made a script that died partway indistinguishable
+# from one that finished: the next boot saw the trigger file already gone
+# and never retried.
+ConditionPathExists=!/boot/firmware/overboard-firstboot.done
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/sbin/overboard-firstboot
+# A first-boot credential installer must fail the boot loudly, never wedge
+# it silently. Type=oneshot disables TimeoutStartSec by default, so without
+# this a hang here blocks the boot transaction forever.
+TimeoutStartSec=120
 # Deliberately NOT `StandardOutput=null`: on a headless board with no user yet
 # configured, the journal is the only record of why the network did not come
 # up, and that is the failure this unit exists around.

--- a/scripts/pi/image/layer/overboard-base.rootfs-overlay/usr/local/sbin/overboard-firstboot
+++ b/scripts/pi/image/layer/overboard-base.rootfs-overlay/usr/local/sbin/overboard-firstboot
@@ -24,12 +24,20 @@ NET_SRC="$BOOT/overboard-net.d"
 NM_DIR="/etc/NetworkManager/system-connections"
 USERCONF="$BOOT/overboard-userconf"
 AUTHKEYS="$BOOT/overboard-authorized_keys"
+# Written only once this script reaches its end without error. The unit's
+# ConditionPathExists gates on this file's ABSENCE, not on USERCONF/AUTHKEYS
+# still being there -- those get shredded as the last step below, so gating
+# on them made a script that died partway (or was interrupted by a hung
+# boot) look identical to one that finished: the next boot would see the
+# trigger file already gone and skip retrying with no config ever installed.
+DONE="$BOOT/overboard-firstboot.done"
 
 log() { echo "overboard-firstboot: $*"; }
 
 # Nothing staged is the normal state on every boot after the first.
 if [ ! -d "$NET_SRC" ] && [ ! -f "$USERCONF" ]; then
   log "no staged configuration - nothing to do"
+  touch "$DONE" 2>/dev/null || true
   exit 0
 fi
 
@@ -94,7 +102,13 @@ if [ "${ssh_password_auth:-false}" = "false" ]; then
     > /etc/ssh/sshd_config.d/10-overboard.conf
   log "SSH password authentication disabled (key-only)"
 fi
-systemctl enable --now ssh >/dev/null 2>&1 || log "WARNING: could not enable ssh"
+# NOT `--now`: this script runs from inside the boot transaction as
+# overboard-firstboot.service, which is ordered `Before=NetworkManager.service`
+# and (transitively, via multi-user.target) before ssh.service too. `--now`
+# would try to start ssh synchronously from within that same transaction --
+# a circular wait that hangs the boot forever. `enable` alone drops the
+# symlink; multi-user.target starts the unit once this transaction finishes.
+systemctl enable ssh >/dev/null 2>&1 || log "WARNING: could not enable ssh"
 
 # ---------------------------------------------------------------------------
 # Wi-Fi
@@ -110,7 +124,11 @@ if [ -d "$NET_SRC" ]; then
     count=$((count + 1))
   done
   log "installed $count wifi profile(s)"
-  nmcli connection reload 2>/dev/null || systemctl reload NetworkManager 2>/dev/null || true
+  # No reload call: this unit is ordered Before=NetworkManager.service, so NM
+  # has not started yet and will read this directory itself when it does.
+  # `nmcli connection reload` here would try to D-Bus-activate a service that
+  # is ordered to start *after* this one -- the same kind of ordering bug
+  # `--now` above was.
 fi
 
 # ---------------------------------------------------------------------------
@@ -129,4 +147,5 @@ fi
 [ -f "$AUTHKEYS" ] && { shred -u "$AUTHKEYS" 2>/dev/null || rm -f "$AUTHKEYS"; }
 [ -f "$USERCONF" ] && { shred -u "$USERCONF" 2>/dev/null || rm -f "$USERCONF"; }
 
+touch "$DONE" 2>/dev/null || log "WARNING: could not write completion marker $DONE -- next boot will retry"
 log "complete - staged credentials removed from $BOOT"

--- a/scripts/pi/image/layer/overboard-base.yaml
+++ b/scripts/pi/image/layer/overboard-base.yaml
@@ -38,6 +38,16 @@ mmdebstrap:
     - network-manager
     # Key-only SSH is how the board is reached; there is no console user.
     - openssh-server
+    # overboard-firstboot falls back to `iw reg set` when raspi-config isn't
+    # present (it isn't -- that's a Raspberry Pi OS tool, and this is a slim
+    # image), so the fallback itself needs to be shipped. rfkill lets the
+    # radio be inspected at all when regulatory-domain setup fails.
+    - iw
+    - rfkill
+    # The board has no console and no static IP story; docs and flash_pi.sh
+    # both tell the operator to reach it at overboard.local, which is a dead
+    # instruction without an mDNS responder actually running.
+    - avahi-daemon
     # Required by the STOCK image-rpios layer, not by us: its
     # `customize05-pkgs` hook shells out to apt inside the target, and a slim
     # base does not install apt there. Build round 4 died on


### PR DESCRIPTION
## What

Fixes the four defects filed in #249, all found on the first real hardware boot (Pi 5 Rev 1.1, 2026-08-06) and invisible to CI because every one of them only shows up on real hardware.

## D1 — deadlock, fixed

`overboard-firstboot.service` hung forever on `systemctl enable --now ssh`: the unit runs inside the same boot transaction that `--now` tries to start ssh synchronously in — a circular wait, and `Type=oneshot` disables `TimeoutStartSec` by default so it never times out. Dropped `--now`; `enable` alone is enough, `multi-user.target` starts the unit once the transaction clears.

`nmcli connection reload` a few lines later has the identical bug in a second flavour (the unit is `Before=NetworkManager.service`, so `nmcli` tries to D-Bus-activate a service ordered to start after it) — not reached before, because D1 hung first. Removed the reload call entirely: since the unit is ordered before NetworkManager starts, NM reads the freshly-dropped connection profiles itself on its own first start. No reload was ever needed.

Also added `TimeoutStartSec=120` so a *future* hang here fails the boot loudly instead of wedging it silently, per the issue's explicit ask.

## D2 — retry, fixed

The unit gated on `ConditionPathExists=/boot/firmware/overboard-userconf`, but the script deletes that same file as its last step — so a script that died partway (or was interrupted mid-hang) looked, to the next boot, identical to one that had finished cleanly. Replaced it with a completion marker (`overboard-firstboot.done`) the script writes only once it reaches the end without error; the unit now gates on that marker's *absence*. A partial run leaves no marker and retries on the next boot; a clean run (real work or a true no-op) writes it once and stops re-running.

I did not try to re-derive exactly how the userconf marker was already gone by the third boot in the CEO's report — the fix makes that mechanism irrelevant rather than depending on identifying it.

## D3 / D4 — missing packages, fixed

`overboard-firstboot` already calls `iw reg set` as its regulatory-domain fallback and the runbook/`flash_pi.sh` promise `overboard.local`, but the image shipped none of `iw`, `rfkill`, or `avahi-daemon`. Added all three to `overboard-base.yaml`'s package list — the "ship it" option the issue itself called the better answer for a headless board with no console.

## Deliberately left out

- **The runbook's "console password is optional" line** — `docs/` is COO turf, not mine, and the issue itself says this needs correcting. Flagging it here rather than editing it.
- **Root-causing exactly why the userconf trigger file was already absent on the third boot** — the completion-marker redesign makes the retry story correct regardless of that mechanism, so it wasn't necessary to chase down, and this repo's convention is not to chase what isn't blocking.

## Verification

Hardware-in-the-loop is the only real verification for a first-boot script, and this session has none. What I could check from here:
- `bash -n` on the modified script — clean.
- `python3 scripts/pi/check_layer_headers.py` — all layer files still parse as valid DEB822.
- `python3 .github/policy_check.py` — all hard checks pass; no new advisories from this change.
- Traced the systemd unit ordering (`Before=NetworkManager.service`, transitively before `ssh.service` via `multi-user.target`) by hand against both bugs to confirm the circular-wait mechanism the issue describes, and that removing `--now`/the reload call doesn't lose any functionality NM/systemd wasn't already going to provide on its own.

Real confirmation needs another flash + boot cycle on hardware, same as the original report.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59K2L1AWibRiFWqwU3cHb)_