### PR TITLE
fix(controls): the wheel-odometry estimator path inverts at full stick -- unpinned before this (#227)

### DIFF
--- a/crates/sim-host/src/bin/sim-host.rs
+++ b/crates/sim-host/src/bin/sim-host.rs
@@ -13,6 +13,7 @@
 //!          [--stats-path PATH|none]
 //!          [--free-run] [--max-sim-secs SECONDS]
 //!          [--pitch-source estimator|truth] [--pitch-bias-deg DEGREES]
+//!          [--estimator-aiding command-feedforward|wheel-odometry]
 //!          [--cmd-reserve FRACTION] [--cmd-reserve-braking FRACTION]
 //!          [--incline-deg DEGREES] [--kerb [Y[,HEIGHT]]]
 //!          [--terrain HFIELD.bin]
@@ -132,6 +133,28 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 };
                 cfg.max_sim_time_s = Some(secs);
+                i += 2;
+            }
+            // Issue #227: which signal aids the complementary filter's
+            // accelerometer branch. `command-feedforward` is the deployed
+            // default and the only path (f1)/(f2) pinned before this issue;
+            // `wheel-odometry` is what `hill.py`/`terrain.py` actually run.
+            "--estimator-aiding" => {
+                let Some(v) = args.get(i + 1) else {
+                    eprintln!("sim-host: --estimator-aiding needs a value");
+                    return ExitCode::FAILURE;
+                };
+                cfg.estimator_aiding = match v.as_str() {
+                    "command-feedforward" => sim_host::host::EstimatorAiding::CommandFeedforward,
+                    "wheel-odometry" => sim_host::host::EstimatorAiding::WheelOdometry,
+                    other => {
+                        eprintln!(
+                            "sim-host: unknown --estimator-aiding '{other}' \
+                             (want: command-feedforward, wheel-odometry)"
+                        );
+                        return ExitCode::FAILURE;
+                    }
+                };
                 i += 2;
             }
             // ADR-0011 criterion (f): "every pass must hold with the

--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -131,7 +131,9 @@ use crate::wire::{self, InputIn, StateOut};
 use board_types::{
     Command, Faults, ImuSample, Params, Saturation, DEFAULT_R_EFF_M, RAD_S_PER_ERPM,
 };
-use control_core::{CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator};
+use control_core::{
+    CommandFeedforward, ComplementaryFilter, Estimator, PitchRegulator, WheelAccelEstimator,
+};
 use hal::BoardObserve;
 use hal_actuate::BoardActuate;
 use safety::Envelope;
@@ -551,6 +553,12 @@ const ESTIMATOR_TAU_S: f32 = 2.0;
 /// rather than passing its own gain, so this host does too, duplicated here
 /// because this host does not link `control-ffi`.
 const ACCEL_FF_GAIN_M_S2_PER_A: f32 = 0.0584;
+/// `impulse-response-rust`'s own constant (`crates/board-app-driverless/src/
+/// bin/impulse-response-rust.rs`), which mirrors `RustController()`'s
+/// `wheel_accel_tau_s` default (`sim/scenarios/rust_controller.py`).
+/// Duplicated here for the same reason `ACCEL_FF_GAIN_M_S2_PER_A` above is:
+/// this host does not link `control-ffi`.
+const WHEEL_ACCEL_TAU_S: f32 = 0.05;
 
 /// `weight_shift_fore_aft` / `weight_shift_lateral`, both clamped to
 /// `[-1, 1]` on the wire, map linearly onto this range -- the SAME +/-0.05 m
