### PR TITLE
fix(sim-host): turn radius was ~2x too wide, doubled the curvature gain (#201)

### DIFF
--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -596,14 +596,47 @@ const BALLAST_RANGE_M: f32 = 0.05;
 /// yaw rate is zero too -- you cannot carve a stationary onewheel.
 ///
 /// `k` (this constant) is picked for a believable radius at full steer, not
-/// derived: 0.15 rad/m gives a tightest radius of `1 / 0.15` ≈ 6.7 m at full
-/// steer, at ANY speed -- a wide, committed arc rather than a go-kart-tight
-/// spin, closer to "very large turning radius" than the old flat gain's
-/// spin-in-place. "Tune for feel, he will judge" -- this is a first
-/// approximation, picked to be conservative ("reduce overall authority" per
-/// the COO) rather than to hit an exact number; see this file's own
-/// measured results for what it produces against the new speed cap.
-const YAW_CURVATURE_PER_STEER_RAD_PER_M: f32 = 0.15;
+/// derived: at ANY speed at or above [`YAW_TIGHTEN_REF_SPEED_M_S`] the
+/// tightest achievable radius is `1 / k` -- a wide, committed arc rather than
+/// a go-kart-tight spin. "Tune for feel, he will judge" -- this is still a
+/// first approximation, not a hit-an-exact-number derivation.
+///
+/// # Issue #201 -- 0.15 measured too wide, doubled to 0.30
+///
+/// The CEO's own report: **"turn radius is too wide by maybe 2x to turn
+/// around completely."** `0.15` was quoted as ≈6.7 m from the formula above
+/// and never actually driven through a full turn to check; issue #201 did,
+/// with `--scripted-scenario turnaround` (`tests/test_turn_radius.py`) and a
+/// ground-track measurement rather than the formula alone, because full-sim
+/// turning also passes through `roll_authority`
+/// (`YAW_AUTHORITY_FLOOR`/`ROLL_FULL_YAW_AUTHORITY_RAD`, added after this
+/// constant was first picked) and the low-speed tighten ramp, neither of
+/// which the plain `1 / k` formula accounts for.
+///
+/// **BEFORE (0.15):** measured **6.16 m** at 8.67 m/s ground speed (93% of
+/// the 9.34 m/s reference speed), climbing toward the formula's 6.67 m
+/// asymptote as speed approaches the reference -- i.e. the formula was
+/// right, `roll_authority` saturates to ~1.0 in practice and does not
+/// explain the discrepancy from a naive expectation; the number was simply
+/// too wide, as reported.
+///
+/// **AFTER (0.30, this constant):** median **3.284 m** (10th-90th percentile
+/// spread 0.096 m) across samples within 5% of the 9.34 m/s reference speed,
+/// comfortably inside issue #201's `≤ 3.6 m` acceptance bound, and inside the
+/// drivable corridor (`CORRIDOR_HALF_WIDTH_M` = 8.6 m half-width) throughout
+/// the measurement hold -- max lateral excursion 5.05 m, not the ±8.6 m the
+/// pre-fix radius would need. The median is used rather than the max because
+/// the local `dheading/dt` estimate is numerically unstable for the 1-2
+/// samples exactly at the ground-speed peak (`dv/dt -> 0` there); see
+/// `tests/test_turn_radius.py` for the full method and the outliers this
+/// excludes. Doubling `k` exactly halves the radius at every speed (the
+/// formula is linear in `k`, confirmed by measurement, not just assumed).
+///
+/// `full_steer_at_a_standstill_injects_nothing` and
+/// `the_turn_radius_shrinks_as_the_board_slows` (this file's own unit tests)
+/// both re-derive their expectations from this constant directly and needed
+/// no changes for the retune -- see their own doc comments.
+const YAW_CURVATURE_PER_STEER_RAD_PER_M: f32 = 0.30;
 
 /// How much tighter the turn gets at a standstill than at top speed, as a
 /// multiple of [`YAW_CURVATURE_PER_STEER_RAD_PER_M`].
@@ -1557,6 +1590,12 @@ struct TraceRow {
     applied_amps: f32,
     /// `safety::Envelope` reported the clamp bound this cycle.
     saturated: bool,
+    /// MuJoCo's true world-frame ground position (issue #201: the turn
+    /// radius has to be fitted off an actual track, not quoted from
+    /// `1 / (steer * k)`). Same values `truth_pos_x_m`/`truth_pos_y_m`
+    /// carry elsewhere in this file -- see [`write_stats`].
+    pos_x_m: f32,
+    pos_y_m: f32,
     /// `|proposed_amps| / MAX_CURRENT_A`, unfiltered.
     utilisation: f32,
     /// ... and low-passed at [`AUTHORITY_UTILISATION_TAU_S`].
@@ -2516,6 +2555,8 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
                 proposed_amps,
                 applied_amps: last_amps,
                 saturated,
+                pos_x_m: truth_pos_x_m as f32,
+                pos_y_m: truth_pos_y_m as f32,
                 utilisation,
                 utilisation_filtered,
                 authority_warning,
@@ -2727,12 +2768,12 @@ fn write_trace(path: &std::path::Path, rows: &[TraceRow]) -> Result<(), HostErro
     out.push_str(
         "seq,sim_time_s,stick_fore_aft,shaped_fore_aft,applied_fore_aft,truth_pitch_deg,\
          est_pitch_deg,est_pitch_rate_deg_s,truth_pitch_rate_deg_s,forward_speed_m_s,proposed_amps,applied_amps,\
-         saturated,utilisation,utilisation_filtered,authority_warning,fallen\n",
+         saturated,utilisation,utilisation_filtered,authority_warning,fallen,pos_x_m,pos_y_m\n",
     );
     for r in rows {
         let _ = writeln!(
             out,
-            "{},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{},{:?},{:?},{},{}",
+            "{},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{:?},{},{:?},{:?},{},{},{:?},{:?}",
             r.seq,
             r.sim_time_s,
             r.stick_fore_aft,
@@ -2750,6 +2791,8 @@ fn write_trace(path: &std::path::Path, rows: &[TraceRow]) -> Result<(), HostErro
             r.utilisation_filtered,
             r.authority_warning as u8,
             r.fallen as u8,
+            r.pos_x_m,
+            r.pos_y_m,
         );
     }
     std::fs::write(path, out).map_err(HostError::Io)

--- a/crates/sim-host/src/scenario.rs
+++ b/crates/sim-host/src/scenario.rs
@@ -385,6 +385,82 @@ pub const CRUISE_TURN_SCHEDULE: Schedule = &[
     ),
 ];
 
+/// A MEASUREMENT schedule, not a viewing one: hold 0.6 fore/aft lean AND full
+/// steer/lateral together from a standing start, long enough for ground
+/// speed to climb through the low-speed-tighten ramp (`crate::host::
+/// YAW_LOW_SPEED_TIGHTEN`) and approach the reference speed, so the achieved
+/// turn RADIUS can be measured off the ground track instead of being quoted
+/// from `1 / (steer * k)` and hoped for.
+///
+/// It exists because the CEO's steering feedback is about a radius ("too wide
+/// by maybe 2x to turn around completely") and nothing else in this file
+/// produces one: `default`'s turn phase happens while the board is reversing
+/// at low speed, and `s-curve` flips before it ever reaches its carve (issue
+/// #190, ADR-0011) -- neither can answer "what radius does full stick
+/// actually give?".
+///
+/// # Why there is no separate build phase
+///
+/// [`crate::host`]'s yaw law makes turn radius a function of ground speed
+/// ALONE (`1 / (steer * yaw_curvature_per_steer(v) * roll_authority)`) --
+/// what the fore/aft stick is doing barely matters except through what speed
+/// it produces. `feat/controls/turn-radius-and-reset`'s stale version of this
+/// schedule (salvaged for the general shape, not the numbers) built speed
+/// straight first, THEN released fore/aft to zero for the turn -- with
+/// nothing left driving it, the coasting board decelerated under turning
+/// drag the whole way round, so radius and speed were both changing
+/// continuously and a single circle-fit number was never well-defined.
+///
+/// This version holds 0.6 lean straight through -- entering the turn at
+/// t=[`ACCEPTANCE_SETTLE_S`] from a standing start, at issue #201's own
+/// acceptance criterion's stated lean, and simply keeping it there. Ground
+/// speed then climbs on its own (this plant has no outer velocity loop, see
+/// this crate's own header, so a sustained positive lean keeps accelerating
+/// it) and the achieved radius is READ OFF WHATEVER SPEED THE BOARD IS
+/// ACTUALLY DOING at each instant, via the ground-track derivative
+/// (`tests/test_turn_radius.py`), not assumed constant. Measuring the
+/// reported radius once the speed trace is within a few percent of
+/// [`crate::host::MAX_GROUND_SPEED_M_S`] (a) matches this file's own pinned
+/// property that radius is *widest* at/above the reference speed and *only
+/// gets tighter below it, never wider* (`the_turn_radius_shrinks_as_the_board
+/// _slows`), so a near-top-speed reading is the worst-case (widest) turn the
+/// board can produce at this lean, not a cherry-picked favourable one; and
+/// (b) stays inside the drivable corridor (`CORRIDOR_HALF_WIDTH_M`), which a
+/// full multi-loop circle at the PRE-fix (too-wide) radius does not.
+///
+/// **Lean is 0.6, not 1.0.** Full-stick lean is exactly what issue #190's
+/// flip needs: the current to hold the frame saturates the 40 A envelope at
+/// ~6.5 m/s and the board is inverted 1.55 s later. A measurement scenario
+/// that flipped would measure nothing, and ADR-0011 has the launch held on
+/// that defect. 0.6 is `DEFAULT_SCHEDULE`'s own already-validated
+/// accelerating value, and it is what issue #201's own acceptance criterion
+/// names.
+///
+/// Lateral and steer are at full stick throughout: the radius being measured
+/// is the tightest one the board offers at a given speed, which is the
+/// number the CEO's feedback is about.
+const TURNAROUND_LEAN: f32 = 0.6;
+const TURNAROUND_HOLD_S: f64 = 16.0;
+pub const TURNAROUND_SCHEDULE: Schedule = &[
+    (0.0, ACCEPTANCE_SETTLE_S, 0.0, 0.0, 0.0, "settle"),
+    (
+        ACCEPTANCE_SETTLE_S,
+        ACCEPTANCE_SETTLE_S + TURNAROUND_HOLD_S,
+        TURNAROUND_LEAN,
+        1.0,
+        1.0,
+        "hold 0.6 lean + full steer (measure the radius)",
+    ),
+    (
+        ACCEPTANCE_SETTLE_S + TURNAROUND_HOLD_S,
+        ACCEPTANCE_SETTLE_S + TURNAROUND_HOLD_S + 1.5,
+        0.0,
+        0.0,
+        0.0,
+        "release (coast)",
+    ),
+];
+
 /// Every schedule a `--scenario`/`--scripted-scenario` flag accepts, by name.
 pub const BY_NAME: &[(&str, Schedule)] = &[
     ("default", DEFAULT_SCHEDULE),
@@ -394,6 +470,7 @@ pub const BY_NAME: &[(&str, Schedule)] = &[
     ("brake-stop", BRAKE_STOP_SCHEDULE),
     ("brake-turn", BRAKE_TURN_SCHEDULE),
     ("cruise-turn", CRUISE_TURN_SCHEDULE),
+    ("turnaround", TURNAROUND_SCHEDULE),
 ];
 
 /// Looks up a schedule by its command-line name.

--- a/roles/senior-controls/log/2026-08-12-turn-radius-tighten.md
+++ b/roles/senior-controls/log/2026-08-12-turn-radius-tighten.md
@@ -1,0 +1,56 @@
+# 2026-08-12 — Issue #201: turn radius was too wide, doubled the curvature gain
+
+CEO's own report: "turn radius is too wide by maybe 2x to turn around completely," against
+an ask of roughly 3.5 m. `YAW_CURVATURE_PER_STEER_RAD_PER_M` (0.15) had only ever been
+quoted from `1 / k` ≈ 6.7 m — never actually driven through a turn and measured. PR TBD.
+
+## What was measured, and why the formula alone wasn't enough
+
+`host.rs`'s full-sim yaw law also passes through `roll_authority`
+(`YAW_AUTHORITY_FLOOR`/`ROLL_FULL_YAW_AUTHORITY_RAD`) and the low-speed tighten ramp,
+neither of which the plain `1 / k` formula accounts for, and both were added after this
+constant was first picked. So this needed a real measurement, not a re-quote.
+
+Added `--scripted-scenario turnaround` (`scenario.rs`) — full steer/lateral and 0.6 lean
+(issue #201's own acceptance criterion) from a standing start — and measured the ground
+track's LOCAL radius (ground speed / heading rate, `tests/test_turn_radius.py`), not a
+whole-run circle fit. This plant has no outer velocity loop, so a sustained lean keeps
+accelerating the board the whole time; radius is only well-defined instant-to-instant, not
+as a run-wide constant, so a global circle fit assumes something that isn't true here.
+
+**BEFORE (0.15):** measured 6.16 m at 93% of the reference speed, climbing toward the
+formula's 6.67 m asymptote as speed approached it — i.e. the formula was right,
+`roll_authority` saturates to ~1.0 in practice, and the radius really was that wide.
+
+**AFTER (0.30):** median 3.284 m (10th-90th percentile spread 0.096 m) across the
+near-reference-speed tail of the hold — comfortably inside the 3.6 m acceptance ceiling,
+and comfortably inside the drivable corridor throughout (max lateral excursion 5.05 m
+against an 8.6 m half-width) — where the *pre-fix* radius would not have fit.
+
+## What salvaged from the stale branch, and what didn't
+
+`feat/controls/turn-radius-and-reset` (issue #201's own prior WIP, NEEDS-REWORK, do not
+merge) is many commits behind `master` and its `host.rs` diff deletes several ADR-0012 and
+ADR-0011-matrix features that master has since grown — not usable as-is. Salvaged only the
+idea of a dedicated `turnaround` schedule; the actual schedule shape is new (this one holds
+0.6 lean straight through the turn instead of coasting through it, because coasting lets
+speed — and therefore curvature — drift the whole way round, which is what made the stale
+branch's own circle fit unfittable in the first place).
+
+## Deliberately left out
+
+- `feat/controls/turn-radius-and-reset`'s "reset" half is untouched — issue #201 doesn't
+  ask for it, and the issue's own note says it's tracked separately.
+- No change to `roll_authority`, the low-speed tighten ramp, or anything else in the yaw
+  law besides the one constant issue #201 names.
+
+## A local false alarm, corrected before reporting anything
+
+`cargo run -p xtask -- gate` failed in this session's sandbox on an unmodified `master`
+checkout (`hal-actuate, plant-mujoco are unreachable from board-app-ridden`), which looked
+like a real regression on master. Checked against the actual GitHub Actions run for that
+exact commit (2e41fc73) before reporting it: the `crate-exclusion boundary gate` step
+passed there, and every other job did too. So this was an artefact of this sandbox's own
+incremental-build state (crates built piecemeal, one at a time, ahead of the gate check,
+which can change what `cargo metadata`'s feature unification sees), not a real defect on
+master. Recorded here so a future session doesn't rediscover the same false alarm.

--- a/tests/test_turn_radius.py
+++ b/tests/test_turn_radius.py
@@ -1,0 +1,199 @@
+"""Issue #201: the turn radius was too wide, and nobody had measured it.
+
+THE CEO'S REPORT
+-----------------
+"turn radius is too wide by maybe 2x to turn around completely" -- against an
+ask of roughly 3.5 m. `YAW_CURVATURE_PER_STEER_RAD_PER_M` (0.15) was quoted
+from `1 / k` as ~6.7 m and never actually driven through a turn to check.
+
+WHY A FORMULA ALONE ISN'T ENOUGH
+----------------------------------
+`host.rs`'s yaw law makes turn radius a function of ground speed:
+`1 / (steer * yaw_curvature_per_steer(v) * roll_authority)`. `roll_authority`
+(added after the constant was first picked) and the low-speed tighten ramp
+both live outside the plain `1 / k` formula, so the only honest way to check
+the achieved radius is to drive a full turn and measure the ground track --
+which is what `--scripted-scenario turnaround` and this file do.
+
+METHOD -- local curvature from the ground track, not a whole-path circle fit
+-------------------------------------------------------------------------
+`turnaround` holds 0.6 lean (issue #201's own acceptance criterion) and full
+steer/lateral from a standing start. This plant has no outer velocity loop
+(see `host.rs`'s own header), so ground speed keeps climbing under a
+sustained positive lean -- the achieved radius is NOT constant over the run,
+it tightens as speed climbs through `YAW_LOW_SPEED_TIGHTEN`'s ramp and only
+reaches the "widest" ~`1 / k` radius once ground speed is near
+`YAW_TIGHTEN_REF_SPEED_M_S`. A single circle fit over the whole run assumes a
+constant radius that does not hold here (see `scenario.rs`'s own doc comment
+on `TURNAROUND_SCHEDULE` for why the stale `feat/controls/turn-radius-and-
+reset` branch's coast-through-the-turn version produced an un-fittable
+spiral). Fitting the LOCAL radius at each instant instead -- ground speed
+divided by the ground track's own instantaneous heading rate -- needs no such
+assumption, and it is what `the_turn_radius_shrinks_as_the_board_slows`
+(`host.rs`'s own unit test) already asserts is the correct shape: radius
+shrinks monotonically as speed falls, and is WIDEST at and above the
+reference speed. So the acceptance number is measured at the near-reference-
+speed tail of the hold, which is deliberately the worst case (widest turn),
+not a favourable one.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+HOST_RS = REPO / "crates" / "sim-host" / "src" / "host.rs"
+
+STATE_OUT = "127.0.0.1:19805"
+INPUT_IN = "127.0.0.1:19806"
+
+#: Issue #201's own acceptance criterion 1.
+TURN_RADIUS_CEILING_M = 3.6
+
+#: `CORRIDOR_HALF_WIDTH_M` in `host.rs` -- the measurement must stay well
+#: inside this or the corridor brake (`CORRIDOR_BRAKE_LEAN`) contaminates the
+#: speed trace and the radius reading with it.
+CORRIDOR_HALF_WIDTH_M = 8.6
+
+#: Sampling stride for the ground-track derivative -- coarse enough that
+#: consecutive heading samples are not dominated by floating-point noise at
+#: the 500 Hz control rate, fine enough to resolve the speed ramp.
+SAMPLE_DT_S = 0.1
+
+
+def _rust_constant(name: str) -> float:
+    m = re.search(rf"^const {name}: f32 = ([0-9.]+);", HOST_RS.read_text(), re.M)
+    assert m is not None, f"{name} is not a plain f32 const in {HOST_RS}"
+    return float(m.group(1))
+
+
+def _run(tmp_path: Path) -> list[dict]:
+    out = tmp_path / "turnaround.csv"
+    argv = [
+        "cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+        "--scripted-scenario", "turnaround",
+        "--free-run",
+        "--stats-path", "none",
+        "--pitch-source", "estimator",
+        "--state-out-addr", STATE_OUT,
+        "--input-in-addr", INPUT_IN,
+        "--trace-csv", str(out),
+    ]
+    proc = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert proc.returncode == 0, f"sim-host failed:\n{proc.stderr[-4000:]}"
+    with out.open() as f:
+        return [{k: float(v) for k, v in row.items()} for row in csv.DictReader(f)]
+
+
+def _local_radius(rows: list[dict]):
+    """`(mid_time_s, ground_speed_m_s, radius_m)` at `SAMPLE_DT_S` spacing.
+
+    Radius is `|v / dheading_dt|`, heading taken from consecutive ground-track
+    deltas -- see this file's own module doc comment for why a local estimate
+    is used instead of a whole-run circle fit.
+    """
+    seen_buckets: set[int] = set()
+    sel = []
+    for r in rows:
+        bucket = round(r["sim_time_s"] / SAMPLE_DT_S)
+        if bucket in seen_buckets:
+            continue
+        seen_buckets.add(bucket)
+        sel.append(r)
+    t = np.array([r["sim_time_s"] for r in sel])
+    x = np.array([r["pos_x_m"] for r in sel])
+    y = np.array([r["pos_y_m"] for r in sel])
+    v = np.array([r["forward_speed_m_s"] for r in sel])
+
+    heading = np.unwrap(np.arctan2(np.diff(y), np.diff(x)))
+    tm = (t[:-1] + t[1:]) / 2
+    yaw_rate = np.diff(heading) / np.diff(tm)
+    tm2 = (tm[:-1] + tm[1:]) / 2
+    v_mid = np.interp(tm2, t, v)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        radius = np.abs(v_mid / yaw_rate)
+    return tm2, v_mid, radius
+
+
+def test_the_sim_host_binary_is_actually_built():
+    assert (REPO / "target" / "release" / "sim-host").exists(), (
+        "sim-host is not built, so this whole gate would be vacuous. Run:\n"
+        "    cargo build --release -p sim-host --bin sim-host"
+    )
+
+
+def test_the_turn_radius_at_full_steer_and_0_6_lean_is_within_acceptance(tmp_path):
+    """Issue #201, acceptance criterion 1.
+
+    Measured, not quoted: drives the `turnaround` scenario, takes the local
+    radius reading once ground speed is within 5% of the reference speed
+    (`YAW_TIGHTEN_REF_SPEED_M_S` -- the widest, worst-case turn this lean can
+    produce), and asserts it against the acceptance ceiling with the
+    residual spread reported alongside it, not hidden.
+    """
+    # `YAW_TIGHTEN_REF_SPEED_M_S` is defined as `= MAX_GROUND_SPEED_M_S`, not a
+    # literal of its own -- read the literal it aliases instead.
+    ref_speed = _rust_constant("MAX_GROUND_SPEED_M_S")
+    k = _rust_constant("YAW_CURVATURE_PER_STEER_RAD_PER_M")
+
+    rows = _run(tmp_path)
+    hold_rows = [r for r in rows if r["sim_time_s"] <= 16.5]  # TURNAROUND hold window
+    max_abs_y = max(abs(r["pos_y_m"]) for r in hold_rows)
+    assert max_abs_y < CORRIDOR_HALF_WIDTH_M - 1.0, (
+        f"the measurement run's ground track reached {max_abs_y:.2f} m laterally, "
+        f"too close to the {CORRIDOR_HALF_WIDTH_M} m corridor half-width -- the "
+        "corridor brake may have engaged and contaminated the speed/radius trace"
+    )
+
+    t, v, radius = _local_radius(hold_rows)
+    near_ref = radius[(v >= 0.95 * ref_speed) & np.isfinite(radius)]
+    assert near_ref.size >= 10, (
+        f"only {near_ref.size} samples reached 95% of the {ref_speed:.2f} m/s "
+        "reference speed -- lengthen TURNAROUND_HOLD_S in scenario.rs"
+    )
+    # MEDIAN, not max: the local (per-sample) derivative is a `dheading/dt`
+    # finite difference, and it is numerically unstable for the 1-2 samples
+    # right at the ground speed peak, where `dv/dt` -> 0 makes the heading
+    # difference itself the dominant source of noise -- measured directly,
+    # not assumed: this run's own near-reference-speed window has 2 outlier
+    # samples (~5.2 m) sitting inside an otherwise smooth 3.17-3.42 m band.
+    # The median is insensitive to a couple of outliers among 40+ samples;
+    # `spread` is reported so that noise is visible, not hidden by the choice
+    # of a robust statistic.
+    measured = float(np.median(near_ref))
+    spread = float(np.percentile(near_ref, 90) - np.percentile(near_ref, 10))
+    print(
+        f"\nturn radius near reference speed ({ref_speed:.2f} m/s, k={k}): "
+        f"median {measured:.3f} m, 10-90th pct spread {spread:.3f} m, "
+        f"range [{near_ref.min():.3f}, {near_ref.max():.3f}] m, n={near_ref.size}"
+    )
+    assert measured <= TURN_RADIUS_CEILING_M, (
+        f"turn radius at full steer + 0.6 lean measured {measured:.3f} m near "
+        f"the reference speed, exceeding issue #201's {TURN_RADIUS_CEILING_M} m "
+        "acceptance ceiling"
+    )
+
+
+def test_the_pinned_formula_matches_what_was_actually_driven():
+    """Cross-check: the shipped constant's own `1 / k` asymptote must be under
+    the acceptance ceiling too, so a future retune of `k` alone (without
+    rerunning the full-sim measurement) cannot silently regress past the
+    corridor-safe, CEO-accepted radius by relying on the formula matching
+    reality less well than it does today.
+    """
+    k = _rust_constant("YAW_CURVATURE_PER_STEER_RAD_PER_M")
+    asymptote = 1.0 / k
+    assert asymptote <= TURN_RADIUS_CEILING_M, (
+        f"YAW_CURVATURE_PER_STEER_RAD_PER_M={k} gives a widest-case radius of "
+        f"{asymptote:.3f} m by the formula alone, already over the "
+        f"{TURN_RADIUS_CEILING_M} m ceiling -- full-sim measurement would only "
+        "make this worse, not better"
+    )


### PR DESCRIPTION
## What changed

`YAW_CURVATURE_PER_STEER_RAD_PER_M` (0.15) doubled to **0.30**, plus a new `--scripted-scenario turnaround` and `tests/test_turn_radius.py` to actually measure the result instead of quoting it from `1 / k`.

## Why

The CEO's own report: **"turn radius is too wide by maybe 2x to turn around completely"** — against an ask of roughly 3.5 m. The 0.15 constant had only ever been quoted from the formula (≈6.7 m), never driven through a real turn and measured. That formula alone isn't reliable any more: full-sim turning also passes through `roll_authority` (`YAW_AUTHORITY_FLOOR`/`ROLL_FULL_YAW_AUTHORITY_RAD`) and the low-speed tighten ramp, both added after this constant was first picked.

## How it was measured

`turnaround` holds full steer + 0.6 lean (issue #201's own acceptance criterion) from a standing start. This plant has no outer velocity loop, so ground speed keeps climbing under a sustained lean — turn radius is only well-defined **instant to instant**, not as a run-wide constant. `tests/test_turn_radius.py` reads the LOCAL radius off the ground track (speed / heading rate) instead of fitting one circle to the whole run, then reports the value near the reference speed (the widest, worst-case turn this lean can produce, per the file's own pinned `the_turn_radius_shrinks_as_the_board_slows` property).

**Before (0.15):** measured 6.16 m at 93% of reference speed, climbing toward the formula's 6.67 m asymptote — the formula was right, `roll_authority` saturates to ~1.0 in practice, and the radius really was that wide.

**After (0.30):** median **3.284 m** (10th-90th pct spread 0.096 m) near reference speed — comfortably under the **3.6 m** acceptance ceiling, and comfortably inside the drivable corridor throughout the measurement (max lateral excursion 5.05 m against an 8.6 m half-width), where the pre-fix radius would not have fit.

## Acceptance criteria satisfied (issue #201)

1. ✅ Turn radius at full steer + 0.6 lean measures ≤ 3.6 m, via a measurement with a stated residual (`tests/test_turn_radius.py`).
2. ✅ `full_steer_at_a_standstill_injects_nothing` still passes unchanged — it derives its expectation from the constant directly.
3. ✅ The new constant carries a provenance comment citing the measured before/after radii (`host.rs`).

## Deliberately left out

- The "reset" half of `feat/controls/turn-radius-and-reset` (issue #201's own prior WIP branch) — tracked separately, not touched here. That branch is otherwise NEEDS-REWORK against current `master` (its `host.rs` diff predates several ADR-0011/ADR-0012 features master has since grown), so only the general idea of a dedicated turnaround schedule was salvaged from it, not its code.
- Any change to `roll_authority` or the low-speed tighten ramp themselves — out of this issue's scope.

## Note

This session's sandbox initially reported a local `cargo run -p xtask -- gate` failure on an unmodified `master` checkout, unrelated to this change. Checked against the real GitHub Actions run for that commit before reporting anything: that step passed there, so it was a sandbox build-state artefact, not a real regression — recorded in the log entry so it isn't rediscovered.

Closes #201


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjLh2qPUVpQ4pZBgVsRdLp)_