### PR TITLE
fix(controls): the removable-media guard refuses the CEO's own card reader (#182)

### DIFF
--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -5,7 +5,7 @@ covers:
   - scripts/pi/flash_pi.sh
   - scripts/pi/pins.env
   - crates/loop-profiler/src/lib.rs
-reconciled: 7665f70
+reconciled: ec67a9e
 -->
 
 **Owned by: Senior Controls.** **Executed by: the CEO**, at a desk, with a monitor and a
@@ -220,9 +220,17 @@ $EDITOR ~/.overboard/pi-secrets.env       # real SSID/passphrase/pubkey; keep PI
 scripts/pi/flash_pi.sh --disk /dev/diskN --image ~/Downloads/<stock-raspios>.img.xz --dry-run
 ```
 
-`--dry-run` runs every guard and generates the boot payload, skipping only the write. Find the
-disk with `diskutil list external` (macOS) or `lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT` (Linux)
-first.
+`--dry-run` runs every guard and generates the boot payload, skipping only the write.
+
+**Finding the disk on macOS: use `diskutil list`, not `diskutil list external`.** A MacBook's
+built-in SDXC slot reports `Device Location: Internal` — it hangs off an internal bus — while the
+card in it is `Removable Media: Removable`. So the card does **not** appear under `external`, and
+the obvious command silently shows you everything except the disk you want. On Linux,
+`lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT`.
+
+**Match the size.** `flash_pi.sh` refuses the system disk and refuses non-removable media, but it
+cannot tell one removable device from another — a USB stick is as valid a target as your card.
+Size is what distinguishes them, and that part is the operator's job.
 
 **What this does and does not do.** `--image` points at the stock image purely to satisfy the
 resolver; the exercise validates the removable-media guard, the confirmation prompt and

--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -71,19 +71,40 @@ assert_removable() {
   [ -e "$disk" ] || die "$disk does not exist"
 
   if [ "$OS" = "Darwin" ]; then
-    local info removable internal
+    local info removable virtual this_whole root_whole
     info="$(diskutil info "$disk" 2>/dev/null)" || die "diskutil could not read $disk"
-    removable="$(echo "$info" | awk -F': *' '/Removable Media/{print $2}' | xargs)"
-    internal="$(echo "$info" | awk -F': *' '/Device Location/{print $2}' | xargs)"
+    removable="$(echo "$info"  | awk -F': *' '/Removable Media/{print $2}' | xargs)"
+    virtual="$(echo "$info"    | awk -F': *' '/^ *Virtual:/{print $2}' | xargs)"
+    this_whole="$(echo "$info" | awk -F': *' '/Part of Whole/{print $2}' | xargs)"
     echo "$info" | grep -E 'Device / Media Name|Disk Size|Device Location|Removable Media|Volume Name' \
       | sed 's/^ */    /'
-    if [ "$internal" = "Internal" ]; then
-      die "$disk is an INTERNAL disk. Refusing.
-       This is almost certainly your system drive. Re-read `diskutil list external`."
+
+    # Refuse the system disk BY IDENTITY, not by which bus it hangs off.
+    #
+    # This replaces a `Device Location: Internal` test that was simply wrong
+    # about the world. A MacBook's built-in SDXC slot reports **Internal**
+    # while holding **Removable** media, so the old check refused the CEO's
+    # only card reader on 2026-08-06 -- the worst failure mode a safety guard
+    # has. Not a missed catch: a false refusal on the correct target, which
+    # teaches the operator to route around the guard. One that cries wolf gets
+    # disabled, and then it is not there on the day it matters.
+    root_whole="$(diskutil info / 2>/dev/null | awk -F': *' '/Part of Whole/{print $2}' | xargs)"
+    if [ -n "$root_whole" ] && [ -n "$this_whole" ] && [ "$root_whole" = "$this_whole" ]; then
+      die "$disk holds the volume this Mac is booted from. Refusing.
+       There is no --force. The only reason to want one here is a mistake."
     fi
+
+    # Removability is now the load-bearing test, so it must be exact. An
+    # internal NVMe reports 'Fixed' or 'Not removable' and is refused here.
     case "$removable" in
-      Removable|"Yes") ;;
+      Removable|Yes) ;;
       *) die "$disk does not report as removable media (got: '${removable:-unknown}'). Refusing." ;;
+    esac
+
+    # Synthesized APFS containers are Virtual: Yes and are not raw targets.
+    case "$virtual" in
+      No|"") ;;
+      *) die "$disk is a virtual/synthesized device (Virtual: $virtual), not physical media. Refusing." ;;
     esac
   else
     local base rm_flag


### PR DESCRIPTION
Replaces #246, which went stale against three later changes to `flash_pi.sh`.

## The bug

Guard 1 refused any disk reporting `Device Location: Internal`. A MacBook's **built-in SDXC slot reports `Internal`** — it hangs off an internal bus — while the card in it is `Removable`:

    Device Node:      /dev/disk7
    Disk Size:        128.0 GB
    Device Location:  Internal      <-- guard refused on this
    Removable Media:  Removable     <-- what actually matters
    Virtual:          No

So the script refused the only card reader the CEO has. **That is the worst failure mode a safety guard can have** — not a missed catch, but a false refusal on the *correct* target, which sends the operator looking for a way around it. A guard that cries wolf gets disabled, and then it is not there on the day it matters.

"Which bus is the reader on" was never the question. "Is this the system disk, and is the media removable" is.

## The fix — same strictness, correct predicate

1. **Refuse the system disk by identity**, comparing `Part of Whole` against `diskutil info /`.
2. **Removability becomes load-bearing** and exact. Internal NVMe reports `Fixed` and is refused here.
3. **Refuse `Virtual: Yes`** — synthesized APFS containers are not raw targets.

No `--force`. Guard 2 (type the identifier back) untouched.

## Verified on the CEO's disks

| Disk | Reports | Result |
|---|---|---|
| `/dev/disk0` internal NVMe | Fixed | REFUSED — *does not report as removable media* |
| `/dev/disk3` root APFS container | Fixed | REFUSED — *holds the volume this Mac is booted from* (the new check) |
| `/dev/disk7` his SD card | Removable, Internal | ACCEPTED when present — verified 2026-08-06, and it is the card he flashed |

Re-run today with no removable media attached, so only the two refusal paths were exercised in this branch; the accept path was verified on the original branch and by the flash actually succeeding.

**The honest caveat, now written into the runbook:** these guards do not distinguish one removable device from another. A USB stick is as valid a target as an SD card. Only size-matching does that, and it is the operator's job.

## Doc

The runbook said to find the disk with `diskutil list external`, which cannot work on this hardware. Now says `diskutil list`, explains why, and states the size-matching responsibility.