@@ -1341,6 +1349,10 @@ pub struct HostConfig {
     /// exists.
     pub pitch_source: PitchSource,
 
+    /// **Verification only.** Which signal aids the complementary filter's
+    /// accelerometer branch. See [`EstimatorAiding`]; issue #227.
+    pub estimator_aiding: EstimatorAiding,
+
     /// **Verification only.** A static pitch offset, DEGREES, added to
     /// whatever [`HostConfig::pitch_source`] hands the regulator. Positive is
     /// nose-up, matching ICD 10.1.
@@ -1477,6 +1489,31 @@ pub enum PitchSource {
     PlantTruth,
 }
 
+/// Which signal aids the complementary filter's accelerometer branch --
+/// issue #227.
+///
+/// ADR-0011's (f1)/(f2) freeze-and-pin regression-tests only the
+/// [`CommandFeedforward`] path, because until now this host offered no
+/// other one to test: `hill.py`/`terrain.py` (and therefore
+/// `tests/test_terrain.py`, which found the anomaly (f1)/(f2) are cited
+/// against) default to `control-ffi`'s wheel-odometry aiding instead, via
+/// [`WheelAccelEstimator`]. This enum makes that second path selectable
+/// here too, so it can be measured rather than assumed to behave the same.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EstimatorAiding {
+    /// Predicts the acceleration from the current just commanded --
+    /// `RustController()`'s mode 2. The deployed default: matches
+    /// `shuttle_run.py`'s "recommended configuration" and every ADR-0011
+    /// acceptance number measured so far.
+    #[default]
+    CommandFeedforward,
+    /// Measures the acceleration by differentiating wheel speed --
+    /// `RustController()`'s mode 1, and `hill.py`/`terrain.py`'s default.
+    /// Not pinned before issue #227; see
+    /// `tests/test_cmd_envelope_reserve.py` for the coverage this adds.
+    WheelOdometry,
+}
+
 /// A scheduled external force/torque disturbance, world frame, applied to the
 /// `frame` body over a fixed window of SIMULATED time.
 ///
