### PR TITLE
fix(controls): pin AC-5's cyclictest to the isolated core (#255)

### DIFF
--- a/roles/senior-controls/log/2026-08-08-ac5-pin-isolated-core.md
+++ b/roles/senior-controls/log/2026-08-08-ac5-pin-isolated-core.md
@@ -1,0 +1,25 @@
+# Issue #255 — pin AC-5's cyclictest to the isolated core (PR TBD)
+
+`cyclictest -S` starts one thread per CPU **in the current cpuset**, and `isolcpus=3` removes
+CPU 3 — the core the 500 Hz control loop is meant to run on — from that set. The 30-minute AC-5
+run recorded 2026-08-07 (`docs/design-pi-image-stage0b-reference.md` Q1/AC-5 rows) therefore
+covered CPUs 0–2 and never touched the isolated core. The pass stands (conservative, not wrong —
+the noisy cores cleared the threshold with margin and the isolated core should do no worse), but
+the number for the control core is, strictly, still unmeasured.
+
+Fixed forward in the one place the repo tells the operator what to run: `scripts/pi/flash_pi.sh`'s
+post-flash guidance. Replaced the bare `cyclictest -m -Sp95 -i 2000 -D 30m` line with the full
+protocol from the issue — `stress-ng --cpu 4 --sock 2` load, `cyclictest ... -a 3` pinned to the
+isolated core, and a `vcgencmd get_throttled` check afterward (per #230, a throttled run is
+uninterpretable, not just pessimistic). Next time this runbook step is executed the repro command
+itself is correct, instead of relying on the operator to remember the caveat from the issue.
+
+**Deliberately left out:** did not touch `docs/design-pi-image-stage0b-reference.md`'s Q1/AC-5
+rows — they already record the CPU 0-2 caveat honestly, and this reference doc isn't one this
+role carries a standing TURF-OVERRIDE on (issue #54's override was scoped to that one split, not
+a blanket claim on the file). Updating the row to reflect a re-run against CPU 3, once the CEO
+actually executes the corrected command, is follow-up work for whoever reviews that data — not
+invented here. Also did not decide whether AC-5's own wording should name the isolated core
+explicitly (the issue raises this as a question, not an instruction); that reads as a Promise
+(changes what an acceptance criterion says) and belongs in the escalation queue if anyone wants
+to press it, not a default action for an unattended run.

--- a/scripts/pi/flash_pi.sh
+++ b/scripts/pi/flash_pi.sh
@@ -329,9 +329,15 @@ else
   echo "    boot partition, so they are not left on a FAT32 filesystem."
   echo
   echo "    Works immediately -- these ship in the image:"
-  echo "      cyclictest -m -Sp95 -i 2000 -D 30m       # kernel wakeup jitter (AC-5)"
   echo "      ip -details link show can0               # only with the CAN HAT fitted"
   echo "      cangen vcan0 & candump vcan0             # CAN stack, no hardware needed"
+  echo
+  echo "    AC-5 (kernel wakeup jitter), full protocol -- 'cyclictest -S' only starts"
+  echo "    one thread per CPU in the current cpuset, and isolcpus=3 removes CPU 3 from"
+  echo "    it, so this pins explicitly to the isolated core the control loop will use:"
+  echo "      sudo stress-ng --cpu 4 --sock 2 &"
+  echo "      sudo cyclictest -m -S -p95 -i 2000 -D 30m -a 3 -h 1000 --histfile=ac5-cpu3.txt"
+  echo "      vcgencmd get_throttled     # 0x0 required, or the run is uninterpretable (#230)"
   echo
   echo "    NOT on the card yet -- no Overboard code ships in the image (issue"
   echo "    #182 I5). To run the controller or the loop profiler you must put"


### PR DESCRIPTION
## What changed

`cyclictest -S` starts one thread per CPU **in the current cpuset**. `isolcpus=3` (baked into the
image by `scripts/pi/image/device/overboard-pi5/device.yaml`) removes CPU 3 — the core the 500 Hz
control loop is meant to run on — from that set. The 30-minute AC-5 run recorded 2026-08-07
(`docs/design-pi-image-stage0b-reference.md` Q1/AC-5 rows, `throttled=0x0`, p99.9 72 µs / max
113 µs) therefore measured CPUs 0–2 and never touched the isolated core. The pass stands
(conservative, not wrong — the noisy cores cleared the threshold with margin and the isolated
core should do no worse), but the figure quoted for the control core is, strictly, unmeasured.

Fixed forward in the one place the repo hands the operator a command to run:
`scripts/pi/flash_pi.sh`'s post-flash guidance. Replaced the bare
`cyclictest -m -Sp95 -i 2000 -D 30m` line with the full protocol from the issue:

```
sudo stress-ng --cpu 4 --sock 2 &
sudo cyclictest -m -S -p95 -i 2000 -D 30m -a 3 -h 1000 --histfile=ac5-cpu3.txt
vcgencmd get_throttled     # 0x0 required, or the run is uninterpretable (#230)
```

`-a 3` pins to the isolated core; the `stress-ng` load and the post-run `get_throttled` check
were already the correct protocol (per #230, a throttled run is a jitter source in its own right,
not just pessimistic) but weren't surfaced anywhere the operator would see them at flash time.

## Acceptance criteria satisfied

Issue #255's own "Fix" section is reproduced verbatim as the printed command. This doesn't
*produce* the CPU-3 measurement itself — that requires physical hardware this session doesn't
have (the runbook this touches is explicitly "**Executed by: the CEO**, at a desk") — but it
means the next time this step runs, it measures the right core by default instead of relying on
the operator to remember the caveat from the issue thread.

## Deliberately left out

- **`docs/design-pi-image-stage0b-reference.md`'s Q1/AC-5 rows** — left unchanged. They already
  record the CPU 0-2 caveat honestly, and this reference doc isn't one Senior Controls carries a
  standing `TURF-OVERRIDE` on (issue #54's override was scoped to that one doc split, not a
  blanket claim on the file going forward). Updating the row to a CPU-3-measured figure is
  follow-up work for whoever reviews that data once the corrected command is actually run.
- **Whether AC-5's own wording should name the isolated core explicitly** — the issue raises this
  as an open question ("worth also deciding..."), not an instruction. Changing what an acceptance
  criterion says is a Promise per `docs/decisions/INDEX.md`'s escalation test; not a default
  action for an unattended run.

Closes #255.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZuaJHgvA6wSS6WDtYjSdb)_