### PR TITLE
fix(controls): pin the bootloader EEPROM version and channel (#222)

### DIFF
--- a/roles/senior-controls/log/2026-08-08-pin-bootloader-eeprom.md
+++ b/roles/senior-controls/log/2026-08-08-pin-bootloader-eeprom.md
@@ -1,0 +1,34 @@
+# Issue #222 — pin the bootloader EEPROM version in pins.env (PR TBD)
+
+Added `BOOTLOADER_VERSION`, `BOOTLOADER_TIMESTAMP`, `BOOTLOADER_CHANNEL` to
+`scripts/pi/pins.env`, "held, not tracked" like the kernel pin, using the
+values the issue's own comment thread already measured on the CEO's Pi 5
+Rev 1.1 (`086b83e3332dfc8927c56762771d082f3077a1ae`, built 2026-05-26,
+channel `default`). The channel is pinned alongside the hash, not the hash
+alone — `rpi-eeprom-update` resolves "latest" differently per channel, so a
+hash without its channel does not reproduce a state (the issue's own
+revised proposal, made after seeing the hardware data). Not consumed by
+`check_image_pin.py` or `verify_pins.sh`, deliberately: there is nothing on
+the card to check the bootloader against, unlike the kernel.
+
+**Deliberately left out:**
+
+- **Step 2 of the issue's proposal** ("have the Stage-0B run record
+  `vcgencmd bootloader_version` into the run log, alongside `git_sha`").
+  The obvious home for that is `crates/loop-profiler`'s JSON schema
+  (`report.rs`/`profile.rs`) — but PR #234 (issue #226) is an open PR
+  actively bumping that exact schema to v2 right now. Landing a competing
+  schema edit to the same files in parallel would conflict with in-flight
+  work for no benefit; this is a separate, smaller increment once #234
+  merges.
+- **Item 3 of the issue** (whether AC-11's restore test should assert the
+  bootloader pin). The issue itself frames this as "worth a considered call
+  rather than a default" — a Promise-class call (it would change a public
+  acceptance criterion for a hobbyist-facing image), not mine to decide
+  unilaterally.
+- `docs/runbook-pi-first-boot.md` §4 still reads "Follow-up, not done here:
+  add the bootloader version to `pins.env`..." — now stale now that the pin
+  exists. `docs/` is COO turf; flagged rather than edited.
+
+Addresses #222 (step 1 of its proposal); left open for step 2 and item 3 as
+noted above, so the issue stays open rather than auto-closing.

--- a/scripts/pi/pins.env
+++ b/scripts/pi/pins.env
@@ -55,6 +55,34 @@ KERNEL_REQUIRED_FILES="mcp251xfd.ko vcan.ko gs_usb.ko bcm2712-rpi-5-b.dtb"
 # the card, not as evidence the platform is fast enough.
 KERNEL_REQUIRED_CONFIG="CONFIG_PREEMPT_RT=y CONFIG_CPU_ISOLATION=y CONFIG_CAN_MCP251XFD=m CONFIG_CAN_VCAN=m"
 
+# ---------------------------------------------------------------------------
+# THE BOOTLOADER PIN IS HELD FOR THE SAME REASON THE KERNEL IS, AND IT CANNOT
+# BE CAPTURED BY THE IMAGE.
+#
+# The bootloader lives in EEPROM on the Pi itself, not on the SD card, so
+# flashing a fresh, fully-pinned image does not reset it and the provenance
+# manifest that ships beside the image cannot see it either (issue #222). It
+# is therefore the one input to the Stage-0B go/no-go number that our whole
+# pinning discipline structurally cannot see from the card -- held here, not
+# tracked, exactly like the kernel pin above, and not consumed by any
+# verification script for the same reason: there is nothing on the card to
+# check it against.
+#
+# Recorded from the CEO's Pi 5 Rev 1.1 via `rpi-eeprom-update -a` +
+# `vcgencmd bootloader_version` (docs/runbook-pi-first-boot.md §4),
+# 2026-08-05.
+#
+# The version hash alone does not reproduce a state: Raspberry Pi ships two
+# EEPROM channels and `rpi-eeprom-update` resolves "latest" differently on
+# each, so the channel is pinned alongside the hash, not just the hash.
+# `default` (NOT `latest`) is also the right choice on the merits -- it is
+# the stable channel and what a fresh Pi ships with, which matters for an
+# image published to a public release.
+BOOTLOADER_VERSION="086b83e3332dfc8927c56762771d082f3077a1ae"
+BOOTLOADER_TIMESTAMP="1779807685"   # 2026-05-26T15:01:25Z
+BOOTLOADER_CHANNEL="default"        # NOT latest -- see above
+# ---------------------------------------------------------------------------
+
 # Bench and verification tooling. Versions verified against Debian trixie
 # arm64 on 2026-07-27 (see the verification log). CI is the check on whether
 # they are still satisfiable -- an unsatisfiable pin here is a RED BUILD by


### PR DESCRIPTION
## What changed

Added `BOOTLOADER_VERSION`, `BOOTLOADER_TIMESTAMP`, `BOOTLOADER_CHANNEL` to `scripts/pi/pins.env`, "held, not tracked" with the same comment convention the kernel pin already carries.

## Why

The bootloader lives in EEPROM **on the Pi itself, not on the SD card**. Flashing a fresh, fully-pinned image does not reset it, and the provenance manifest that ships beside the image cannot capture it — the manifest describes the card, and this isn't on the card. It is therefore the one input to every Stage-0B latency number that our pinning discipline structurally couldn't see (issue #222).

Values are the ones the issue's own comment thread already measured on the CEO's Pi 5 Rev 1.1 (`086b83e3332dfc8927c56762771d082f3077a1ae`, built 2026-05-26T15:01:25Z, channel `default`). The **channel** is pinned alongside the hash, not the hash alone — `rpi-eeprom-update` resolves "latest" differently per channel, so a version hash recorded without its channel doesn't reproduce a state. `default` is also correct on the merits: it's the stable channel and what a fresh Pi ships with.

Not consumed by `check_image_pin.py` or `verify_pins.sh` — unlike the kernel pin, there is nothing on the card to check the bootloader pin against.

## Acceptance criteria this satisfies

Issue #222's proposal item 1 ("Add `BOOTLOADER_VERSION` to `pins.env` with the same 'held, not tracked' comment the kernel pin carries") — extended to include the channel field, per the issue's own follow-up comment establishing that a hash alone is insufficient.

## Deliberately left out

- **Proposal item 2** ("have the Stage-0B run record `vcgencmd bootloader_version` into the run log, alongside `git_sha`"). The natural home is `crates/loop-profiler`'s JSON schema (`report.rs`/`profile.rs`), but PR #234 (issue #226) is currently in flight bumping that exact schema to v2. Landing a competing schema edit to the same files right now would conflict with work already in progress for no benefit — this is its own increment once #234 merges.
- **Item 3** (whether AC-11's restore test should assert the bootloader pin). The issue itself frames this as "worth a considered call rather than a default" — it's a Promise-class decision (changes a public acceptance criterion for a hobbyist-facing image), not mine to make unilaterally.
- `docs/runbook-pi-first-boot.md` §4's "Follow-up, not done here: add the bootloader version to `pins.env`..." note is now stale. `docs/` is COO turf — flagged here rather than edited.

This intentionally does not close #222 — items 2 and 3 remain open.

Related: #222.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ybeU2E3G77MPiQct3TT6B)_