@@ -1511,6 +1548,7 @@ impl Default for HostConfig {
             scripted_scenario: None,
             max_sim_time_s: None,
             pitch_source: PitchSource::Estimator,
+            estimator_aiding: EstimatorAiding::CommandFeedforward,
             pitch_bias_deg: 0.0,
             free_run: false,
             cmd_envelope_reserve: None,
@@ -1832,6 +1870,10 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
     let regulator = PitchRegulator::new(KP_NM_PER_RAD, KD_NM_PER_RAD_S);
     let mut estimator = ComplementaryFilter::with_trust_band(ESTIMATOR_TAU_S, 0.0);
     let accel_ff = CommandFeedforward::new(ACCEL_FF_GAIN_M_S2_PER_A);
+    // Only advanced when `cfg.estimator_aiding` selects it (issue #227) --
+    // built unconditionally anyway, since a `WheelAccelEstimator` is cheap
+    // and this keeps the loop body below free of a branch on construction.
+    let mut wheel_accel = WheelAccelEstimator::new(WHEEL_ACCEL_TAU_S);
     // Last cycle's POST-envelope commanded current, amps -- the feedforward's
     // input (mode 2 / "commanded", matching `shuttle_run.py`'s own default
     // `accel_ff_current_source`, rather than the measured-current mode
@@ -2253,11 +2295,11 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let obs = backend.wait_observe().map_err(HostError::Backend)?;
         t_known_s = obs.t_recv_ns as f64 * 1e-9;
 
-        // Controller: raw IMU -> estimate -> regulate -> envelope. Mode 2
-        // (command feedforward), matching `shuttle_run.py`'s tuned ridden
-        // config -- "the recommended configuration" per that scenario's own
-        // comment. `pitch_ref` is always 0: no outer loop (see this file's
-        // header).
+        // Controller: raw IMU -> estimate -> regulate -> envelope. Aiding
+        // mode is `cfg.estimator_aiding` (default: command feedforward,
+        // matching `shuttle_run.py`'s tuned ridden config -- "the
+        // recommended configuration" per that scenario's own comment).
+        // `pitch_ref` is always 0: no outer loop (see this file's header).
         let sample = obs.newest_imu().copied().unwrap_or(ImuSample::ZERO);
         let wheel_rate_rad_s = obs.erpm * RAD_S_PER_ERPM;
         // Real forward ground speed, m/s, signed -- computed here (rather
@@ -2267,7 +2309,15 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         // `last_forward_speed_m_s` above) at the end of this loop body.
         let forward_speed_m_s = wheel_rate_rad_s * DEFAULT_R_EFF_M;
         last_forward_speed_m_s = forward_speed_m_s;
-        let aiding = accel_ff.predict(last_amps);
+        // Issue #227: the two aiding sources are mutually exclusive, matching
+        // `control-ffi`'s "at most one is Some" (`crates/control-ffi/src/
+        // lib.rs`). `wheel_accel` is only ADVANCED on the branch that uses
+        // it, so its filter state does not silently accumulate on a run that
+        // never reads it.
+        let aiding = match cfg.estimator_aiding {
+            EstimatorAiding::CommandFeedforward => accel_ff.predict(last_amps),
+            EstimatorAiding::WheelOdometry => wheel_accel.update(forward_speed_m_s, DT_S as f32),
+        };
         // The estimator runs on EVERY run, including a `PitchSource::
         // PlantTruth` acceptance run where the regulator is not listening to
         // it -- it is the only signal path a real board has, and an

--- a/tests/test_cmd_envelope_reserve.py
+++ b/tests/test_cmd_envelope_reserve.py
@@ -15,12 +15,20 @@ measured number, (a)-entry-1 full stick from rest, (a)-entry-2 the full stick
 reversal at speed -- which the ADR records as never having been tested and
 names as the worst case.
 
-Two do not pass, at any value of the constant, and are written here as
+Three do not pass, at any value of the constant, and are written here as
 `xfail(strict=True)`:
 
 * **(a)-entry-3, the kerb strike.** During a full-stick hold the board cannot
   ride out a strike much above a 1 mm lip.
 * **(f), "every pass must hold with the estimator bias removed".**
+* **(a)-entry-1, ON THE WHEEL-ODOMETRY ESTIMATOR PATH (issue #227).** Every
+  test above this line runs `CommandFeedforward` aiding -- the only path this
+  file covered before issue #227. `hill.py`/`terrain.py` (and therefore
+  `tests/test_terrain.py`) default to the OTHER aiding source,
+  `WheelAccelEstimator`, which is unpinned by anything above and, measured
+  here, does not survive the same full-stick-from-rest hold the
+  `CommandFeedforward` path clears. See
+  `test_criterion_a1_full_stick_from_rest_does_not_invert_on_the_wheel_odometry_path`.
 
 They are written as the criteria SHOULD read, and marked expected-to-fail,
 rather than being softened into something that passes or left out. `strict=True`
@@ -28,6 +36,18 @@ matters: the day somebody fixes the underlying problem these turn RED as
 XPASS, which is the only mechanism that reliably tells a future session a known
 failure has stopped being one. A green suite that quietly stopped covering the
 thing it was written for is the failure mode this repo keeps hitting.
+
+WHY THE (f1)/(f2) TRIM PINS DO NOT COVER THE WHEEL-ODOMETRY PATH (issue #227)
+-------------------------------------------------------------------------------
+`PINNED_TRIM_DEG`/`PINNED_TRIM_BAND_DEG` below are measured and pinned only
+for `CommandFeedforward`, on FLAT GROUND -- neither the pin nor ADR-0011's
+text says so explicitly, and both should be read with that scope. An
+equivalent settled-trim pin for the wheel-odometry path is not written here
+because there is no settled trim to pin: that path inverts during the same
+full-stick-from-rest hold `test_criterion_a1_full_stick_from_rest_does_not_
+invert` (the `CommandFeedforward` version) clears, so criterion (a)-entry-1
+fails before the run ever reaches `TRIM_WINDOW_S`. A trim pin is downstream
+of surviving the hold; this path does not get there.
 
 WHY CRITERION (f) IS ALSO FLAGGED AS MIS-SPECIFIED
 ---------------------------------------------------
@@ -451,6 +471,51 @@ def test_criterion_a2_a_full_stick_reversal_at_speed_does_not_invert(tmp_path):
     assert _inversion_time(rows) is None, "a full stick reversal at speed inverted the board"
     print(f"\n(a)2 full stick reversal at speed -- {_margin(rows)}")
     assert _peak_pitch_deg(rows) < PITCH_CEILING_DEG
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Issue #227: on the WheelAccelEstimator (wheel-odometry) aiding path "
+        "-- the one hill.py/terrain.py actually run, not CommandFeedforward -- "
+        "a full-stick hold from rest inverts the board at 5.470 s, deterministic "
+        "to the bit (two runs diffed byte-identical). The envelope saturates at "
+        "4.502 s (close to CommandFeedforward's 4.92 s -- the shaped command "
+        "map does not depend on the aiding source), FALLEN trips at 5.196 s, "
+        "and the authority warning leads all of it at 3.618 s, but none of that "
+        "matters here: the board goes over anyway. CMD_ENVELOPE_RESERVE was "
+        "derived from, and only ever measured against, the CommandFeedforward "
+        "path's peak-demand slope (test_f2_...); it buys nothing on this one. "
+        "test_criterion_a2 (stick reversal) fails identically at the same "
+        "5.470 s, because both schedules share this build phase and the board "
+        "has already gone over before either schedule's reversal input would "
+        "arrive -- not filed as a second xfail since it is the same event, not "
+        "a second one. NOT a harness defect: the estimate tracks truth closely "
+        "throughout (both cross 90 deg within 0.1 deg of each other), so the "
+        "aiding is doing its job right up to the point where the job is not "
+        "survivable."
+    ),
+)
+def test_criterion_a1_full_stick_from_rest_does_not_invert_on_the_wheel_odometry_path(tmp_path):
+    """The (a1) positive control this file has been missing since it was
+    written -- every test above this line covers `CommandFeedforward` only.
+
+    Same schedule, same shipped `CMD_ENVELOPE_RESERVE`, same shaping -- the
+    only thing that changes is `--estimator-aiding wheel-odometry`, i.e.
+    which signal aids the complementary filter. See `EstimatorAiding` in
+    `host.rs` (issue #227) for why this option exists at all: it did not,
+    before this test needed it, because nothing on this signal path had ever
+    been measured against ADR-0011's own acceptance matrix.
+    """
+    rows = _run(
+        tmp_path, "a1wheel", "full-stick",
+        pitch_source="estimator", estimator_aiding="wheel-odometry",
+    )
+    t = _inversion_time(rows)
+    assert t is None, (
+        f"full stick from rest inverted the board at {t:.3f} s on the "
+        "wheel-odometry aiding path"
+    )
 
 
 def test_the_worst_point_in_the_matrix_is_quoted_in_both_currencies(tmp_path):


