### PR TITLE
fix(image): put the first-boot done-marker on the boot partition, where a laptop can reach it (#249)

### DIFF
--- a/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-firstboot.service
+++ b/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-firstboot.service
@@ -29,7 +29,13 @@ Wants=NetworkManager.service
 #
 # Conditioning on completion instead means an interrupted run is retried on
 # the next boot, which is the behaviour a first-boot installer needs.
-ConditionPathExists=!/var/lib/overboard/firstboot-done
+#
+# The marker lives on the FAT BOOT PARTITION, not the rootfs. Credit to the
+# parallel #251 branch for this: the failure this marker exists to survive is
+# "the board will not boot", so a reset lever reachable only by booting the
+# board is on the wrong side of the partition. On FAT it can be deleted from a
+# laptop with the card in a reader, forcing a clean first boot with no console.
+ConditionPathExists=!/boot/firmware/overboard-firstboot.done
 
 [Service]
 Type=oneshot

--- a/scripts/pi/image/layer/overboard-base.rootfs-overlay/usr/local/sbin/overboard-firstboot
+++ b/scripts/pi/image/layer/overboard-base.rootfs-overlay/usr/local/sbin/overboard-firstboot
@@ -155,7 +155,11 @@ fi
 # The success marker the unit conditions on. Written LAST, so anything that
 # aborts before this point is retried on the next boot rather than being
 # skipped forever.
-install -d -m 0755 /var/lib/overboard
-date -u +%Y-%m-%dT%H:%M:%SZ | tee /var/lib/overboard/firstboot-done >/dev/null
+#
+# On the BOOT partition deliberately: it is the only filesystem a laptop can
+# mount, so deleting this file with the card in a reader forces a clean first
+# boot even on a board that will not come up. A marker on the rootfs would be
+# unreachable in exactly the situation it needs to be reachable.
+date -u +%Y-%m-%dT%H:%M:%SZ | tee "$BOOT/overboard-firstboot.done" >/dev/null
 
 log "complete - staged credentials removed from $BOOT"


### PR DESCRIPTION
Ports the one thing the parallel #251 branch got right and #256 (merged) got wrong. Credit to that branch.

#256 placed the first-boot success marker at `/var/lib/overboard/firstboot-done` — on the **ext4 rootfs**. #251 placed it on the **FAT boot partition**.

The boot partition is correct, and the reasoning is worth stating because it is the sort of thing that only becomes obvious after a bad night:

**The failure this marker exists to survive is "the board will not boot".** A reset lever reachable only by booting the board is on the wrong side of the partition. On FAT, the marker can be deleted from a laptop with the card in a reader — forcing a clean first-boot retry on a board with no console, no network and no SSH. That is precisely the situation the CEO was in on 2026-08-06, and precisely when a rootfs marker would have been unreachable.

It is also the same partition `flash_pi.sh` already writes and `overboard-firstboot` already shreds, so it needs no new mount, no new path, and no new failure mode.

Two sessions fixed #249 in parallel — my fault for not checking for an existing branch first. #256 is a superset on everything else (it also adds the `video` group for `vcgencmd`, and writes the cfg80211 regdom config directly rather than relying on shipping `iw`), so this ports the single genuine improvement rather than reverting anything.

**Not exercised on hardware** — the next flash is the test. The specific claim to check: `/boot/firmware/overboard-firstboot.done` exists after a completed first boot, and deleting it from a Mac makes the next boot re-run the installer.