### PR TITLE
docs(controls): three runbook corrections from executing it — EEPROM channel, four confounds, recovery section (#182)

### DIFF
--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -5,7 +5,7 @@ covers:
   - scripts/pi/flash_pi.sh
   - scripts/pi/pins.env
   - crates/loop-profiler/src/lib.rs
-reconciled: 7665f70
+reconciled: ec67a9e
 -->
 
 **Owned by: Senior Controls.** **Executed by: the CEO**, at a desk, with a monitor and a
@@ -124,9 +124,21 @@ input to every latency number Stage 0B produces that no image pin can capture, a
 `scripts/pi/pins.env` does not currently name it. Update it while the card is disposable, then
 record the version so the number is attributable.
 
-**Follow-up, not done here:** add the bootloader version to `pins.env` alongside the kernel pin,
-for the same reason the kernel is pinned — two numbers taken across a bootloader change are not
-obviously comparable, and nothing in the data says so.
+**Record three things, not one** — the version hash alone does not reproduce the state:
+
+| Field | Example (Pi 5 Rev 1.1, 2026-08-05) |
+|---|---|
+| Version hash | `086b83e3332dfc8927c56762771d082f3077a1ae` |
+| Firmware build timestamp | `1779807685` (2026-05-26T15:01:25Z) |
+| **Release channel** | **`default`**, not `latest` |
+
+The channel matters as much as the hash: `rpi-eeprom-update` resolves "latest" differently on the
+two channels, so a version recorded without its channel is not reproducible. `default` is correct
+here — the stable channel, and what a fresh Pi ships with.
+
+**Follow-up, not done here:** add the bootloader version *and channel* to `pins.env` alongside the
+kernel pin, for the same reason the kernel is pinned — two numbers taken across a bootloader
+change are not obviously comparable, and nothing in the data says so. Tracked in issue #222.
 
 ---
 
@@ -158,12 +170,51 @@ uname -r
 **Pass:** the Pi boots and `uname -r` reports the v8 flavour rather than 2712. Q12 is then closed
 by observation, and the image build knows exactly what `config.txt` must contain.
 
-**Fail (does not boot):** put the card in the host laptop and restore `config.txt` from
-`config.txt.bak` on the FAT boot partition — this is why §0 lists a card reader. **A failure here
-is a significant finding, not a mishap:** it means the image as designed would ship a card that
-does not boot, and it must reach Senior Controls before I1 goes green.
+**Fail:** the Pi does not boot — no login prompt, no SSH. **This is a significant finding, not a
+mishap:** it means the image as designed would ship a card that does not boot, and it must reach
+Senior Controls. Recover with §5.1 and report it.
 
 Record the outcome either way. A confirmed pass is as load-bearing as a fail.
+
+### 5.1 Recovery — only if the Pi did NOT boot
+
+**On a pass, skip this section entirely.** It is a repair procedure for a failure, not a further
+step of the test.
+
+**If the Pi still boots, you do not need the card reader.** Undo the change over a normal shell:
+
+```sh
+ls -la /boot/firmware/config.txt*          # confirm the .bak is there
+sudo cp /boot/firmware/config.txt.bak /boot/firmware/config.txt
+sudo reboot
+```
+
+**Only if there is no way in at all** — no console, no SSH — go via the card:
+
+1. Power down. `sudo shutdown -h now` if a shell exists; otherwise pull power once the activity
+   LED settles.
+2. Move the microSD to the host laptop's reader.
+3. macOS mounts the FAT boot partition — usually `/Volumes/bootfs`, but our image labels it
+   **`BOOT`**. It is the *only* partition that appears; the rootfs is ext4 and macOS cannot read
+   it. Expected, not a fault.
+4. Restore the file. No `sudo`: FAT32 carries no Unix permissions.
+   ```sh
+   ls /Volumes/BOOT/config.txt*
+   cp /Volumes/BOOT/config.txt.bak /Volumes/BOOT/config.txt
+   ```
+5. **No `.bak`?** Edit in place with `nano /Volumes/BOOT/config.txt` — **not** TextEdit, which can
+   save rich text and corrupt a file the firmware then cannot parse.
+6. **`cmdline.txt` must stay ONE line.** Appending with `printf ' ...' >>` lands on a second line,
+   because the file already ends in a newline — and firmware reads only the first line, so the
+   argument is silently ignored. Rewrite the whole line rather than appending, and check with
+   `wc -l`.
+7. Eject cleanly: `diskutil eject /dev/diskN`. Pulling the card mid-flush turns a config problem
+   into a re-flash.
+8. Card back in the Pi, power on.
+
+**Restoring after a pass is optional.** The card is scratch and the Stage-0B image overwrites it.
+The only reason to go back to 2712 is the second §6/§7 baseline — and since **v8 is the flavour
+the image ships**, a single baseline is better taken on v8.
 
 ---
 
@@ -199,9 +250,24 @@ problem is ours.
 AC-5 asks for p99.9 wakeup latency ≤ 150 µs and max ≤ 500 µs. A stock non-RT kernel will very
 likely miss that, **and that is the expected result rather than a bad sign.** But:
 
-1. **This is not a clean control.** The delta from here to the image changes **two** variables at
-   once — non-RT → RT, *and* 2712/16K-page → v8/4K-page. Treat it as a sanity floor, not as an
-   isolated measurement of what PREEMPT_RT bought.
+1. **This is not a clean control — it moves four variables at once.** Measured on a Pi 5 Rev 1.1,
+   2026-08-05, stock Raspberry Pi OS against the pinned image:
+
+   | | Baseline (stock) | Stage-0B image |
+   |---|---|---|
+   | Preemption | `PREEMPT` | `PREEMPT_RT` |
+   | Flavour / page size | `rpi-2712`, 16K | `rpi-v8`, 4K |
+   | Kernel line | **6.18.34** | **6.12.75** (`pins.env`) |
+   | Userspace | full desktop | `base-slim`, headless |
+
+   The kernel-line row is the one most easily missed: stock ships 6.18.34 — **the exact version
+   `pins.env` predicted the floating metapackage would resolve to** — while the pin deliberately
+   holds the longer-supported 6.12 line for the `mcp251xfd` fix. This is not one kernel built two
+   ways; it is two different kernels.
+
+   Consequence, stated so it does not have to be discovered in the AC-5 record: **this comparison
+   cannot support a claim of the form "PREEMPT_RT bought us X µs."** It is a sanity floor and
+   nothing more.
 2. **If stock already meets AC-5, that is the interesting outcome.** It would materially weaken
    the case for the RT-kernel path and the 16K-page cost the design accepts in §4, and it should
    be escalated rather than filed.


### PR DESCRIPTION
Consolidates #223 and #225, both of which went DIRTY against the four `flash_pi.sh` and runbook changes that landed after them. Same content, rebuilt on master, plus what the second night taught.

## 1. The EEPROM record needs its channel, not just a hash

Observed: version `086b83e3332dfc8927c56762771d082f3077a1ae`, build timestamp `1779807685`, release channel **`default`** — not `latest`. `rpi-eeprom-update` resolves "latest" differently per channel, so a hash without its channel does not reproduce a state. Feeds #222.

## 2. The baseline caveat undercounted its confounds — four, not two

Stock reported `6.18.34+rpt-rpi-2712`, `PREEMPT`, on the full desktop image. The missed row is the **kernel line**: stock ships 6.18.34, the exact version `pins.env` predicted the floating metapackage would resolve to, while the pin holds 6.12 for the `mcp251xfd` fix. Two different kernels, not one kernel built two ways.

As written, the doc invited a reading the data cannot support. It now says plainly that this comparison **cannot** support "PREEMPT_RT bought us X µs", so that claim cannot reach the AC-5 record on the strength of a floor measurement.

## 3. Section 5's fail branch read as a test step

The CEO hit this live: he reached the `Fail (does not boot)` paragraph **after passing** and asked for step-by-step help performing it — reading a recovery procedure as another step of the test. A doc defect, not a misread: the paragraph opened with an instruction before establishing it applied only to a failure.

It is now a separate **section 5.1** that opens with *"On a pass, skip this section entirely"*, leads with the case that applies most often (if the Pi still boots, no card reader is needed — three commands), and scopes the card-reader path to "no way in at all".

**Three traps added that cost real time on the night:**

- The boot volume on our image is labelled **BOOT**, not `bootfs`, so lowercase globs miss it.
- **`cmdline.txt` must stay one line.** Appending with `printf` and a double-redirect lands on a *second* line, because the file already ends in a newline — and firmware reads only the first line, so the kernel argument is silently ignored. This cost two boot cycles before it was spotted.
- `nano`, not TextEdit, which can save rich text and corrupt a file firmware then cannot parse. And `diskutil eject`, never pull the card mid-flush.

Also states what the original omitted entirely: restoring after a pass is optional, since the card is scratch and the image overwrites it.

#223 and #225 will be closed in favour of this.