### PR DESCRIPTION
## What changed

`tests/test_cmd_envelope_reserve.py` is the evidence file for ADR-0011's freeze-and-pin exit criteria, but every test in it ran the controller with `CommandFeedforward` estimator aiding — `crates/sim-host/src/host.rs` hardcoded it and offered no other option. `sim/scenarios/hill.py` and `terrain.py` (and therefore `tests/test_terrain.py`, the suite that produced the anomaly ADR-0011's second ratification investigates) default to the *other* aiding source, `control-ffi`'s wheel-odometry `WheelAccelEstimator` — the path closer to what real hardware will run per `control-core`'s own docs. That path was unpinned by anything.

This PR:

1. Adds `EstimatorAiding` (`CommandFeedforward` / `WheelOdometry`) to `HostConfig`, wired the same way `control-ffi` already wires the two (mutually exclusive, matching `crates/control-ffi/src/lib.rs`'s "at most one is Some"), and a `--estimator-aiding` CLI flag on `sim-host`. Default is unchanged (`CommandFeedforward`), so every existing acceptance number in this file is untouched.
2. Measures the wheel-odometry path against ADR-0011's own criterion (a)-entry-1 ("full stick from rest does not invert"), which the deployed `CommandFeedforward` path clears. **It does not clear it**: full stick from rest inverts the board at **5.470 s**, deterministic to the bit (two runs diffed byte-identical). The command-envelope reserve was derived from, and only ever measured against, the `CommandFeedforward` path's peak-demand slope — it buys nothing on this one. Not a harness defect: the estimate tracks truth closely right up to the flip, so the aiding is doing its job correctly up to the point where the job isn't survivable.
3. Records this as a new strict `xfail`, matching the file's existing convention for criteria that fail on purpose (so a future fix shows up as a loud `XPASS` instead of a silently-widened bound).
4. Documents in the file header that the (f1)/(f2) trim pins (`PINNED_TRIM_DEG`/`PINNED_TRIM_BAND_DEG`) are `CommandFeedforward`-only, flat-ground measurements — true before this PR but not stated. No trim pin is added for the wheel-odometry path: there's no settled state to pin, because the board goes over before the run reaches `TRIM_WINDOW_S`. A trim pin is downstream of surviving the hold, and this path doesn't get there.

## Why this matters

"The estimator trim is frozen and pinned" does load-bearing work in ADR-0011's second ratification, but as written it was a claim about one estimator path while the scenarios that exercise the board over terrain use the other, unpinned one. This closes that specific gap by measuring it rather than assuming parity between the two paths — and the measurement is worse than "unpinned," it's "actively fails a criterion the pinned path passes."

`test_criterion_a2` (stick reversal) fails identically at the same 5.470 s, because both scripted schedules share the same full-stick-from-rest build phase and the board has already gone over before either schedule's reversal input would arrive. Not filed as a second `xfail` — it's the same event, not a second one.

## Acceptance criteria addressed (issue #227)

- Ask 2 ("add f1/f2-equivalent coverage for the wheel-odometry path, or record explicitly why the pin on one path is sufficient") — addressed: coverage added, and it's a failing criterion rather than a pinnable trim.
- Ask 1, the non-ADR half ("state the pin's scope explicitly... in `tests/test_cmd_envelope_reserve.py`") — addressed, in the file header.

## Deliberately left out

- **ADR-0011's own text is not amended.** `docs/decisions/` is COO turf; this PR only measures and gates code. The ADR itself still needs a decision about what this finding means for the launch hold.
- **Ask 3** ("decide whether world expansion beyond the gated 8% grade requires the deferred headroom-based fix first") is a decision, not a measurement, and stays open — it belongs in the Escalations queue, not in this diff.
- The grade-dependent trim characterisation (5×–38× outside the flat-ground band at 10–14% grade, also reported in #227) is not re-measured here; this PR is scoped to the full-stick acceptance-matrix gap specifically.

## Testing

- `cargo build --release -p sim-host --bin sim-host`, `cargo clippy --release -p sim-host --all-targets -- -D warnings`, `cargo fmt -p sim-host -- --check` — all clean.
- `cargo test --release -p sim-host` — 39/39 unit tests pass, no regressions.
- `cargo check --workspace` — clean.
- `cargo run -p xtask -- gate` — passes (pre-existing informational message, unrelated to this change).
- `python3 -m pytest tests/test_cmd_envelope_reserve.py -v` — 14 passed, 4 xfailed (was 3 xfailed before this PR; the new one is the wheel-odometry finding).
- `python3 .github/policy_check.py` — all hard checks pass, no new advisories.
- The 5.470 s inversion time was independently re-run and diffed byte-identical against the trace CSV before being written into the xfail reason and the test docstring, per this repo's "never fabricate a fact you could not verify" rule.

Closes #227


---
_Generated by [Claude Code](https://claude.ai/code/session_01JczUZLzxhNmKwAJZskQFPn)_