### PR TITLE
feat(controls): flash_pi.sh proposes the single removable disk — with the predicate that actually finds it (#182)

### DIFF
--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -5,7 +5,7 @@ covers:
   - scripts/pi/flash_pi.sh
   - scripts/pi/pins.env
   - crates/loop-profiler/src/lib.rs
-reconciled: ec67a9e
+reconciled: 60d5e3c
 -->
 
 **Owned by: Senior Controls.** **Executed by: the CEO**, at a desk, with a monitor and a
@@ -288,11 +288,16 @@ scripts/pi/flash_pi.sh --disk /dev/diskN --image ~/Downloads/<stock-raspios>.img
 
 `--dry-run` runs every guard and generates the boot payload, skipping only the write.
 
-**Finding the disk on macOS: use `diskutil list`, not `diskutil list external`.** A MacBook's
-built-in SDXC slot reports `Device Location: Internal` — it hangs off an internal bus — while the
-card in it is `Removable Media: Removable`. So the card does **not** appear under `external`, and
-the obvious command silently shows you everything except the disk you want. On Linux,
-`lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT`.
+**`--disk` is optional.** With no `--disk`, `flash_pi.sh` proposes the single removable disk in
+the machine; zero or several is an error rather than a guess. It filters on `Removable Media` —
+the same field the safety guard checks, so detection and validation cannot disagree — and
+deliberately *not* on `diskutil list external`, which omits a MacBook's built-in SDXC reader.
+
+**Finding the disk by hand on macOS: use `diskutil list`, not `diskutil list external`.** A
+MacBook's built-in SDXC slot reports `Device Location: Internal` — it hangs off an internal bus —
+while the card in it is `Removable Media: Removable`. So the card does **not** appear under
+`external`, and the obvious command silently shows you everything except the disk you want. On
+Linux, `lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT`.
 
 **Match the size.** `flash_pi.sh` refuses the system disk and refuses non-removable media, but it
 cannot tell one removable device from another — a USB stick is as valid a target as your card.

--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # Flash an Overboard image to an SD card and stage credentials onto it.
 #
-#     scripts/pi/flash_pi.sh --disk /dev/disk4                 # newest release
-#     scripts/pi/flash_pi.sh --disk /dev/disk4 --image ./x.img.xz
-#     scripts/pi/flash_pi.sh --disk /dev/disk4 --dry-run       # rehearse
+#     scripts/pi/flash_pi.sh                                   # newest release
+#     scripts/pi/flash_pi.sh --disk /dev/disk4                 # explicit target
+#     scripts/pi/flash_pi.sh --image ./x.img.zst               # local image
+#     scripts/pi/flash_pi.sh --dry-run                         # rehearse
+#
+# With no --disk, the one removable disk in the machine is proposed. Zero or
+# more than one is an error, never a guess. Detection removes the LOOKUP step
+# only -- the confirmation prompt below still has to be answered by hand.
 #
 # THIS WRITES TO A RAW BLOCK DEVICE. The classic way to lose a laptop's
 # internal disk is a mistyped device path in exactly this kind of script, so
@@ -36,7 +41,11 @@ die() { echo "error: $*" >&2; exit 1; }
 say() { echo "==> $*"; }
 
 usage() {
-  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  # Print the header block, whatever length it is: line 2 up to the first line
+  # of real code. The previous hard-coded '2,30p' silently truncated the moment
+  # the header grew, which is how --help starts lying about a script whose whole
+  # job is not to surprise you.
+  sed -n '2,/^set -/p' "${BASH_SOURCE[0]}" | sed '$d' | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -52,16 +61,66 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$DISK" ] || die "--disk is required. There is no default: a default target
-       for a raw write is a loaded gun. Find yours with:
-         macOS:  diskutil list external
-         Linux:  lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT"
-
 OS="$(uname -s)"
 case "$OS" in
   Darwin|Linux) ;;
   *) die "unsupported platform: $OS" ;;
 esac
