### PR TITLE
fix(controls): a runtime damping-scale knob, and ADR-0011 criterion (g) taken (#229)

### DIFF
--- a/crates/plant-mujoco/src/lib.rs
+++ b/crates/plant-mujoco/src/lib.rs
@@ -62,6 +62,8 @@ extern "C" {
     fn plant_mujoco_joint_id(model: *mut c_void, name: *const c_char) -> c_int;
     fn plant_mujoco_joint_qposadr(model: *mut c_void, joint_id: c_int) -> c_int;
     fn plant_mujoco_joint_dofadr(model: *mut c_void, joint_id: c_int) -> c_int;
+    fn plant_mujoco_get_dof_damping(model: *mut c_void, dofadr: c_int) -> f64;
+    fn plant_mujoco_set_dof_damping(model: *mut c_void, dofadr: c_int, damping: f64);
     fn plant_mujoco_set_qpos_range(data: *mut c_void, adr: c_int, src: *const f64, n: c_int);
     fn plant_mujoco_set_qvel_range(data: *mut c_void, adr: c_int, src: *const f64, n: c_int);
 }
@@ -494,6 +496,39 @@ impl Plant {
         Some(adr as usize)
     }
 
+    /// `mjModel::dof_damping[dofadr]` -- the linear damping coefficient on the
+    /// degree of freedom at `dofadr` (from [`Plant::joint_dofadr`]). Valid for
+    /// a 1-DOF joint (e.g. a hinge); a multi-DOF joint has more than one
+    /// damping slot starting at `dofadr`, which this does not attempt to
+    /// return.
+    pub fn dof_damping(&self, dofadr: usize) -> f64 {
+        // SAFETY: `self.model` is non-null and owned for the life of `self`;
+        // `dofadr` came from `joint_dofadr` against this same model.
+        unsafe { plant_mujoco_get_dof_damping(self.model, dofadr as c_int) }
+    }
+
+    /// Overwrites `mjModel::dof_damping[dofadr]` -- **verification only**, the
+    /// only supported way to vary a joint's damping without editing
+    /// `sim/models/` and rebuilding (ADR-0011 criterion (g): "every pass must
+    /// hold across a damping sweep of 0.5x-2x" on `wheel_hinge`'s
+    /// `damping="0.08"`). Mirrors [`Plant::set_gravity`]'s reasoning: a model
+    /// edit changes every scenario, this changes one run.
+    ///
+    /// # Panics
+    /// If called after any [`Plant::step`] -- same "before the first step"
+    /// rule as `set_gravity`, for the same reason: damping is read every
+    /// step, so changing it mid-run is a step disturbance, not a sweep point.
+    pub fn set_dof_damping(&mut self, dofadr: usize, damping: f64) {
+        assert!(
+            self.time() == 0.0,
+            "Plant::set_dof_damping must be called before the first Plant::step (mjData::time \
+             is {:.6}, not 0) -- a mid-run change is a disturbance, not a sweep point",
+            self.time()
+        );
+        // SAFETY: see `dof_damping`; this call only writes the one slot.
+        unsafe { plant_mujoco_set_dof_damping(self.model, dofadr as c_int, damping) };
+    }
+
     /// `mjData::xmat[body_id]`, row-major, exactly `data.xmat[body].reshape(3,
     /// 3)` on the Python side. Exists so the I1c Rust-hosted impulse harness
     /// (AC6) can compute ground-truth pitch with
@@ -662,6 +697,55 @@ mod tests {
     fn timestep_matches_the_onewheel_models_documented_option() {
         let plant = Plant::open(&model_path()).expect("the onewheel model should load");
         assert_eq!(plant.timestep(), 0.002);
+    }
+
+    /// `wheel_hinge`'s declared `damping="0.08"` (`sim/models/overboard_onewheel.xml`),
+    /// read and round-tripped through `dof_damping`/`set_dof_damping` -- the
+    /// FFI plumbing ADR-0011 criterion (g)'s damping sweep (issue #229) needs
+    /// to vary that constant at runtime instead of editing `sim/models/` and
+    /// rebuilding for every sweep point.
+    #[test]
+    fn dof_damping_reads_the_declared_value_and_set_dof_damping_round_trips() {
+        let mut plant = Plant::open(&model_path()).expect("the onewheel model should load");
+        let dofadr = plant
+            .joint_dofadr("wheel_hinge")
+            .expect("the onewheel model declares a wheel_hinge joint");
+        assert_eq!(
+            plant.dof_damping(dofadr),
+            0.08,
+            "wheel_hinge's damping is declared as 0.08 in the model; if this ever moves, the \
+             0.5x-2x sweep in tests/test_damping_sweep.py is sweeping around the wrong centre"
+        );
+
+        plant.set_dof_damping(dofadr, 0.16);
+        assert_eq!(
+            plant.dof_damping(dofadr),
+            0.16,
+            "the write did not round-trip"
+        );
+
+        // Setting a DIFFERENT dof must not perturb this one -- a shared
+        // damping array indexed wrong would silently move every joint's
+        // damping together instead of the one requested.
+        if let Some(other_dofadr) = plant.joint_dofadr("frame_free") {
+            plant.set_dof_damping(other_dofadr, 5.0);
+            assert_eq!(
+                plant.dof_damping(dofadr),
+                0.16,
+                "writing frame_free's damping must not touch wheel_hinge's"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "before the first Plant::step")]
+    fn set_dof_damping_after_a_step_panics() {
+        let mut plant = Plant::open(&model_path()).expect("the onewheel model should load");
+        let dofadr = plant
+            .joint_dofadr("wheel_hinge")
+            .expect("wheel_hinge exists");
+        plant.step();
+        plant.set_dof_damping(dofadr, 0.5);
     }
 
     #[test]

--- a/crates/plant-mujoco/src/shim.c
+++ b/crates/plant-mujoco/src/shim.c
@@ -225,6 +225,22 @@ int plant_mujoco_joint_dofadr(void* model, int joint_id) {
   return ((mjModel*)model)->jnt_dofadr[joint_id];
 }
 
+// `mjModel::dof_damping[dofadr]` -- read AND write, for the same reason
+// `plant_mujoco_get_gravity`/`plant_mujoco_set_gravity` are: ADR-0011
+// criterion (g) requires a damping sweep (0.5x-2x on the wheel-hinge joint)
+// to be TAKEN, not assumed, and the model's own `damping="0.08"` can
+// otherwise only be varied by editing sim/models/ and rebuilding. A 1-DOF
+// joint (e.g. `wheel_hinge`, a hinge) has exactly one damping slot at its
+// dofadr; this is not valid for a multi-DOF joint (free/ball), which the
+// caller must not pass here.
+double plant_mujoco_get_dof_damping(void* model, int dofadr) {
+  return ((mjModel*)model)->dof_damping[dofadr];
+}
+
+void plant_mujoco_set_dof_damping(void* model, int dofadr, double damping) {
+  ((mjModel*)model)->dof_damping[dofadr] = damping;
+}
+
 // The only WRITE path into qpos/qvel this crate exposes, and deliberately a
 // RANGE write rather than a whole-array one (issue #163's kinematic yaw
 // injection): the caller names exactly which slots it means, so a bug can

--- a/crates/sim-backend/src/lib.rs
+++ b/crates/sim-backend/src/lib.rs
@@ -206,6 +206,15 @@ pub struct SimBackend {
     /// value, so a run with no incline is bit-identical to one built before
     /// this knob existed.
     incline_deg: f64,
+    /// **Verification only.** Multiplier on the `wheel_hinge` joint's
+    /// `mjModel::dof_damping`, applied at `open()`. See
+    /// [`SimBackend::set_damping_scale`]. `None` (the default) leaves the
+    /// model's declared damping untouched -- not applied as an implicit
+    /// `1.0`, so a run with no override is bit-identical to one built before
+    /// this knob existed. Deliberately not an `f64` defaulting to `1.0`:
+    /// `#[derive(Default)]` would give `0.0`, which is a real (and
+    /// destructive) damping multiplier, not an identity value.
+    damping_scale: Option<f64>,
 }
 
 impl SimBackend {
@@ -275,6 +284,26 @@ impl SimBackend {
     /// an estimator fault.
     pub fn set_incline_deg(&mut self, incline_deg: f64) {
         self.incline_deg = incline_deg;
+    }
+
+    /// **Verification only.** Scales the `wheel_hinge` joint's declared
+    /// `mjModel::dof_damping` by `scale`, taking effect at the next `open()`.
+    /// `None` (the default -- see [`SimBackend::set_incline_deg`]'s sibling
+    /// field for why) leaves the model's declared damping untouched.
+    ///
+    /// ADR-0011 criterion (g): "every pass must hold across a damping sweep
+    /// of 0.5x-2x" on `wheel_hinge`'s `damping="0.08"`, the only load-bearing
+    /// constant in the MJCF with no provenance comment. That sweep needs a
+    /// runtime knob or it can only be taken by editing `sim/models/` (Sr.
+    /// Mechanical & Systems' fidelity contract) and rebuilding for every
+    /// point -- the same reasoning [`SimBackend::set_incline_deg`] already
+    /// established for the incline tolerance sweep.
+    ///
+    /// A no-op (`None`) on a model that declares no `wheel_hinge` joint,
+    /// rather than an error -- same tolerance [`SimBackend::apply_external_force`]
+    /// has for a body/site a model does not declare.
+    pub fn set_damping_scale(&mut self, scale: Option<f64>) {
+        self.damping_scale = scale;
     }
 
     /// As [`SimBackend::with_params`], but with a non-default imperfection
@@ -429,6 +458,15 @@ impl SimBackend {
     /// `mjModel::opt.gravity`, which `mj_resetData` does NOT touch, but
     /// re-asserting it keeps this path honestly identical to `open()`'s
     /// rather than relying on that.
+    ///
+    /// The damping override (`damping_scale`) is deliberately NOT re-applied
+    /// here, unlike the incline. `mjModel::dof_damping` is also untouched by
+    /// `mj_resetData`, so `open()`'s scaling is still in effect -- but
+    /// re-deriving it the way the incline block does would read the ALREADY
+    /// scaled value as `base` and scale it again, compounding on every reset.
+    /// The incline block avoids this only because rotating a vector preserves
+    /// its magnitude; multiplying a damping coefficient by a scale has no
+    /// such property.
     ///
     /// # Panics
     /// If called before `open()`.
@@ -766,6 +804,18 @@ impl BoardObserve for SimBackend {
             let mag = (g[0] * g[0] + g[1] * g[1] + g[2] * g[2]).sqrt();
             let (s, c) = self.incline_deg.to_radians().sin_cos();
             plant.set_gravity([mag * s, 0.0, -mag * c]);
+        }
+
+        // The damping override, if any -- same "before forward()" placement
+        // as the incline above, and for the same underlying rule
+        // (`Plant::set_dof_damping` must run before the first `Plant::step`).
+        // A no-op on a model with no `wheel_hinge` joint (the ballast lookups
+        // further down tolerate the same kind of absence).
+        if let Some(scale) = self.damping_scale {
+            if let Some(dofadr) = plant.joint_dofadr("wheel_hinge") {
+                let base = plant.dof_damping(dofadr);
+                plant.set_dof_damping(dofadr, base * scale);
+            }
         }
 
         // AC8 (issue #107, carried forward from I1b/#106): the CONTROLLED
@@ -1196,6 +1246,63 @@ mod tests {
         let mut b = opened();
         b.arm().unwrap();
         b
+    }
+
+    /// The `wheel_hinge` dof this backend's own damping override targets,
+    /// read directly off the opened plant -- the same accessor `open()`
+    /// itself uses, so this fails first if the joint name or lookup ever
+    /// drifts, before any test relying on it produces a confusing result.
+    fn wheel_hinge_damping(b: &SimBackend) -> f64 {
+        let dofadr = b
+            .plant
+            .as_ref()
+            .expect("backend must be open")
+            .joint_dofadr("wheel_hinge")
+            .expect("the onewheel model declares a wheel_hinge joint");
+        b.plant.as_ref().unwrap().dof_damping(dofadr)
+    }
+
+    /// ADR-0011 criterion (g)'s sweep needs `set_damping_scale` to actually
+    /// scale the model's declared damping, and needs `None` (the default) to
+    /// leave it untouched -- mirroring `set_incline_deg`'s own "zero is a
+    /// true no-op, not merely small" guarantee.
+    #[test]
+    fn set_damping_scale_scales_the_declared_wheel_hinge_damping() {
+        let default = opened();
+        assert_eq!(
+            wheel_hinge_damping(&default),
+            0.08,
+            "wheel_hinge's declared damping moved off 0.08 -- the sweep centre in \
+             tests/test_damping_sweep.py is now wrong"
+        );
+
+        let mut half = SimBackend::with_params(Params {
+            max_current_a: 40.0,
+            ..Params::default()
+        });
+        half.set_damping_scale(Some(0.5));
+        half.open().unwrap();
+        assert_eq!(wheel_hinge_damping(&half), 0.04);
+
+        let mut double = SimBackend::with_params(Params {
+            max_current_a: 40.0,
+            ..Params::default()
+        });
+        double.set_damping_scale(Some(2.0));
+        double.open().unwrap();
+        assert_eq!(wheel_hinge_damping(&double), 0.16);
+
+        let mut explicit_one = SimBackend::with_params(Params {
+            max_current_a: 40.0,
+            ..Params::default()
+        });
+        explicit_one.set_damping_scale(Some(1.0));
+        explicit_one.open().unwrap();
+        assert_eq!(
+            wheel_hinge_damping(&explicit_one),
+            0.08,
+            "an explicit scale of 1.0 must reproduce the declared value exactly"
+        );
     }
 
     /// `truth_body_pitch_rate_rad_s` must be the actual time derivative of

--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -14,7 +14,7 @@
 //!          [--free-run] [--max-sim-secs SECONDS]
 //!          [--pitch-source estimator|truth] [--pitch-bias-deg DEGREES]
 //!          [--cmd-reserve FRACTION] [--cmd-reserve-braking FRACTION]
-//!          [--incline-deg DEGREES] [--kerb [Y[,HEIGHT]]]
+//!          [--incline-deg DEGREES] [--damping-scale SCALE] [--kerb [Y[,HEIGHT]]]
 //!          [--terrain HFIELD.bin]
 //!          [--disturbance t0,dur,fx,fy,fz,tx,ty,tz] [--trace-csv PATH]
 //! ```
@@ -272,6 +272,25 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
                 cfg.incline_deg = deg;
+                i += 2;
+            }
+            // ADR-0011 criterion (g): "every pass must hold across a damping
+            // sweep of 0.5x-2x" on `wheel_hinge`'s `damping="0.08"`. See
+            // HostConfig::damping_scale.
+            "--damping-scale" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --damping-scale needs a value");
+                    return ExitCode::FAILURE;
+                };
+                let Ok(scale) = v.parse::<f64>() else {
+                    eprintln!("sim-host: --damping-scale value '{v}' is not a number");
+                    return ExitCode::FAILURE;
+                };
+                if !(0.0..=10.0).contains(&scale) {
+                    eprintln!("sim-host: --damping-scale must be within [0, 10], got {scale}");
+                    return ExitCode::FAILURE;
+                }
+                cfg.damping_scale = Some(scale);
                 i += 2;
             }
             // `t0,duration,fx,fy,fz,tx,ty,tz` -- world frame, SI. The kerb

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -1426,6 +1426,18 @@ pub struct HostConfig {
     /// that is the same problem and not an approximation of it.
     pub incline_deg: f64,
 
+    /// **Verification only.** Multiplier on the `wheel_hinge` joint's
+    /// declared `damping="0.08"`. `None` (the default) leaves the model's
+    /// declared damping untouched; no shipped configuration sets this.
+    ///
+    /// ADR-0011 criterion (g): "every pass must hold across a damping sweep
+    /// of 0.5x-2x" on that constant, which carries no provenance comment and
+    /// sets the whole speed-dependence of the full-stick flip (issue #229).
+    /// Applied by [`sim_backend::SimBackend::set_damping_scale`], the same
+    /// "runtime knob, not a `sim/models/` edit" pattern `incline_deg` above
+    /// established.
+    pub damping_scale: Option<f64>,
+
     /// **Verification only.** Writes one CSV row per control cycle to this
     /// path when the run ends. Buffered in memory and written once, never
     /// during the loop: a 500 Hz control thread does not do file I/O per
@@ -1517,6 +1529,7 @@ impl Default for HostConfig {
             cmd_envelope_reserve_braking: None,
             disturbance: None,
             incline_deg: 0.0,
+            damping_scale: None,
             trace_path: None,
             kerb: None,
             terrain: None,
@@ -1806,6 +1819,8 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     // Before `open()`, which is where the tilt is applied -- see
     // `HostConfig::incline_deg`.
     backend.set_incline_deg(cfg.incline_deg);
+    // Before `open()`, same reason -- see `HostConfig::damping_scale`.
+    backend.set_damping_scale(cfg.damping_scale);
     backend.open().map_err(HostError::Backend)?;
     // Armed unconditionally at startup, the same way every other Rust-hosted
     // harness in this repo arms (`impulse-response-rust`, `sim-backend`'s own

--- a/roles/senior-controls/log/2026-08-12-damping-sweep-knob.md
+++ b/roles/senior-controls/log/2026-08-12-damping-sweep-knob.md
@@ -1,0 +1,55 @@
+# Issue #229 — ADR-0011 criterion (g), a runtime damping override and the sweep itself
+
+**PR:** #TBD (`fix/controls/damping-sweep-knob`)
+
+## What
+
+`wheel_hinge`'s `damping="0.08"` (both MJCF models) could previously only be varied by
+editing `sim/models/` (Sr. Mechanical & Systems' fidelity contract) and rebuilding for
+every sweep point — so ADR-0011 criterion (g) ("every pass must hold across a damping
+sweep of 0.5x-2x") had never actually been taken, at either the 40 A or 60 A operating
+point. Added a runtime knob mirroring `--incline-deg`'s own pattern exactly:
+
+- `plant-mujoco`: `plant_mujoco_get_dof_damping`/`plant_mujoco_set_dof_damping` (shim.c),
+  `Plant::dof_damping`/`Plant::set_dof_damping` (safe wrapper, same "before the first
+  step" panic contract `set_gravity` carries).
+- `sim-backend`: `SimBackend::set_damping_scale(Option<f64>)`, applied at `open()`
+  against `wheel_hinge`'s dofadr. Deliberately `Option<f64>` rather than an `f64`
+  defaulting to `1.0` — `#[derive(Default)]` would silently default to `0.0`, a real
+  (and destructive) multiplier, not an identity value. Not re-applied in `reset()` the
+  way the incline is: `dof_damping` is a model field `mj_resetData` does not touch, and
+  unlike `set_gravity`'s reapply (which is idempotent because rotation preserves
+  magnitude), reapplying `base * scale` from an already-scaled value would compound on
+  every reset.
+- `sim-host`: `--damping-scale SCALE` CLI flag, threaded through `HostConfig`.
+
+## The measurement (Ask 2)
+
+Took the sweep at the current 40 A operating point (the 60 A packet is withdrawn per
+ADR-0011's second ratification). **Criterion (g), taken literally, fails.** Both
+deployed-path entries of the criterion (a) matrix hold cleanly through 1.4x
+(peak lean 9.0°) and invert at 1.5x (8.04 s) and every point above it — a real cliff,
+not numerical noise, reaching full inversion by 5.64 s at 2.0x. At the model's own
+declared damping (1.0x) both scenarios hold with real margin; this is not a claim that
+today's board is unsafe, it is a measured, false robustness claim in the exact place
+the criterion exists to check for. Full sweep table in
+`tests/test_damping_sweep.py::test_the_acceptance_matrix_does_not_hold_across_the_full_0_5x_2x_sweep`,
+written `xfail(strict=True)` per this repo's own convention for a measured, not-yet-fixed
+criterion — so it turns XPASS the day someone lands a fix, rather than staying a silent
+green.
+
+## Deliberately left out (Ask 3)
+
+Whether this blocks the launch-hold exit or is re-homed to the hardware gate (the way
+criterion (a)-3, the kerb strike, already was) is a decision, not a measurement, and not
+mine to make alone — flagged in the issue and in the PR rather than decided here.
+
+## Verification
+
+`cargo build`/`clippy -D warnings`/`test --workspace` clean on the touched crates (no
+regressions: 17+37+39 pre-existing tests still pass, plus 5 new ones — 2 Rust unit tests,
+3 Python). `cargo fmt` clean. `python3 -m pytest tests/test_damping_sweep.py` — 3 passed,
+1 xfailed as designed. `python3 .github/policy_check.py` — all hard checks pass, every
+touched path resolves to Senior Controls turf. `cargo run -p xtask -- gate` — unrelated
+pre-existing finding only (`hal-actuate`/`plant-mujoco` unreachable from
+`board-app-ridden`).

--- a/tests/test_damping_sweep.py
+++ b/tests/test_damping_sweep.py
@@ -1,0 +1,203 @@
+"""ADR-0011 criterion (g) -- the wheel-hinge damping sweep, MEASURED.
+
+Issue #229's finding: criterion (g) ("every pass must hold across a damping
+sweep of 0.5x-2x on the wheel-hinge damping=0.08") had never actually been
+taken, at either the 40 A or 60 A operating point -- there was no way to vary
+`wheel_hinge`'s declared damping without editing `sim/models/` (Sr.
+Mechanical & Systems' fidelity contract) and rebuilding for every sweep
+point. `sim-host`'s `--damping-scale` flag exists to close exactly that gap,
+the same "runtime knob, not a model edit" pattern `--incline-deg` already
+established for the incline-tolerance sweep (`test_incline_tolerance.py`).
+
+WHAT THIS FILE FOUND
+---------------------
+Criterion (g), taken literally, FAILS at the current 40 A operating point.
+Both deployed-path entries of ADR-0011's criterion (a) matrix (full stick
+from rest, the stick-reversal at speed) invert well inside the 0.5x-2x
+sweep -- there is a real cliff between 1.4x (holds, peak 9.0 deg) and 1.5x
+(inverts at 8.04 s). The full range up to 2x is not a close call: at 2x
+damping the board is upside down by 5.64 s. See
+`test_the_acceptance_matrix_does_not_hold_across_the_full_0_5x_2x_sweep`,
+marked `xfail(strict=True)` for the same reason `test_cmd_envelope_reserve.py`
+marks its own known-failing criteria that way: written as the criterion
+SHOULD read, not softened into something that passes, so the day someone
+fixes the underlying problem this turns red as XPASS rather than staying a
+silent, uninformative green.
+
+This does NOT mean the board is unsafe at today's *declared* damping (1.0x,
+`wheel_hinge`'s actual `damping="0.08"`) -- that point holds cleanly in both
+scenarios, and is asserted as a plain (non-xfail) test below. It means the
+specific claim "the pass is robust to a 2x error in that undocumented
+constant" is false, which is exactly the thing criterion (g) exists to
+check for, and exactly the kind of finding ADR-0011 says should not be
+tuned away or silently absorbed into a passing threshold.
+
+Whether this blocks the launch-hold exit, or is re-homed to the hardware
+gate the way criterion (a)-3 (the kerb strike) already was, is issue #229's
+open Ask 3 -- a decision, not a measurement, and not this file's call.
+
+DETERMINISM
+-----------
+Same rule as `test_incline_tolerance.py` and `test_cmd_envelope_reserve.py`:
+every run is `--scripted-scenario ... --free-run`, schedule indexed on
+simulated time, fixed-timestep RK4, no stochastic terms -- reproducible bit
+for bit.
+
+THE BINARY MUST BE BUILT. Same rule as the two files above: FAILS, not
+skips, if it is missing.
+"""
+
+from __future__ import annotations
+
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+#: Ports well away from every other test file's own pair (19601-19606) --
+#: see test_incline_tolerance.py's own comment on why this matters.
+STATE_OUT = "127.0.0.1:19607"
+INPUT_IN = "127.0.0.1:19608"
+
+#: Pitch beyond which the board is unambiguously going over -- same
+#: threshold `test_incline_tolerance.py` uses.
+INVERTED_DEG = 90.0
+
+#: `wheel_hinge`'s declared damping in both MJCF models
+#: (`sim/models/overboard_onewheel.xml`, `overboard_rider.xml`). The sweep
+#: below is centred on this; if it ever moves, re-derive the sweep rather
+#: than assume it is still 0.08.
+DECLARED_DAMPING = 0.08
+
+#: ADR-0011 criterion (g)'s own stated range.
+SWEEP_LO, SWEEP_HI = 0.5, 2.0
+
+#: The measured cliff (see module docstring): holds through 1.4x, inverts at
+#: 1.5x and above, on both swept scenarios.
+CLIFF_SCALES = (0.5, 1.0, 1.2, 1.4, 1.5, 1.6, 1.8, 2.0)
+
+
+def _run(tmp_path: Path, name: str, scenario: str, **kw) -> list[dict]:
+    """One deterministic free run; returns the per-cycle trace.
+
+    Through `cargo run` rather than the raw binary -- see
+    `test_cmd_envelope_reserve.py`'s own comment: Cargo puts the linked
+    libmujoco's `OUT_DIR` on the dynamic loader path.
+    """
+    out = tmp_path / f"{name}.csv"
+    argv = [
+        "cargo", "run", "--release", "-q", "-p", "sim-host", "--bin", "sim-host", "--",
+        "--scripted-scenario", scenario,
+        "--free-run",
+        "--stats-path", "none",
+        "--pitch-source", "estimator",
+        "--state-out-addr", STATE_OUT,
+        "--input-in-addr", INPUT_IN,
+        "--trace-csv", str(out),
+    ]
+    for flag, value in kw.items():
+        if value is None:
+            continue
+        argv += [f"--{flag.replace('_', '-')}", str(value)]
+    proc = subprocess.run(argv, cwd=REPO, capture_output=True, text=True)
+    assert proc.returncode == 0, f"sim-host failed:\n{proc.stderr[-4000:]}"
+    with out.open() as f:
+        return [{k: float(v) for k, v in row.items()} for row in csv.DictReader(f)]
+
+
+def _inversion_time(rows):
+    return next((r["sim_time_s"] for r in rows if abs(r["truth_pitch_deg"]) > INVERTED_DEG), None)
+
+
+def test_the_sim_host_binary_is_actually_built():
+    assert (REPO / "target" / "release" / "sim-host").exists(), (
+        "sim-host is not built, so this whole gate would be vacuous. Run:\n"
+        "    cargo build --release -p sim-host --bin sim-host"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The positive control: is `--damping-scale` a no-op at 1.0, the way
+# `--incline-deg 0` is a no-op at zero?
+# ---------------------------------------------------------------------------
+
+
+def test_a_damping_scale_of_one_is_bit_identical_to_omitting_the_flag(tmp_path):
+    """`SimBackend::set_damping_scale`'s `None` case is exercised by omitting
+    the flag; an explicit `1.0` takes the `Some` path and re-derives the same
+    value from the model. Both must produce the identical trajectory, or the
+    knob is perturbing every other test in this repo that never passes it.
+
+    `crates/sim-backend/src/lib.rs::set_damping_scale_scales_the_declared_wheel_hinge_damping`
+    already checks this at the Rust unit level (the damping VALUE matches);
+    this is the black-box counterpart (the resulting TRAJECTORY matches).
+    """
+    unset = _run(tmp_path, "ds_unset", "full-stick")
+    explicit_one = _run(tmp_path, "ds_one", "full-stick", damping_scale=1.0)
+    assert [list(r.values()) for r in unset] == [list(r.values()) for r in explicit_one], (
+        "--damping-scale 1.0 is not bit-identical to omitting the flag, so the "
+        "knob perturbs a default run and every other test in this repo is now "
+        "measuring something slightly different"
+    )
+
+
+# ---------------------------------------------------------------------------
+# What holds today, at the model's own declared damping
+# ---------------------------------------------------------------------------
+
+
+def test_the_acceptance_matrix_holds_at_the_declared_damping(tmp_path):
+    """Not a criterion (g) claim -- criterion (g) is about ROBUSTNESS to an
+    error in the constant, not about today's board being flyable at its own
+    declared value. This is the baseline the sweep below is measured against.
+    """
+    for scenario in ("full-stick", "stick-reversal"):
+        rows = _run(tmp_path, f"declared_{scenario}", scenario, damping_scale=1.0)
+        t = _inversion_time(rows)
+        assert t is None, (
+            f"{scenario} inverted at {t:.3f} s at the MODEL'S OWN declared damping "
+            f"({DECLARED_DAMPING}) -- that is not a criterion (g) finding, it is a "
+            "plant regression and belongs to whoever's change caused it"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Criterion (g) itself, taken literally
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ADR-0011 criterion (g), literal reading: 'every pass must hold across "
+        "a damping sweep of 0.5x-2x'. Measured at the current 40 A operating "
+        "point: it does not. Both full-stick-from-rest and the stick-reversal "
+        "hold cleanly through 1.4x (peak 9.0 deg) and invert at 1.5x (8.04 s) "
+        "and every point above it, reaching full inversion by 5.64 s at 2.0x. "
+        "This is a real cliff, not numerical noise -- see the printed sweep "
+        "table. Whether this blocks the launch-hold exit or is re-homed to the "
+        "hardware gate (as criterion (a)-3, the kerb strike, already was) is "
+        "issue #229's open decision, not this test's to make."
+    ),
+)
+def test_the_acceptance_matrix_does_not_hold_across_the_full_0_5x_2x_sweep(tmp_path):
+    for scenario in ("full-stick", "stick-reversal"):
+        print(f"\n{scenario} across the damping sweep ({SWEEP_LO}x-{SWEEP_HI}x):")
+        for scale in CLIFF_SCALES:
+            rows = _run(tmp_path, f"g_{scenario}_{scale}", scenario, damping_scale=scale)
+            t = _inversion_time(rows)
+            peak_pitch = max(abs(r["truth_pitch_deg"]) for r in rows)
+            print(
+                f"  {scale:4.2f}x (damping={scale * DECLARED_DAMPING:.3f}): "
+                f"{'held' if t is None else f'INVERTED at {t:.2f} s'}, "
+                f"peak lean {peak_pitch:6.2f} deg"
+            )
+            assert t is None, (
+                f"{scenario} inverted at {t:.3f} s at damping scale {scale}x -- "
+                "criterion (g) does not hold across the full swept range"
+            )


### PR DESCRIPTION
## What changed

`wheel_hinge`'s `damping="0.08"` (both MJCF models) could previously only be varied by editing `sim/models/` (Sr. Mechanical & Systems' fidelity contract) and rebuilding for every sweep point — so ADR-0011 criterion (g) ("every pass must hold across a damping sweep of 0.5x-2x") had never actually been taken, at either the 40 A or 60 A operating point (see the ADR's own "criterion (g)" note and issue #229).

Adds a runtime knob, mirroring `--incline-deg`'s own established pattern end to end:

- `crates/plant-mujoco/src/shim.c` + `src/lib.rs`: `Plant::dof_damping`/`Plant::set_dof_damping` over `mjModel::dof_damping`, same "must be called before the first `Plant::step`" contract `set_gravity` carries.
- `crates/sim-backend/src/lib.rs`: `SimBackend::set_damping_scale(Option<f64>)`, applied at `open()` against `wheel_hinge`'s dofadr. Deliberately `Option<f64>` rather than a bare `f64` — `#[derive(Default)]` would silently default to `0.0`, a real (and destructive) multiplier, not an identity value. Not re-applied in `reset()` the way the incline is, and the doc comment there explains why: `dof_damping` is a model field `mj_resetData` doesn't touch, and unlike `set_gravity`'s reapply (idempotent because rotation preserves magnitude), reapplying `base * scale` from an already-scaled value would compound on every reset.
- `crates/sim-host`: `--damping-scale SCALE` CLI flag, threaded through `HostConfig`.

## The measurement (issue #229's Ask 2)

Took the sweep at the current 40 A operating point (the 60 A packet is withdrawn per ADR-0011's second ratification). **Criterion (g), taken literally, fails.** Both deployed-path entries of the criterion (a) matrix (full-stick-from-rest, the stick-reversal) hold cleanly through 1.4x (peak lean 9.0°) and invert at 1.5x (8.04 s) and every point above it — a real cliff, not numerical noise, reaching full inversion by 5.64 s at 2.0x.

This is **not** a claim that today's board is unsafe: at the model's own declared damping (1.0x) both scenarios hold with real margin (asserted as a plain, non-xfail test). It's a measured, false robustness claim in exactly the place criterion (g) exists to check for.

Full sweep table and the measurement itself are in `tests/test_damping_sweep.py`, written `xfail(strict=True)` per this repo's existing convention (`test_cmd_envelope_reserve.py`) for a measured, not-yet-fixed criterion — so it turns XPASS the day someone lands a fix, rather than staying a silently uninformative green.

## Deliberately left out (issue #229's Ask 3)

Whether this blocks the launch-hold exit or is re-homed to the hardware gate — the way criterion (a)-3, the kerb strike, already was — is a decision, not a measurement, and not mine to make alone. Flagged here rather than decided.

## Verification

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test --workspace` clean on every touched crate — no regressions (17+37+39 pre-existing tests still pass), plus 5 new tests (2 Rust unit tests in `plant-mujoco`/`sim-backend`, 3 Python in `tests/test_damping_sweep.py`).
- `cargo fmt --check` clean.
- `python3 -m pytest tests/test_damping_sweep.py -v` — 3 passed, 1 xfailed as designed.
- `python3 .github/policy_check.py` — all hard checks pass; every touched path resolves to Senior Controls turf.
- `cargo run -p xtask -- gate` — one pre-existing, unrelated finding only (`hal-actuate`/`plant-mujoco` unreachable from `board-app-ridden`).

Closes #229.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GBuG97VVjnC98xoaUJu82a)_