### PR TITLE
fix(controls): report jitter percentiles from the host, not just a miss count (#168)

### DIFF
--- a/crates/sim-host/src/bin/wire-probe.rs
+++ b/crates/sim-host/src/bin/wire-probe.rs
@@ -106,21 +106,48 @@ fn percentile(sorted_ms: &[f64], p: f64) -> f64 {
     sorted_ms[idx.min(sorted_ms.len() - 1)]
 }
 
+/// The subset of `sim-host`'s stats file this tool reports. `jitter_*` is
+/// `None` on a stats file written before issue #168's fields existed --
+/// this is internal, best-effort tooling, not the wire, so an old-format
+/// file degrades to the pre-#168 report rather than failing to parse.
+struct HostStats {
+    ticks: u64,
+    missed_deadlines: u64,
+    jitter_p50_ns: Option<u64>,
+    jitter_p99_ns: Option<u64>,
+    jitter_max_ns: Option<u64>,
+}
+
 /// Best-effort read of `sim-host`'s own stats file. Internal tooling, not
 /// the wire -- absent or unparsable is reported honestly, not faked.
-fn read_host_stats(path: &std::path::Path) -> Option<(u64, u64)> {
+fn read_host_stats(path: &std::path::Path) -> Option<HostStats> {
     let contents = std::fs::read_to_string(path).ok()?;
     let mut ticks = None;
     let mut missed = None;
+    let mut jitter_p50_ns = None;
+    let mut jitter_p99_ns = None;
+    let mut jitter_max_ns = None;
     for line in contents.lines() {
         if let Some(v) = line.strip_prefix("ticks=") {
             ticks = v.trim().parse().ok();
         } else if let Some(v) = line.strip_prefix("missed_deadlines=") {
             missed = v.trim().parse().ok();
+        } else if let Some(v) = line.strip_prefix("jitter_p50_ns=") {
+            jitter_p50_ns = v.trim().parse().ok();
+        } else if let Some(v) = line.strip_prefix("jitter_p99_ns=") {
+            jitter_p99_ns = v.trim().parse().ok();
+        } else if let Some(v) = line.strip_prefix("jitter_max_ns=") {
+            jitter_max_ns = v.trim().parse().ok();
         }
     }
     match (ticks, missed) {
-        (Some(t), Some(m)) => Some((t, m)),
+        (Some(ticks), Some(missed_deadlines)) => Some(HostStats {
+            ticks,
+            missed_deadlines,
+            jitter_p50_ns,
+            jitter_p99_ns,
+            jitter_max_ns,
+        }),
         _ => None,
     }
 }
@@ -262,11 +289,40 @@ fn main() {
     println!("inter-packet interval (ms): mean={mean_ms:.4} p50={p50_ms:.4} p99={p99_ms:.4} max={max_ms:.4}");
 
     match read_host_stats(&args.host_stats) {
-        Some((host_ticks, missed)) => {
-            println!(
-                "missed-deadline count from the host: {missed} (host reports {host_ticks} ticks, stats file {})",
-                args.host_stats.display()
-            );
+        Some(stats) => {
+            // Issue #168: a raw miss count against a zero-slack deadline
+            // reads as catastrophic ("70% missed") even when the underlying
+            // jitter is small and the mean is correct. Percentiles are the
+            // actionable form of the same fact; the count stays alongside
+            // them rather than being replaced, since "how often" is still a
+            // real question the percentiles alone don't answer.
+            match (
+                stats.jitter_p50_ns,
+                stats.jitter_p99_ns,
+                stats.jitter_max_ns,
+            ) {
+                (Some(p50), Some(p99), Some(max)) => {
+                    println!(
+                        "host-side jitter (ms, recent window): p50={:.4} p99={:.4} max={:.4} \
+                         -- {}/{} ticks missed overall, stats file {}",
+                        p50 as f64 / 1e6,
+                        p99 as f64 / 1e6,
+                        max as f64 / 1e6,
+                        stats.missed_deadlines,
+                        stats.ticks,
+                        args.host_stats.display()
+                    );
+                }
+                _ => {
+                    println!(
+                        "missed-deadline count from the host: {} (host reports {} ticks, stats \
+                         file {} predates issue #168's jitter fields)",
+                        stats.missed_deadlines,
+                        stats.ticks,
+                        args.host_stats.display()
+                    );
+                }
+            }
         }
         None => {
             println!(

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -126,7 +126,7 @@
 //! than in a test fixture, because an acceptance number nobody else can
 //! re-take is not a measurement.
 
-use crate::pacer::Pacer;
+use crate::pacer::{JitterPercentiles, Pacer};
 use crate::wire::{self, InputIn, StateOut};
 use board_types::{
     Command, Faults, ImuSample, Params, Saturation, DEFAULT_R_EFF_M, RAD_S_PER_ERPM,
@@ -2651,6 +2651,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
                     path,
                     ticks,
                     pacer.missed_deadlines(),
+                    pacer.jitter_percentiles(),
                     truth_pos_x_m,
                     truth_pos_y_m,
                 );
@@ -2681,6 +2682,7 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
             path,
             ticks,
             pacer.missed_deadlines(),
+            pacer.jitter_percentiles(),
             truth_pos_x_m,
             truth_pos_y_m,
         );
@@ -2764,16 +2766,24 @@ fn write_trace(path: &std::path::Path, rows: &[TraceRow]) -> Result<(), HostErro
 /// here for continuity with the tooling that already reads them -- as of
 /// issue #163 they are the SAME values the wire's `pos` now carries, since
 /// the dead-reckoned path is gone and MuJoCo's own position is authoritative.
+///
+/// `jitter` (issue #168) is `pacer::JitterPercentiles` over the pacer's
+/// recent window, not the whole run -- `missed_deadlines` stays the
+/// whole-run count it always was. Reporting both is the point: "70% missed"
+/// and "p99 = 15 ms with a correct mean" are the same underlying fact, and
+/// only the second is actionable on its own.
 fn write_stats(
     path: &std::path::Path,
     ticks: u64,
     missed_deadlines: u64,
+    jitter: JitterPercentiles,
     truth_pos_x_m: f64,
     truth_pos_y_m: f64,
 ) {
     let tmp = path.with_extension("tmp");
     let contents = format!(
-        "ticks={ticks}\nmissed_deadlines={missed_deadlines}\ntruth_pos_x_m={truth_pos_x_m}\ntruth_pos_y_m={truth_pos_y_m}\n"
+        "ticks={ticks}\nmissed_deadlines={missed_deadlines}\njitter_p50_ns={}\njitter_p99_ns={}\njitter_max_ns={}\ntruth_pos_x_m={truth_pos_x_m}\ntruth_pos_y_m={truth_pos_y_m}\n",
+        jitter.p50_ns, jitter.p99_ns, jitter.max_ns,
     );
     let _ = std::fs::write(&tmp, contents).and_then(|_| std::fs::rename(&tmp, path));
 }

--- a/crates/sim-host/src/pacer.rs
+++ b/crates/sim-host/src/pacer.rs
@@ -9,7 +9,53 @@
 //! cycle is paced against where the clock SHOULD be, not against how long
 //! the previous cycle happened to take.
 
+use std::collections::VecDeque;
 use std::time::{Duration, Instant};
+
+/// How many recent per-tick lateness samples [`Pacer`] keeps for
+/// [`Pacer::jitter_percentiles`]. A bounded ring, not the whole run: `Pacer`
+/// can run for as long as the process does (`HostConfig::duration: None`),
+/// so an unbounded `Vec` here would be a slow memory leak in exactly the
+/// long-running, real-time-adjacent loop this crate cannot afford to
+/// perturb. 2,000 samples is a 4 s window at 500 Hz -- long enough to be a
+/// meaningful jitter picture, small enough that sorting it every
+/// [`write_stats`]-interval (issue #168: currently ~100 ms) costs
+/// microseconds, not milliseconds.
+///
+/// [`write_stats`]: crate::host
+const JITTER_WINDOW: usize = 2_000;
+
+/// Nearest-rank percentiles over a recent window of per-tick lateness, in
+/// nanoseconds. Same nearest-rank convention as
+/// `crates/loop-profiler/src/stats.rs::Percentiles` (a real observed sample,
+/// never an interpolated value that no tick actually took) -- duplicated
+/// here rather than pulled in as a dependency: this crate has no other
+/// reason to depend on `loop-profiler`, and the algorithm is ~10 lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JitterPercentiles {
+    pub count: usize,
+    pub p50_ns: u64,
+    pub p99_ns: u64,
+    pub max_ns: u64,
+}
+
+impl JitterPercentiles {
+    pub const EMPTY: JitterPercentiles = JitterPercentiles {
+        count: 0,
+        p50_ns: 0,
+        p99_ns: 0,
+        max_ns: 0,
+    };
+}
+
+fn nearest_rank(sorted: &[u64], q: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = (q * sorted.len() as f64).ceil() as usize;
+    let idx = rank.clamp(1, sorted.len()) - 1;
+    sorted[idx]
+}
 
 /// Paces a loop at a fixed period. Call [`Pacer::wait_for_next`] once per
 /// iteration, after that iteration's work is done; sleep for the returned
@@ -24,6 +70,13 @@ pub struct Pacer {
     period: Duration,
     next_deadline: Instant,
     missed_deadlines: u64,
+    /// Per-call lateness (0 when on time), most recent
+    /// [`JITTER_WINDOW`] calls only. See issue #168: a raw
+    /// `missed_deadlines` count alone conflates "every tick was 1 ns late"
+    /// with "one tick stalled 15 ms" -- the same count, very different
+    /// severity. This is what lets a caller report the shape of the lag,
+    /// not just how many times it happened.
+    lateness_ns: VecDeque<u64>,
 }
 
 impl Pacer {
@@ -34,12 +87,31 @@ impl Pacer {
             period,
             next_deadline: now + period,
             missed_deadlines: 0,
+            lateness_ns: VecDeque::with_capacity(JITTER_WINDOW),
         }
     }
 
     /// Total missed deadlines observed so far.
     pub fn missed_deadlines(&self) -> u64 {
         self.missed_deadlines
+    }
+
+    /// Percentiles of per-tick lateness over the most recent
+    /// [`JITTER_WINDOW`] calls to [`Self::wait_for_next`] (0 for a tick that
+    /// was on time or early). Cheap enough to call every stats-file write:
+    /// sorts a bounded, small buffer, never the whole run.
+    pub fn jitter_percentiles(&self) -> JitterPercentiles {
+        if self.lateness_ns.is_empty() {
+            return JitterPercentiles::EMPTY;
+        }
+        let mut sorted: Vec<u64> = self.lateness_ns.iter().copied().collect();
+        sorted.sort_unstable();
+        JitterPercentiles {
+            count: sorted.len(),
+            p50_ns: nearest_rank(&sorted, 0.50),
+            p99_ns: nearest_rank(&sorted, 0.99),
+            max_ns: *sorted.last().unwrap(),
+        }
     }
 
     /// How far past `period` this call is deliberately allowed to lag
@@ -54,6 +126,11 @@ impl Pacer {
             self.missed_deadlines += 1;
             Duration::ZERO
         };
+        let late_ns = now.saturating_duration_since(self.next_deadline).as_nanos() as u64;
+        if self.lateness_ns.len() == JITTER_WINDOW {
+            self.lateness_ns.pop_front();
+        }
+        self.lateness_ns.push_back(late_ns);
         // Advances by exactly one period regardless of the overrun, so the
         // loop never skips a physics step or accelerates sim-time to "catch
         // up" -- one call to wait_for_next() is always exactly one hal
@@ -175,5 +252,72 @@ mod tests {
             assert!(sleep_for.is_zero());
         }
         assert_eq!(p.missed_deadlines(), 4);
+    }
+
+    #[test]
+    fn jitter_percentiles_are_empty_before_any_call() {
+        let p = Pacer::new(Duration::from_millis(10), base());
+        assert_eq!(p.jitter_percentiles(), JitterPercentiles::EMPTY);
+    }
+
+    #[test]
+    fn on_time_ticks_report_zero_jitter() {
+        let t0 = base();
+        let period = Duration::from_millis(20);
+        let mut p = Pacer::new(period, t0);
+        let mut now = t0;
+        for _ in 0..5 {
+            now += Duration::from_micros(1);
+            let sleep_for = p.wait_for_next(now);
+            now += sleep_for;
+        }
+        let j = p.jitter_percentiles();
+        assert_eq!(j.count, 5);
+        assert_eq!(j.p50_ns, 0);
+        assert_eq!(j.p99_ns, 0);
+        assert_eq!(j.max_ns, 0);
+    }
+
+    #[test]
+    fn one_late_tick_among_on_time_ones_shows_up_in_max_but_not_p50() {
+        // Same shape as issue #168's own report: mostly on-time, one stall.
+        // A p50 of 0 next to a non-zero max is exactly the "same fact, two
+        // readings" distinction #168 asked to be able to tell apart.
+        let t0 = base();
+        let period = Duration::from_millis(2);
+        let mut p = Pacer::new(period, t0);
+        for i in 0..20u32 {
+            let mut now = t0 + period * (i + 1);
+            if i == 10 {
+                now += Duration::from_millis(15);
+            }
+            p.wait_for_next(now);
+        }
+        let j = p.jitter_percentiles();
+        assert_eq!(j.count, 20);
+        assert_eq!(j.p50_ns, 0, "the other 19 ticks were on time");
+        assert_eq!(j.max_ns, Duration::from_millis(15).as_nanos() as u64);
+    }
+
+    #[test]
+    fn the_jitter_window_forgets_samples_older_than_its_capacity() {
+        let t0 = base();
+        let period = Duration::from_millis(1);
+        let mut p = Pacer::new(period, t0);
+        // One large stall, then enough clean ticks to push it out of the
+        // bounded window -- the whole point of JITTER_WINDOW being bounded
+        // rather than "the whole run" is that this DOES eventually happen.
+        let mut now = t0 + period + Duration::from_millis(50);
+        p.wait_for_next(now);
+        for i in 0..JITTER_WINDOW {
+            now = t0 + period * (i as u32 + 2);
+            p.wait_for_next(now);
+        }
+        let j = p.jitter_percentiles();
+        assert_eq!(j.count, JITTER_WINDOW);
+        assert_eq!(
+            j.max_ns, 0,
+            "the 50 ms stall should have scrolled out of the window"
+        );
     }
 }

--- a/roles/senior-controls/log/2026-08-08-issue-168-jitter-percentiles.md
+++ b/roles/senior-controls/log/2026-08-08-issue-168-jitter-percentiles.md
@@ -1,0 +1,65 @@
+# Issue #168, ask 3 — jitter percentiles instead of a bare miss count
+
+**PR:** `fix/controls/pacer-jitter-percentiles-168` (references #168, does not close it).
+
+## What was done
+
+Ask 1 (fix the inverted `Pacer` comment) and the underlying bursty-not-late finding were already
+landed and correctly described in `crates/sim-host/src/pacer.rs`'s `CORRECTION (issue #168)`
+comment block. Asks 2 and 4 are explicitly deferred by the issue itself ("Tuesday work, not
+weekend work" / "Fine for W1"). Ask 3 — "report jitter percentiles, not just a miss count" — was
+the one remaining, in-scope, unimplemented item, and is what this PR does:
+
+- `Pacer` now keeps a bounded (2,000-sample, ~4 s at 500 Hz) ring of per-tick lateness and exposes
+  `jitter_percentiles()` — nearest-rank p50/p99/max, same convention as
+  `crates/loop-profiler/src/stats.rs` (duplicated, not depended on — the algorithm is ~10 lines and
+  this crate has no other reason to pull in `loop-profiler`).
+- `host.rs`'s stats file (`/tmp/overboard-sim-host-stats.txt`) gained `jitter_p50_ns` /
+  `jitter_p99_ns` / `jitter_max_ns` alongside the existing `missed_deadlines`.
+- `wire-probe`'s report line changed from a bare "missed-deadline count from the host: N" to
+  "host-side jitter (ms, recent window): p50=... p99=... max=... -- N/M ticks missed overall" when
+  the fields are present, falling back to the old bare-count line for a stats file written before
+  this change (best-effort internal tooling, not the wire — no version bump needed).
+
+## Verification
+
+- `cargo test -p sim-host --lib pacer` — 9/9 (5 pre-existing + 4 new, deterministic, no real
+  sleeps, matching the module's existing style).
+- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo fmt --all -- --check`, `cargo run -p xtask -- gate` — all clean.
+- Manual end-to-end smoke test: ran `sim-host` and `wire-probe` against each other locally,
+  confirmed the stats file carries the new fields and `wire-probe` prints the new percentile line
+  (`host-side jitter (ms, recent window): p50=0.0000 p99=0.0000 max=8.5193 -- 5/1500 ticks missed
+  overall`).
+- `python3 .github/policy_check.py` — all hard checks pass (pre-existing advisories only, none
+  touched by this change).
+
+## Deliberately left out
+
+- Ask 2 (real-time thread policy on macOS) and ask 4 (promote the miss count to a wire field on
+  the next version bump) — the issue itself defers both.
+- `RunSummary`/`bin/sim-host.rs`'s final one-line summary print was **not** touched: it prints once
+  at process exit over the whole run, and `jitter_percentiles()` is deliberately a *recent* window,
+  not a whole-run statistic — mixing the two into one line would misrepresent a multi-hour run's
+  jitter as "the last 4 seconds." The stats file / `wire-probe` path this PR touches is the
+  mechanism the issue's own report was actually built from.
+- Did not widen `JITTER_WINDOW` or otherwise validate it against a real macOS/Linux run — 2,000
+  samples (4 s at 500 Hz) was sized to keep the periodic in-loop sort cheap, not measured against
+  hardware.
+
+## Also found, out of scope, flagged rather than fixed
+
+- **Duplicate PRs on the same issue.** #242 and #253 are both open, both closing #222, both adding
+  the same `pins.env` fields. Not this session's turf to resolve (would mean closing someone else's
+  PR), but worth a COO/CEO look — this run's dispatch check ("skip any issue that already has an
+  open PR against it") should have prevented a second one and evidently didn't catch this pair.
+- **The `Dispatch: cron OK` marker this run's own instructions describe as the gating field still
+  does not exist as a convention anywhere in the 37 open issues checked** (confirmed again this
+  run; PR #245 flagged the same thing on 2026-08-07). Only two explicit reservations exist in the
+  whole set: `Dispatch: COO only` on #61, and #33's "not dispatchable." The actual routing
+  mechanism is the `role:` GitHub label (ADR-0007, `ops/dispatch.sh`). Flagging the mismatch again
+  rather than fixing it — reconciling the dispatch prompt isn't controls turf.
+- Every other issue whose body says `Owner: Senior Controls` already has an open PR against it
+  (#261→#263, #255→#266, #226→#234, #222→#242/#253). #230 (thermal throttling) is a hardware/BoM
+  ask with nothing to code. #194 ("Controls, with Mechanical to weigh in") is a genuine open design
+  question across two roles' turf, not a default-action item for an unattended run.


### PR DESCRIPTION
## What changed

Issue #168 ask 3: *"Report jitter percentiles, not just a miss count. '70% missed' and 'p99 = 15 ms with a correct mean' are the same fact, but the first reads as catastrophic and the second is actionable."*

- `crates/sim-host/src/pacer.rs`: `Pacer` now keeps a bounded (2,000-sample, ~4 s at 500 Hz) ring of per-tick lateness and exposes `jitter_percentiles()` — nearest-rank p50/p99/max, the same convention `crates/loop-profiler/src/stats.rs::Percentiles` already uses (duplicated rather than depended on: the algorithm is ~10 lines and this crate has no other reason to pull in `loop-profiler`). Bounded, not whole-run, because `Pacer` can run for as long as the process does (`HostConfig::duration: None`).
- `crates/sim-host/src/host.rs`: the stats file (`/tmp/overboard-sim-host-stats.txt`) gains `jitter_p50_ns` / `jitter_p99_ns` / `jitter_max_ns` alongside the existing `missed_deadlines`.
- `crates/sim-host/src/bin/wire-probe.rs`: the report line changes from a bare `missed-deadline count from the host: N` to `host-side jitter (ms, recent window): p50=... p99=... max=... -- N/M ticks missed overall`, falling back to the old bare-count line if it reads a stats file written before this change (best-effort internal tooling, not the wire — no version bump needed).

## Why only this ask

#168 has four asks. (1) the inverted `Pacer` comment and the underlying bursty-not-late finding were already landed — `pacer.rs`'s `CORRECTION (issue #168)` comment block documents it. (2) a real-time thread policy on macOS and (4) promoting the miss count to a wire field are both explicitly deferred by the issue itself ("Tuesday work, not weekend work" / "Fine for W1"). (3) is the one remaining, in-scope, unimplemented item, and is what this PR does. Not closing #168 — asks 2 and 4 stay open.

## Verification

- `cargo test -p sim-host --lib pacer` — 9/9 (5 pre-existing + 4 new, deterministic, no real sleeps, matching the module's existing style).
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `cargo run -p xtask -- gate` — all clean.
- Manual end-to-end smoke test: ran `sim-host` and `wire-probe` against each other locally, confirmed the stats file carries the new fields and `wire-probe` prints `host-side jitter (ms, recent window): p50=0.0000 p99=0.0000 max=8.5193 -- 5/1500 ticks missed overall`.
- `python3 .github/policy_check.py` — all hard checks pass (pre-existing advisories only, none touched by this change).

## Deliberately left out

- Asks 2 and 4 (see above — the issue itself defers both).
- `RunSummary` / `bin/sim-host.rs`'s final one-line summary print was **not** touched: it prints once at process exit over the whole run, and `jitter_percentiles()` is deliberately a *recent* window — mixing the two would misrepresent a multi-hour run's jitter as "the last 4 seconds." The stats file / `wire-probe` path this PR touches is the mechanism #168's own report was actually built from.
- Did not tune `JITTER_WINDOW` against a real macOS/Linux run — 2,000 samples (4 s at 500 Hz) was sized to keep the periodic in-loop sort cheap, not measured against hardware.

## Also found, out of scope, flagged rather than fixed

- **Duplicate PRs on the same issue.** #242 and #253 are both open, both close #222, both add the same `pins.env` fields. Not this session's turf to resolve (would mean closing someone else's PR), but worth a look — the dispatch protocol's "skip any issue that already has an open PR against it" should have prevented a second one.
- **The `Dispatch: cron OK` marker this run's own dispatch instructions describe as the gating field still does not exist as a convention anywhere in the 37 open issues checked** (confirmed again this run; PR #245 flagged the same thing on 2026-08-07). Only two explicit reservations exist: `Dispatch: COO only` on #61, and #33's "not dispatchable." The actual routing mechanism is the `role:` GitHub label (ADR-0007, `ops/dispatch.sh`).
- Every other issue whose body says `Owner: Senior Controls` already has an open PR against it (#261→#263, #255→#266, #226→#234, #222→#242/#253). #230 (thermal throttling) is a hardware/BoM ask with nothing to code here. #194 ("Controls, with Mechanical to weigh in") is a genuine cross-role open design question, not a default-action item for an unattended run.

Related: #168 (not closed by this PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu35qBLRF1RKdLJC1RA2cw)_