+
+# ---------------------------------------------------------------------------
+# Target selection.
+#
+# --disk still wins outright. With no --disk we PROPOSE the single removable
+# disk -- but only when there is exactly one. Zero or several is an error,
+# never a guess: "pick the first one" is how a script like this breaks its
+# promise.
+#
+# NOTE the predicate. An earlier version of this enumerated with
+# `diskutil list external`, which does NOT list a MacBook's built-in SDXC
+# slot -- that reader reports Device Location: Internal while holding
+# Removable media, so the convenience feature would silently have failed to
+# find the CEO's only card reader. Same mistake guard 1 made. We therefore
+# filter on `Removable Media`, the exact field guard 1 checks, so detection
+# and validation cannot disagree about what counts.
+#
+# Detection removes the lookup step, not a safety step: guard 1 re-checks
+# whatever lands in $DISK, and guard 2 still makes a human type it back. A
+# target the script chose deserves the SAME scrutiny as one that was typed.
+# ---------------------------------------------------------------------------
+removable_disks() {
+  if [ "$OS" = "Darwin" ]; then
+    local d rm
+    for d in $(diskutil list physical 2>/dev/null | awk '/^\/dev\/disk/{print $1}'); do
+      rm="$(diskutil info "$d" 2>/dev/null | awk -F': *' '/Removable Media/{print $2}' | xargs)"
+      case "$rm" in Removable|Yes) echo "$d" ;; esac
+    done
+  else
+    # RM=1 is the kernel's own removable flag -- the same bit guard 1 reads.
+    lsblk -dno NAME,RM 2>/dev/null | awk '$2 == 1 { print "/dev/" $1 }'
+  fi
+}
+
+if [ -z "$DISK" ]; then
+  FOUND="$(removable_disks || true)"
+  COUNT="$(printf '%s\n' "$FOUND" | grep -c '^/dev/' || true)"
+  case "$COUNT" in
+    1)
+      DISK="$(printf '%s\n' "$FOUND" | grep '^/dev/')"
+      say "no --disk given; exactly one removable disk present: $DISK"
+      ;;
+    0)
+      die "no --disk given, and no removable disk was found.
+       Insert the card, or name the target explicitly:
+         macOS:  diskutil list          (NOT 'list external' -- the built-in
+                                         SDXC reader reports as internal)
+         Linux:  lsblk -o NAME,SIZE,TYPE,RM,MOUNTPOINT" ;;
+    *)
+      die "no --disk given, and $COUNT removable disks are present:
+$(printf '%s\n' "$FOUND" | grep '^/dev/' | sed 's/^/         /')
+       Refusing to choose between them -- pick one with --disk.
+       Match the SIZE: these guards cannot tell a card from a USB stick." ;;
+  esac
+fi
 
 # ---------------------------------------------------------------------------
 # Guard 1: the target must be removable. Refused, not warned about.


### PR DESCRIPTION
Replaces #231, which was stale **and carried the same blind spot the safety guard had.**

CEO ask from the first-boot session: make reloading the Pi "card in, run a command, done" rather than look-up-the-device-then-run-a-command.

```sh
scripts/pi/flash_pi.sh          # was: diskutil list, then --disk /dev/diskN
```

## The bug #231 would have shipped

Its `removable_disks()` enumerated with `diskutil list external physical`. A MacBook's built-in SDXC slot reports `Device Location: Internal`, so **that command does not list the CEO's card at all** — the convenience feature would have silently found nothing on the only machine that flashes cards.

Exactly the mistake guard 1 made, reproduced in the detector. It is worth naming because the two bugs were written hours apart, independently, from the same wrong mental model: *external bus* is not the same question as *removable media*.

This version filters on **`Removable Media`** — the precise field guard 1 checks — so detection and validation cannot disagree about what counts as a valid target.

## What deliberately did not change

**Detection removes the lookup step, not a safety step.**

- Guard 1 re-checks whatever lands in `$DISK`, whether a human or the script chose it.
- Guard 2 (**type the device identifier back**) is untouched and still mandatory. A target the script picked deserves the *same* scrutiny as one that was typed, not less.
- Several removable disks present is an error, not a guess. "Pick the first one" is how a script like this breaks its promise.
- The multi-disk error now also says **match the size** — these guards cannot tell an SD card from a USB stick, and that remains the operator's job.

## Drive-by, caught by making the change

`usage()` hard-coded `sed -n '2,30p'` to print the header. Growing the header truncated `--help` silently — a script whose whole job is not to surprise you, quietly misreporting its own interface. Now prints from line 2 to the first line of code, so it cannot drift again.

## Testing

- `bash -n` clean; `--help` renders the full header.
- **Zero-disk path exercised live** on macOS with no card inserted: errors, and now points at `diskutil list` rather than `list external`, with the reason.
- Both parsers checked against real `diskutil list physical` and `diskutil info` output shapes, including `Removable` vs `Fixed`.
- **Not exercised: the live one-disk and multi-disk paths.** No removable media was attached when this was rebuilt, and the sandbox blocks `diskutil`. The parsing is covered above; the end-to-end single-disk run is unverified until the next real flash. Stated rather than implied.
- Avoids `mapfile`: macOS ships bash 3.2.
