### PR TITLE
fix(image): first boot no longer hangs, and retries when it fails — closes all six defects (#249)

### DIFF
--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -5,7 +5,7 @@ covers:
   - scripts/pi/flash_pi.sh
   - scripts/pi/pins.env
   - crates/loop-profiler/src/lib.rs
-reconciled: 3251993
+reconciled: 7665f70
 -->
 
 **Owned by: Senior Controls.** **Executed by: the CEO**, at a desk, with a monitor and a
@@ -77,6 +77,13 @@ In **OS customisation**, set:
 - **Username: `overboard`** — matching the real image, so nothing about the login changes later.
 - **SSH: enabled, public-key only.** The same key that will go on the real card
   (`~/.ssh/id_ed25519.pub`). No agent generates or handles a keypair — reference doc §7.
+- **Set `PI_PASSWORD`. This is not optional on a first card.** The example file
+  leaves it blank and the installer then *locks* the account rather than leaving it
+  passwordless — correct for a public image, wrong for bring-up. On 2026-08-06 that
+  combination left a board with a hung first boot, no network, no mDNS and no console
+  login, recoverable only via `init=/bin/sh` on the kernel command line. The network
+  is the single most likely thing to be broken on a first boot, so the console must
+  not depend on it.
 - **Wi-Fi** with the correct **two-letter country code**. An unset country disables 5 GHz and
   presents as "the network is not there" rather than as a configuration error.
 

--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -250,13 +250,14 @@ else
   echo
   echo "    Works immediately -- these ship in the image:"
   echo "      cyclictest -m -Sp95 -i 2000 -D 30m       # kernel wakeup jitter (AC-5)"
-  echo "      ip -details link show can0               # CAN up at 500 kbit/s"
+  echo "      ip -details link show can0               # only with the CAN HAT fitted"
   echo "      cangen vcan0 & candump vcan0             # CAN stack, no hardware needed"
   echo
   echo "    NOT on the card yet -- no Overboard code ships in the image (issue"
   echo "    #182 I5). To run the controller or the loop profiler you must put"
   echo "    them there yourself for now:"
-  echo "      ssh <user>@overboard.local"
+  echo "      ssh <user>@overboard.local     # mDNS; if it does not resolve,"
+  echo "                                     # get the IP from your router"
   echo "      sudo apt install -y git build-essential curl"
   echo "      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
   echo "      git clone https://github.com/MikePaNtZ/overboard && cd overboard"

--- a/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-firstboot.service
+++ b/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-firstboot.service
@@ -18,14 +18,38 @@ RequiresMountsFor=/boot/firmware
 # but must not be RUNNING first -- the installer reloads it afterwards.
 Before=NetworkManager.service
 Wants=NetworkManager.service
-# Idempotent, but the unit still guards on the marker so a normal boot does
-# not pay for a script that will immediately no-op.
-ConditionPathExists=/boot/firmware/overboard-userconf
+# Guarded on a SUCCESS marker the script writes when it finishes, not on the
+# staged input file.
+#
+# The old condition was ConditionPathExists=/boot/firmware/overboard-userconf
+# -- the trigger file. That made a failed first boot TERMINAL: the CEO's board
+# deadlocked twice, the userconf went missing, and the third boot logged
+# "skipped, unmet condition check ConditionPathExists" and came up with no
+# WiFi profiles and no way to retry short of re-flashing (2026-08-06).
+#
+# Conditioning on completion instead means an interrupted run is retried on
+# the next boot, which is the behaviour a first-boot installer needs.
+ConditionPathExists=!/var/lib/overboard/firstboot-done
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/sbin/overboard-firstboot
+
+# NOT the default. Type=oneshot disables TimeoutStartSec entirely, so a unit
+# that blocks does not fail -- it wedges the boot forever, with the console
+# stuck on "Job overboard-firstboot.service/start running" and no timeout to
+# rescue it. That is exactly what happened, and it is the difference between
+# a board that reports a broken first boot and one that is simply dead.
+#
+# A credential installer must fail LOUDLY, never silently hold the system
+# hostage. 120s is generous for what is a few file copies.
+TimeoutStartSec=120
+
+# A failed credential install must not take the boot down with it: ssh may
+# still come up, and a reachable board with no WiFi is far more debuggable
+# than an unreachable one.
+SuccessExitStatus=0
 # Deliberately NOT `StandardOutput=null`: on a headless board with no user yet
 # configured, the journal is the only record of why the network did not come
 # up, and that is the failure this unit exists around.

--- a/scripts/pi/image/layer/overboard-base.rootfs-overlay/usr/local/sbin/overboard-firstboot
+++ b/scripts/pi/image/layer/overboard-base.rootfs-overlay/usr/local/sbin/overboard-firstboot
@@ -59,8 +59,12 @@ if [ -f "$USERCONF" ]; then
 
   if [ -n "$username" ] && ! id -u "$username" >/dev/null 2>&1; then
     log "creating user $username"
-    useradd -m -s /bin/bash -G sudo,dialout,gpio,i2c,spi,netdev "$username" \
-      || useradd -m -s /bin/bash -G sudo,dialout "$username"
+    # `video` is not cosmetic: vcgencmd needs it, and vcgencmd is how the
+    # runbook checks whether an AC-5 run was thermally valid. Without it the
+    # operator gets "Can't open device file /dev/vcio" on the one command
+    # that decides whether a 30-minute measurement counts.
+    useradd -m -s /bin/bash -G sudo,dialout,gpio,i2c,spi,netdev,video "$username" \
+      || useradd -m -s /bin/bash -G sudo,dialout,video "$username"
     if [ -n "${password_hash:-}" ]; then
       usermod -p "$password_hash" "$username"
     else
@@ -72,9 +76,17 @@ if [ -f "$USERCONF" ]; then
 
   if [ -n "${wifi_country:-}" ]; then
     log "regulatory domain -> $wifi_country"
-    raspi-config nonint do_wifi_country "$wifi_country" 2>/dev/null \
-      || iw reg set "$wifi_country" 2>/dev/null \
-      || log "WARNING: could not set regulatory domain; 5 GHz may be unavailable"
+    # Write cfg80211's own config file FIRST, because it needs no tooling.
+    # raspi-config is a Raspberry Pi OS tool a slim image does not carry, and
+    # `iw` was not installed either, so the old chain fell all the way through
+    # to a warning and left the radio with no regulatory domain -- one reason
+    # wlan0 never associated on the CEO's first boot.
+    install -d -m 0755 /etc/modprobe.d
+    printf 'options cfg80211 ieee80211_regdom=%s\n' "$wifi_country" \
+      | tee /etc/modprobe.d/overboard-regdom.conf >/dev/null
+    iw reg set "$wifi_country" 2>/dev/null \
+      || raspi-config nonint do_wifi_country "$wifi_country" 2>/dev/null \
+      || log "note: regdom not set live; the modprobe.d file applies next boot"
   fi
 fi
 
@@ -94,7 +106,13 @@ if [ "${ssh_password_auth:-false}" = "false" ]; then
     > /etc/ssh/sshd_config.d/10-overboard.conf
   log "SSH password authentication disabled (key-only)"
 fi
-systemctl enable --now ssh >/dev/null 2>&1 || log "WARNING: could not enable ssh"
+# `enable`, NOT `enable --now`. `--now` starts ssh.service from inside the
+# boot transaction that is currently blocked on THIS unit, which deadlocks --
+# and because Type=oneshot disables TimeoutStartSec by default, it hangs
+# forever rather than failing. That wedged the CEO's first boot completely
+# (2026-08-06). The symlink is enough: multi-user.target starts ssh in the
+# same boot, a fraction of a second later.
+systemctl enable ssh >/dev/null 2>&1 || log "WARNING: could not enable ssh"
 
 # ---------------------------------------------------------------------------
 # Wi-Fi
@@ -110,7 +128,12 @@ if [ -d "$NET_SRC" ]; then
     count=$((count + 1))
   done
   log "installed $count wifi profile(s)"
-  nmcli connection reload 2>/dev/null || systemctl reload NetworkManager 2>/dev/null || true
+  # Deliberately NOT `nmcli connection reload`. This unit is ordered
+  # Before=NetworkManager.service, so nmcli would try to D-Bus-activate a
+  # service that cannot start until we finish: the same deadlock as the ssh
+  # line above, one line apart. NetworkManager reads system-connections/ when
+  # it starts, and it starts after us, so dropping the files in is sufficient.
+  log "profiles staged; NetworkManager will read them when it starts"
 fi
 
 # ---------------------------------------------------------------------------
@@ -128,5 +151,11 @@ if [ -d "$NET_SRC" ]; then
 fi
 [ -f "$AUTHKEYS" ] && { shred -u "$AUTHKEYS" 2>/dev/null || rm -f "$AUTHKEYS"; }
 [ -f "$USERCONF" ] && { shred -u "$USERCONF" 2>/dev/null || rm -f "$USERCONF"; }
+
+# The success marker the unit conditions on. Written LAST, so anything that
+# aborts before this point is retried on the next boot rather than being
+# skipped forever.
+install -d -m 0755 /var/lib/overboard
+date -u +%Y-%m-%dT%H:%M:%SZ | tee /var/lib/overboard/firstboot-done >/dev/null
 
 log "complete - staged credentials removed from $BOOT"

--- a/scripts/pi/image/layer/overboard-base.yaml
+++ b/scripts/pi/image/layer/overboard-base.yaml
@@ -21,10 +21,14 @@ mmdebstrap:
   architectures:
     - arm64
   packages:
-    # AC-5's instrument. cyclictest measures the KERNEL; overboard-loop-profile
-    # measures OUR loop on that kernel. Both ship, because them disagreeing is
-    # informative -- cyclictest clean and the profiler dirty means the problem
-    # is ours.
+    # AC-5's instrument, and the one that actually took the passing measurement
+    # (p99.9 72us, max 113us, 2026-08-07).
+    #
+    # This comment used to claim overboard-loop-profile ships alongside it.
+    # It does not -- no Overboard binary is in this image at all (#182 I5), so
+    # cyclictest is the ONLY jitter instrument on the card. Corrected rather
+    # than deleted, because a package list that describes tools it does not
+    # install is how an operator plans a bench session around a missing binary.
     - rt-tests
     # candump/cansend/cangen, plus `ip link` to bring can0 up.
     - can-utils
@@ -38,6 +42,17 @@ mmdebstrap:
     - network-manager
     # Key-only SSH is how the board is reached; there is no console user.
     - openssh-server
+    # mDNS. Without it `overboard.local` cannot resolve -- and the runbook,
+    # flash_pi.sh's closing message and every instruction we give the operator
+    # all say to use exactly that name. It resolved on the CEO's stock
+    # Raspberry Pi OS card and not on ours, which made a working board look
+    # dead (2026-08-06).
+    - avahi-daemon
+    # The WiFi path shelled out to `iw` and `rfkill` that were never installed,
+    # so the regulatory domain silently went unset and the radio could not even
+    # be inspected. Ship the tools the scripts actually call.
+    - iw
+    - rfkill
     # Required by the STOCK image-rpios layer, not by us: its
     # `customize05-pkgs` hook shells out to apt inside the target, and a slim
     # base does not install apt there. Build round 4 died on


### PR DESCRIPTION
Closes the six defects in #249. **Without this, a rebuilt image still hangs on first boot** — the CEO asked whether a fresh image was ready to flash, and it was not.

Every one of these was found on hardware on 2026-08-06. `pi-image` was green throughout.

## 1. The deadlock — the image was unusable as shipped

`systemctl enable --now ssh` starts a unit from inside the boot transaction that is blocked on this very unit. Combined with `Type=oneshot`, which **disables `TimeoutStartSec` by default**, it does not fail — it wedges the boot forever at `Job overboard-firstboot.service/start running`.

`nmcli connection reload` one line later has the same bug in a second flavour: the unit is ordered `Before=NetworkManager.service`, so nmcli tries to D-Bus-activate a service that cannot start until we finish.

- `enable --now ssh` becomes `enable ssh`. The symlink is sufficient; `multi-user.target` starts ssh in the same boot.
- The nmcli call is removed entirely. NetworkManager reads `system-connections/` at startup and starts after us, so dropping files in place is all that was ever required.

## 2. `TimeoutStartSec=120` on the unit

The fix above removes the two known blocking calls. This removes the *class*: a credential installer must fail loudly, never hold the system hostage. A board that reports a broken first boot is debuggable; one that hangs at a systemd job line is not.

## 3. A failed first boot is no longer terminal

The unit guarded on `ConditionPathExists=/boot/firmware/overboard-userconf` — the **trigger** file. After two deadlocked boots the userconf went missing and the third boot logged `skipped, unmet condition check`, leaving a board with WiFi profiles never installed and no way to retry short of re-flashing.

Now guarded on a **success marker** (`/var/lib/overboard/firstboot-done`) that the script writes **last**, after the shred. Anything that aborts earlier is retried next boot.

## 4. The WiFi path no longer depends on absent tools

`raspi-config` is a Raspberry Pi OS tool a slim image does not carry; the `iw` fallback was not installed either; `rfkill` was missing too. The chain fell through to a warning and left the radio with no regulatory domain.

- Writes `/etc/modprobe.d/overboard-regdom.conf` directly — cfg80211's own config, needs no tooling at all — then *tries* `iw`/`raspi-config` as a live-apply nicety.
- Ships `iw` and `rfkill`, so the scripts call tools that exist and the radio can at least be inspected.

## 5. mDNS

No `avahi-daemon`, so `overboard.local` could never resolve — while the runbook, `flash_pi.sh`'s closing message and every instruction we give the operator all say to use exactly that name. It worked on the CEO's stock Raspberry Pi OS card that morning and not on ours, which made a working board look dead. Now ships `avahi-daemon`.

## 6. `video` group

`vcgencmd` needs it. `vcgencmd` is how the runbook checks whether an AC-5 run was thermally valid — so the one command that decides whether a 30-minute measurement counts failed for the user the image creates. Added to `useradd`.

## Operator-facing wording that over-promised

- `flash_pi.sh` advertised `can0` at 500 kbit/s unconditionally; it needs the CAN HAT, which is not wired.
- It pointed at `overboard.local` with no fallback. Now names the router as the way to find the IP.
- The layer comment claimed `overboard-loop-profile` ships beside `rt-tests`. It does not — no Overboard binary is in the image (#182 I5), so cyclictest is the only jitter instrument on the card. A package list that describes tools it does not install is how a bench session gets planned around a missing binary.

## The runbook's worst line

It told the CEO a console password was **optional**. Combined with the defects above, that produced a board with no route in at all — hung boot, no network, no mDNS, and a *locked* account (the installer does `passwd -l` rather than leaving it blank, which is right for a public image and wrong for bring-up). Recovery needed `init=/bin/sh`.

The runbook now says set it, and says why: the network is the most likely thing to be broken on a first boot, so the console must not depend on it.

## Testing

`bash -n` clean on both scripts. Layer headers parse as valid DEB822. `policy` passes, manifest reconciled.

**Not yet exercised on hardware** — the next flash is the real test, and that is the point of landing it before one happens. The specific claims worth re-checking on that boot: no hang, `ssh` up in the same boot, `wlan0` associates, `overboard.local` resolves, `vcgencmd` works unprivileged, and an interrupted run retries rather than being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
