### PR TITLE
fix(controls): the delay-budget gate measured the wrong estimator tau (#133)

### DIFF
--- a/docs/design-delay-budget-stage0b.md
+++ b/docs/design-delay-budget-stage0b.md
@@ -12,6 +12,8 @@ covers:
 - **Status:** Analysis. **AC-6 is DEMOTED, not amended — it currently gates nothing** (§3).
   The 20 ms figure is a measured capacity at a design point whose gains, `kt` and reference
   disturbance are all scheduled to change. No implementation change.
+  **Addresses [#133](https://github.com/MikePaNtZ/overboard/issues/133) (AC1's time-domain half,
+  AC3, AC4) — not closed: AC1's frequency-domain re-sweep is left open, see §2's correction.**
 - **Owner:** Senior Controls.
 - **Closes:** [#113](https://github.com/MikePaNtZ/overboard/issues/113),
   [#138](https://github.com/MikePaNtZ/overboard/issues/138),
@@ -81,8 +83,11 @@ Two standard bounds follow from `p` alone, independent of gain choice:
 - **Fundamental delay-margin ceiling, `1/p` = 191 ms** (was quoted as 313 ms).
 - **Textbook robust-design target, `0.2/p` = 38.2 ms** (was quoted as 63 ms).
 
-**The second is not loose — it is accurate to 2%** against the measured 38–39 ms ceiling. See
-§3, where the original "over-predicted by 1.6×" reading is corrected.
+**The second was reported as accurate to 2% against the measured 38–39 ms ceiling — that
+comparison does not survive the #133 tau correction** (§3): the ceiling it was checked against
+moved to 51–52 ms once the estimator was measured at the production time constant, and `0.2/p`
+is now ~26% low against it. See §3 for the corrected comparison and why the original "1.6×
+over-prediction" reading was still right to reject.
 
 **Why this doesn't route through `kt`.** `KT_NM_PER_A = 0.7` (`sim/scenarios/plant.py`) is
 explicitly flagged in-repo as an **unfitted guess**. A crossover-frequency derivation from the
@@ -99,44 +104,70 @@ is trustworthy where a gain-based crossover estimate would not be.
 | CAN transport bit time (extended frame, 8-byte payload, 500 kbit/s per `docs/runbook-stage0a-bench.md`) | ~0.26–0.32 ms | **COMPUTED** from the CAN 2.0B protocol + documented bitrate. The real VESC `SET_CURRENT` frame size is **unconfirmed** — `vesc-wire`/`vesc-tx` are honest stubs (issue #1, issue #52) — so this is a generic protocol bound, not a measurement of our actual frame |
 | Sensor transport (Pi 5 SPI tail, community-reported) | 1.5–2 ms | **REPORTED, not measured on our hardware** — `design-pi-image-stage0b-reference.md` AC-9 is the pending real measurement |
 | Compute (one `control-core` cycle) | not separately measured | **ASSUMED negligible** relative to the items above; no isolated benchmark exists yet |
-| **Estimator cost** (measured: truth-pitch margin − estimate-pitch margin) | **≈21 ms** | **MEASURED**, this issue — `tests/test_delay_budget_stage0b.py` |
-| Sum of the stated line items above | ≈3 + 1 + 0.3 + 2 + 21 ≈ **27.3 ms** | — |
-| **Measured total closed-loop ceiling** (ridden/cascade, nominal impulse, estimator ON — the honest default) | **survives 38 ms, strikes 39 ms** | **MEASURED**, bit-identical on repeat |
+| **Estimator cost** (measured: truth-pitch margin − estimate-pitch margin) | **≈9 ms** | **MEASURED**, this issue — `tests/test_delay_budget_stage0b.py` |
+| Sum of the stated line items above | ≈3 + 1 + 0.3 + 2 + 9 ≈ **15.3 ms** | — |
+| **Measured total closed-loop ceiling** (ridden/cascade, nominal impulse, estimator ON — the honest default) | **survives 51 ms, strikes 52 ms** | **MEASURED**, bit-identical on repeat |
 | For comparison: truth-pitch (no estimator) ceiling | **survives 59 ms, strikes 60 ms** | **MEASURED** |
 
-**The line items do not sum to the measured ceiling, and that gap is reported rather than
-papered over.** ~27.3 ms of accounted-for line items against a measured ~38–39 ms ceiling
-leaves ~11 ms unattributed — likely a mix of the current clamp's nonlinearity and coupling
-terms the simple additive picture does not capture. The **measured total** is the authoritative
-number; the line-item table is diagnostic, not an exhaustive accounting.
+**Correction (#133): the estimator cost above was measured at the wrong time constant.**
+Every number in this section previously used `estimator_tau_s`'s FFI default of 1.0 s, not the
+`tau = 2 s` `sim/scenarios/hill.py:140` documents as the recommended production config — nothing
+had ever asked the estimator for the config that actually ships. The correction runs the
+opposite direction from what was assumed going in: a longer tau trusts the delay-free gyro more
+and the phase-corrupted accelerometer less (see `WheelAccelEstimator`'s comment in
+`crates/control-core/src/lib.rs`), so it **costs less** delay margin, not more — the estimator
+cost drops from ~21 ms to ~9 ms, and the closed-loop ceiling rises from 38–39 ms to 51–52 ms.
+This holds consistently across every disturbance amplitude in §3's sweep, not just the reference
+one. The truth-pitch ceiling (59–60 ms) is untouched — it does not depend on the estimator.
 
-**The estimator is confirmed as the dominant term**, exactly as the issue predicted: ~21 ms
-against a 1.5–2 ms SPI spike is roughly **10–14×**, in the "5–15×" range flagged before this was
-measured. `tests/test_delay_budget_stage0b.py::test_the_estimator_costs_a_large_fraction_of_the_delay_budget`
-pins this as a standing regression gate — a future estimator change that quietly eats more of
-this margin should fail a test, not wait for a bench surprise.
+**The line items do not sum to the measured ceiling, and that gap is reported rather than
+papered over.** ~15.3 ms of accounted-for line items against a measured ~51–52 ms ceiling
+leaves **~36 ms unattributed** — a bigger unattributed share than before the #133 correction,
+not a smaller one. The named line items shrank (the estimator's did); the ceiling grew by more
+than they shrank. This is likely still a mix of the current clamp's nonlinearity and coupling
+terms the simple additive picture does not capture, but that is now the majority of the ceiling
+rather than a minority, and is worth its own measurement rather than being carried as
+"unattributed" indefinitely. The **measured total** is the authoritative number regardless; the
+line-item table remains diagnostic, not an exhaustive accounting.
+
+**The estimator is a real cost, but no longer the dominant term.** ~9 ms against a 1.5–2 ms SPI
+spike is roughly **4.5–6×** — still the single largest *named* line item, but well under the
+previously-reported 10–14× and the "5–15×" range flagged before either measurement.
+`tests/test_delay_budget_stage0b.py::test_the_estimator_costs_a_large_fraction_of_the_delay_budget`
+still pins this as a standing regression gate (threshold lowered from 1.4× to 1.15×, matching the
+smaller-but-real measured ratio) — a future estimator change that quietly eats more of this
+margin should fail a test, not wait for a bench surprise.
 
 ## 3. Outcome (AC3)
 
 **500 Hz is not the problem, and the honest budget says so with a wide margin, not a
 knife's-edge one.** The known/assumed transport-adjacent line items (SPI 1.5–2 ms + sampling/ZOH
-3 ms + CAN ~0.3 ms + current-loop lag 1 ms ≈ **6.3 ms**) sit inside the measured 38–39 ms ceiling
-with roughly **6× headroom**, even before crediting the ~11 ms of unattributed slack in §2. The
+3 ms + CAN ~0.3 ms + current-loop lag 1 ms ≈ **6.3 ms**) sit inside the measured 51–52 ms ceiling
+with roughly **8× headroom**, even before crediting the ~36 ms of unattributed slack in §2. The
 originally-proposed AC-6 (`p99.9 ≤ 1 ms, max ≤ 2 ms`) was not wrong about there being a real
 constraint — it was wrong about which quantity to gate on.
 
 **Correction (#134): the textbook target did not over-predict — the pole was wrong.** This
 section previously recorded the 63 ms robust target as over-predicting by ~1.6×, and blamed the
-current clamp and the estimator. With §1's corrected pole, `0.2/p` = **38.2 ms** against a
-measured **39 ms** ceiling: an agreement of **2%**. The clamp and estimator are real and do
-matter — the estimator demonstrably costs ~21 ms (§2) — but they are not what explained that
-gap, because with the right pole there is no gap to explain. Attributing an error to the
-nearest plausible physical effect, when the arithmetic upstream was simply wrong, is how a wrong
-number survives review.
+current clamp and the estimator. With §1's corrected pole, `0.2/p` = **38.2 ms**, which at the
+time was compared against a measured **39 ms** ceiling — an apparent agreement of **2%**.
 
-The conclusion is unchanged: **gate on the measured number.** What changes is that the analytic
-bound is a far sharper cross-check than it appeared — a future measurement drifting far from
-`0.2/p` should now read as a signal that something moved.
+**Correction (#133) reopens that agreement, and it does not survive.** `0.2/p` is a property of
+the plant and control law alone; it does not depend on the estimator. The 39 ms figure it was
+checked against did — it was the estimator-in-loop ceiling, measured (like everything else in
+§2) at the wrong tau. At the corrected, production-tau ceiling of 51–52 ms, `0.2/p` = 38.2 ms is
+**~26% low**, not a 2% match. Checked instead against the estimator-independent truth-pitch
+ceiling (59–60 ms, unchanged by either correction) it is **~36% low**. Neither is a close
+agreement; the earlier "2%" was this document coincidentally comparing a plant-only bound
+against an estimator-dependent number that happened, at the wrong tau, to land nearby. **This is
+reported rather than re-explained** — a new hypothesis for the analytic/measured gap is real
+analysis work, not a byproduct of a tau fix, and is left open rather than guessed at here.
+
+The conclusion of #134 is otherwise unchanged: **gate on the measured number, not the linear
+one.** What #133 removes is the specific claim that the analytic bound was validated to 2% — it
+was not; that arithmetic itself was correct, but what it was being checked against was not the
+right comparison. `0.2/p` remains a useful order-of-magnitude cross-check (§1's pole correction
+stands on its own, independent of the estimator), just not the tight one previously reported.
 
 **Recommendation — keep the 500 Hz schedule** (already independently justified by IMU
 anti-aliasing, `crates/control-core/src/lib.rs`, `crates/board-types/src/lib.rs`; lowering it
@@ -146,11 +177,14 @@ was a FORBIDDEN outcome per the issue).
 
 **It is deliberately not written as a requirement, and it must not be cited as one.**
 
-> **Measured delay capacity at the stated design point is 38–39 ms; 20 ms is half of it.**
-> The binding hardware threshold is **re-derived after the `kt` fit (#132) and the reference
-> disturbance is settled (#142)** — it does not exist yet.
+> **Measured delay capacity at the stated design point is 51–52 ms; 20 ms is well under half of
+> it.** The binding hardware threshold is **re-derived after the `kt` fit (#132) and the
+> reference disturbance is settled (#142)** — it does not exist yet.
 
-All four conditions are part of the number, not context for it:
+All five conditions are part of the number, not context for it — the estimator's τ is added
+here (#133) having previously been named in the re-open trigger below but never actually
+listed as one of "the" conditions, which is how it went unmeasured at its production value for
+as long as it did:
 
 | Condition | Value | Status |
 |---|---|---|
@@ -158,14 +192,15 @@ All four conditions are part of the number, not context for it:
 | Inner gain `kd` | 30 A/(rad/s) | **about to change** — #132 retune |
 | `kt` | 0.7 N·m/A | **UNFITTED placeholder** |
 | Reference disturbance | 20 N·s | **INHERITED, underived** — see §4 |
+| Estimator `estimator_tau_s` | 2.0 s | **PRODUCTION value** (#133) — was measured at the FFI default of 1.0 s until this correction |
 
 **Re-open trigger, in the criterion itself:** *any* change to `kp`, `kd`, `kt`, the estimator's
 τ, or the reference disturbance **voids this number** and requires re-running
 `scripts/analyse_delay_budget.py`. Three of those five are already scheduled to change.
 
 **The 2× safety factor has moved from the delay axis to the disturbance axis.** §4's table is
-the reason: a 1.5× change in disturbance (20 → 30 N·s) collapses the ceiling from 38 ms to
-15 ms, which outweighs a 2× factor on delay entirely. **A safety factor on the wrong axis is
+the reason: a 1.5× change in disturbance (20 → 30 N·s) collapses the ceiling from 51 ms to
+28 ms, which outweighs a 2× factor on delay entirely. **A safety factor on the wrong axis is
 worse than none, because it reads as covered.** The margin that matters is the one on how hard
 the board gets hit.
 
@@ -174,10 +209,10 @@ the board gets hit.
 `docs/design-pi-image-stage0b-reference.md` is COO turf (`CODEOWNERS`), so this is proposed,
 not applied. Replace AC-6's threshold sentence with:
 
-> **Not yet gateable.** Measured delay capacity is 38–39 ms at the design point
-> (`kp`=200, `kd`=30, `kt`=0.7 *unfitted*, reference disturbance 20 N·s *inherited*). A
-> binding p99.9 threshold is re-derived once #132 (gain retune, `kt` fit) and #142
-> (reference disturbance) land. Until then AC-6 gates **nothing**, and the 20 ms figure
+> **Not yet gateable.** Measured delay capacity is 51–52 ms at the design point
+> (`kp`=200, `kd`=30, `kt`=0.7 *unfitted*, reference disturbance 20 N·s *inherited*, estimator
+> τ=2 s *production*). A binding p99.9 threshold is re-derived once #132 (gain retune, `kt` fit)
+> and #142 (reference disturbance) land. Until then AC-6 gates **nothing**, and the 20 ms figure
 > may not be cited on its own to pass or fail a hardware decision.
 
 **The test for whether this demotion actually worked** (#138's own acceptance criterion): can
@@ -205,15 +240,24 @@ nothing".
 
   | Impulse | Truth ceiling | Estimator ceiling | Peak pitch at zero delay |
   |---|---|---|---|
-  | 10 N·s | 71 ms | 48 ms | 2.94° |
-  | **20 N·s (`NOMINAL_IMPULSE_NS`)** | **60 ms** | **38 ms** | 5.95° |
-  | 30 N·s | 37 ms | **15 ms** | 8.98° |
+  | 10 N·s | 71 ms | 62 ms | 3.21° |
+  | **20 N·s (`NOMINAL_IMPULSE_NS`)** | **60 ms** | **51 ms** | 6.36° |
+  | 30 N·s | 37 ms | **28 ms** | 9.71° |
   | 40 N·s | — | — | **inverts at zero delay** |
 
-  At 30 N·s the estimator-in-loop ceiling is **15 ms, below the 20 ms figure itself**. The
-  ceiling falls faster than linearly (~1.0 ms/N·s from 10→20, ~2.3 ms/N·s from 20→30).
-  (The estimator's own cost is ~22 ms at *every* amplitude — 23/22/22 — which is what justifies
-  §2 charging it as a fixed line item.)
+  **Correction (#133):** the Estimator-ceiling and peak-pitch columns above are re-measured at
+  the production `estimator_tau_s = 2.0` s; the Truth-ceiling column is unchanged (it does not
+  depend on the estimator). At 30 N·s the estimator-in-loop ceiling is now **28 ms, above the
+  20 ms figure** — the opposite of the pre-correction reading (15 ms, below it) that this
+  section previously used to argue AC-6's legacy number was already unsafe at 30 N·s. It is not,
+  at the production estimator config; the margin is thin (28 ms against 20 ms, an 8 ms cushion)
+  but positive. This does not reopen AC-6 as a threshold — that demotion stands on the "the
+  number is a design-point artefact, not a requirement" argument above, independent of which
+  side of it the measurement lands on. The ceiling still falls faster than linearly with
+  amplitude (~0.9 ms/N·s from 10→20, ~2.3 ms/N·s from 20→30), and 40 N·s is still fatal at zero
+  delay regardless of tau. (The estimator's own cost is ~9 ms at *every* amplitude — 9/9/9 — down
+  from ~22 ms (23/22/22) at the previously-used tau; still what justifies §2 charging it as a
+  fixed line item.)
 - **If any of these assumptions turn out to dominate the conclusion, that supersedes this
   document** — per the issue's own instruction, this analysis is not asking to be trusted past
   what it actually checked.

--- a/scripts/analyse_delay_budget.py
+++ b/scripts/analyse_delay_budget.py
@@ -88,39 +88,54 @@ KP_A_PER_RAD, KD_A_PER_RAD_S = 200.0, 30.0
 #: Measured BOTH ways, and the pair is the most useful number in this file:
 #:
 #:   truth pitch      last safe 60 ms, first fatal 61 ms
-#:   estimator in loop last safe 38 ms, first fatal 39 ms
+#:   estimator in loop last safe 51 ms, first fatal 52 ms
 #:
-#: The 22 ms gap between them IS the estimator's cost in delay margin, measured
+#: The 9 ms gap between them IS the estimator's cost in delay margin, measured
 #: in the time domain, against a plant that saturates -- entirely independently
 #: of the frequency-domain phase measurement in `analyse_estimator_phase.py`.
-#: Two methods, one conclusion: the estimator is the dominant delay term.
+#: Two methods, one conclusion: the estimator is a real, but no longer the
+#: dominant, delay term (see the #133 correction below).
 #:
 #: This also supersedes `test_imperfections.py:203`'s "breaks between 40 and
-#: 60 ms", which is stale: with the estimator in the loop it breaks at 39 ms.
+#: 60 ms", which is stale: with the estimator in the loop it breaks at 52 ms.
+#:
+#: **Correction (#133): re-measured at the PRODUCTION estimator time
+#: constant.** Every number on this line previously used `estimator_tau_s`'s
+#: FFI default of 1.0 s (ESTIMATOR_BREAK_S was 0.039, an estimator cost of
+#: ~21 ms) -- not the `tau = 2 s` `sim/scenarios/hill.py:140` documents as the
+#: recommended production config. Nothing had ever asked the estimator for the
+#: config that actually ships. The correction runs the OPPOSITE direction from
+#: what was assumed going in: a longer tau trusts the delay-free gyro more and
+#: the phase-corrupted accelerometer less (see `WheelAccelEstimator`'s comment
+#: in `crates/control-core/src/lib.rs`), so it COSTS LESS delay margin, not
+#: more. `TRUTH_BREAK_S` is untouched -- it does not depend on the estimator.
 TRUTH_BREAK_S = 0.061
-ESTIMATOR_BREAK_S = 0.039
+ESTIMATOR_BREAK_S = 0.052
 
 #: The break is NOT a plant invariant. It is saturation-driven, so it is a
 #: function of disturbance amplitude, and the reference amplitude is a CHOICE.
-#: Swept at 10/20/30/40 N*s, bisected to 1 ms, both attitude sources:
+#: Swept at 10/20/30/40 N*s, bisected to 1 ms, both attitude sources, at the
+#: PRODUCTION estimator_tau_s=2.0 (#133 -- see ESTIMATOR_BREAK_S above; the
+#: `truth_s` column is tau-independent and unchanged from the original sweep):
 #:
 #:   N*s   truth   estimator   peak pitch at zero delay
-#:    10    72 ms     49 ms      2.94 deg
-#:    20    61 ms     39 ms      5.95 deg   <- NOMINAL_IMPULSE_NS
-#:    30    38 ms     16 ms      8.98 deg
+#:    10    72 ms     63 ms      3.21 deg
+#:    20    61 ms     52 ms      6.36 deg   <- NOMINAL_IMPULSE_NS
+#:    30    38 ms     29 ms      9.71 deg
 #:    40   strikes at ZERO delay -- beyond disturbance rejection entirely
 #:
 #: Two things fall out, and both matter more than anything about the transport:
 #:
-#: 1.  The slope STEEPENS: ~1.0 ms/N*s from 10->20, ~2.3 ms/N*s from 20->30.
+#: 1.  The slope STEEPENS: ~0.9 ms/N*s from 10->20, ~2.3 ms/N*s from 20->30.
 #:     A budget quoted at one amplitude and used at another is fiction.
-#: 2.  The estimator's cost is ~22 ms at EVERY amplitude (23/22/22). That is
-#:     what justifies charging it as a fixed line item rather than a fraction.
+#: 2.  The estimator's cost is ~9 ms at EVERY amplitude (9/9/9) at the
+#:     production tau -- down from ~22 ms (23/22/22) at tau=1.0. Still a fixed
+#:     line item, just a smaller one than previously documented.
 AMPLITUDE_BREAKS_NS = {
-    10.0: {"truth_s": 0.072, "estimator_s": 0.049, "zero_delay_peak_deg": 2.942},
-    20.0: {"truth_s": 0.061, "estimator_s": 0.039, "zero_delay_peak_deg": 5.950},
-    30.0: {"truth_s": 0.038, "estimator_s": 0.016, "zero_delay_peak_deg": 8.984},
-    40.0: {"truth_s": None, "estimator_s": None, "zero_delay_peak_deg": 179.956},
+    10.0: {"truth_s": 0.072, "estimator_s": 0.063, "zero_delay_peak_deg": 3.207},
+    20.0: {"truth_s": 0.061, "estimator_s": 0.052, "zero_delay_peak_deg": 6.362},
+    30.0: {"truth_s": 0.038, "estimator_s": 0.029, "zero_delay_peak_deg": 9.708},
+    40.0: {"truth_s": None, "estimator_s": None, "zero_delay_peak_deg": 179.987},
 }
 
 #: The amplitude the budget is quoted at. `NOMINAL_IMPULSE_NS` in the scenario.
@@ -444,10 +459,14 @@ def main() -> int:
     # budget written against the linear number would be writing a cheque the
     # saturated loop cannot cash.
     #
-    # The estimator is charged at its TIME-DOMAIN cost (the 22 ms difference
-    # between the two measured break points) rather than its frequency-domain
-    # phase (16.6 ms). The larger figure is the one measured against the
-    # saturating plant this budget is actually for.
+    # The estimator is charged at its TIME-DOMAIN cost (the 9 ms difference
+    # between the two measured break points, at the production estimator tau
+    # -- #133) rather than its frequency-domain phase. That frequency-domain
+    # figure (previously 16.6 ms) was ALSO measured at the wrong tau and has
+    # not been re-measured here -- `analyse_estimator_phase.py`'s sweep still
+    # needs re-running at tau=2.0 to produce a comparable number (left for a
+    # follow-up; not needed for this budget, which uses the time-domain
+    # figure regardless of which one is larger).
     estimator_cost = TRUTH_BREAK_S - ESTIMATOR_BREAK_S
 
     # The budget itself lives in `docs/design-delay-budget-stage0b.md` (#122),

--- a/scripts/analyse_estimator_phase.py
+++ b/scripts/analyse_estimator_phase.py
@@ -63,9 +63,18 @@ from sim.scenarios.shuttle_run import ShuttleParams, VelocityProfile  # noqa: E4
 
 INK, AMBER, MINT, MUTED, RED = "#16232E", "#F2A24A", "#2AAE97", "#96A8B0", "#C2513B"
 
-#: Where the inner loop crosses over, rad/s. From the gain derivation in
-#: `rust_controller.DEFAULT_KP_NM_PER_RAD`'s docstring, at the ridden inertia.
-OMEGA_C = 12.0
+#: Where the RIDDEN inner loop crosses over, rad/s.
+#:
+#: **Correction (#133): this was 12.0, inherited from the DRIVERLESS gain
+#: derivation (J ~ 0.403) despite the comment's own claim to be "at the ridden
+#: inertia" -- it was not.** At 12 rad/s the ridden loop's measured phase is a
+#: LEAD, not a lag, so anything here that fits `tau = tan|phase|/OMEGA_C` (see
+#: `discriminate`/`fix_sweep` below) was reporting a lead as though it were a
+#: lag. The real ridden crossover, re-derived from `scripts/analyse_delay_
+#: budget.py`'s own linearization (`kp`=200, `kd`=30 A/rad -- same GAINS as
+#: this file) at the settled ridden trim, is 4.4825 rad/s -- reproduce with
+#: `python scripts/analyse_delay_budget.py` and read `loop.omega_c_rad_s`.
+OMEGA_C = 4.4825
 
 # 200 A/rad, 30 A/(rad/s) at kt = 0.7 N*m/A, re-denominated in torque (#137).
 GAINS = dict(kp_nm_per_rad=200.0 * KT_NM_PER_A, kd_nm_per_rad_s=30.0 * KT_NM_PER_A,

--- a/tests/test_delay_budget_stage0b.py
+++ b/tests/test_delay_budget_stage0b.py
@@ -10,21 +10,36 @@ loop -- the vehicle being built -- can absorb before it noses in.
 This file pins the two numbers `scripts/analyse_control.py`'s `delay_budget()`
 found by bisection, so they cannot silently drift: the closed loop (real Rust
 `PitchRegulator` + `VelocityLoop`, current-clamped, nominal impulse) survives
-38 ms of pure actuation delay and strikes at 39 ms -- with the estimator in
+51 ms of pure actuation delay and strikes at 52 ms -- with the estimator in
 the loop, which is the honest default. With truth pitch instead of the
 estimate, the same plant survives to 59 ms. **The estimator alone costs about
-21 ms of the closed loop's delay margin** -- the MANDATORY, measured line item
+9 ms of the closed loop's delay margin** -- the MANDATORY, measured line item
 issue #113 asked for, not an assumed one.
+
+**Correction (#133): re-measured at the PRODUCTION estimator time constant.**
+Every number in this file previously used `estimator_tau_s`'s FFI default of
+1.0 s, not the `tau = 2 s` `sim/scenarios/hill.py:140` documents as the
+recommended production config -- nothing had ever asked the estimator for the
+config that actually ships. The direction of the correction is the opposite
+of what was assumed: a longer tau trusts the (delay-free) gyro more and the
+(phase-corrupted) accelerometer less -- see `WheelAccelEstimator`'s comment in
+`crates/control-core/src/lib.rs` for why that branch is expensive -- so it
+COSTS LESS margin, not more. At tau=1.0 s the estimator cost ~21 ms; at the
+production tau=2.0 s it costs ~9 ms, consistently, across every disturbance
+amplitude swept in `scripts/analyse_delay_budget.py`. Still a real cost, and
+still the dominant named line item next to the ~1.5-2 ms SPI tail -- just a
+smaller one than previously documented.
 
 See docs/design-delay-budget-stage0b.md for the full derivation and the
 delay-budget table this backs.
 
-GATE NUMBERS -- MEASURED (this issue, via `scripts/analyse_control.py`)
+GATE NUMBERS -- MEASURED (this issue, via `scripts/analyse_control.py`,
+estimator_tau_s=2.0)
 ------------------------------------------------------------------------
 | Assertion                                                | Threshold                          | Observed |
 |-----------------------------------------------------------|-------------------------------------|----------|
-| `test_the_ridden_closed_loop_survives_at_38ms`             | `not nose_strike`                   | peak 18.23 deg (< 18.57 strike angle) |
-| `test_the_ridden_closed_loop_strikes_at_39ms`               | `nose_strike`                        | peak 19.88 deg |
+| `test_the_ridden_closed_loop_survives_at_51ms`             | `not nose_strike`                   | peak 13.05 deg (< 18.57 strike angle) |
+| `test_the_ridden_closed_loop_strikes_at_52ms`               | `nose_strike`                        | peak 34.06 deg |
 | `test_truth_pitch_survives_to_59ms`                         | `not nose_strike`                   | peak 12.70 deg |
 | `test_truth_pitch_strikes_at_60ms`                          | `nose_strike`                        | peak 74.21 deg |
 | `test_the_unstable_pole_is_the_expected_order_of_magnitude`  | `2.5 < p < 4.0 rad/s`                | 3.191 rad/s |
@@ -41,6 +56,10 @@ from sim.scenarios.rust_controller import RustController
 CASCADE = dict(kp_nm_per_rad=140.0, kd_nm_per_rad_s=21.0, max_current_a=40.0,
                com_above_axle=True, kp_v_rad_per_m_s=0.05, ki_v_rad_per_m=0.02)
 
+#: The recommended production config (`sim/scenarios/hill.py:140`), not the
+#: FFI's neutral default of 1.0 -- see the module docstring's #133 correction.
+ESTIMATOR_TAU_S = 2.0
+
 
 def _delayed_run(delay_ms, use_estimator):
     model = build_model(70.0, 0.75, 40.0)
@@ -53,30 +72,31 @@ def _delayed_run(delay_ms, use_estimator):
         wheel_rate_quantum_rad_s=STAGE0_PLACEHOLDER.wheel_rate_quantum_rad_s,
         wheel_rate_update_hz=STAGE0_PLACEHOLDER.wheel_rate_update_hz,
     )
-    with RustController(use_estimator=use_estimator, **CASCADE) as c:
+    with RustController(use_estimator=use_estimator, estimator_tau_s=ESTIMATOR_TAU_S,
+                        **CASCADE) as c:
         return run(ImpulseParams(magnitude_ns=NOMINAL_IMPULSE_NS, sim_seconds=8.0),
                    model=model, controller=c, profile=profile)
 
 
-def test_the_ridden_closed_loop_survives_at_38ms():
+def test_the_ridden_closed_loop_survives_at_51ms():
     """Last survivor, WITH the estimator -- the honest default (issue #24 AC1)."""
-    r = _delayed_run(38, use_estimator=True)
+    r = _delayed_run(51, use_estimator=True)
     assert not r.metrics.nose_strike
     assert r.metrics.peak_abs_pitch_deg < 18.57
 
 
-def test_the_ridden_closed_loop_strikes_at_39ms():
+def test_the_ridden_closed_loop_strikes_at_52ms():
     """One millisecond more and it goes over -- the measured boundary AC-6
     should gate on, not an arbitrary fraction of the 2 ms control period."""
-    r = _delayed_run(39, use_estimator=True)
+    r = _delayed_run(52, use_estimator=True)
     assert r.metrics.nose_strike
 
 
 def test_repeat_runs_at_the_boundary_are_bit_identical():
     """The boundary itself must not be a coin flip -- same convention as the
     determinism audit in issue #24 AC4."""
-    first = _delayed_run(39, use_estimator=True)
-    second = _delayed_run(39, use_estimator=True)
+    first = _delayed_run(52, use_estimator=True)
+    second = _delayed_run(52, use_estimator=True)
     assert first.to_json_dict()["metrics"] == second.to_json_dict()["metrics"]
 
 
@@ -94,15 +114,19 @@ def test_truth_pitch_strikes_at_60ms():
 
 def test_the_estimator_costs_a_large_fraction_of_the_delay_budget():
     """The mandatory, measured line item: the estimator is not a rounding
-    error next to the SPI tail, it is the dominant term. Bounded rather than
-    pinned to the exact bisected ms so a one-cycle (2 ms) shift in either
-    boundary from an unrelated change does not flake this gate."""
-    with_est = _delayed_run(38, use_estimator=True)
-    without_est = _delayed_run(38, use_estimator=False)
+    error next to the SPI tail. Bounded rather than pinned to the exact
+    bisected ms so a one-cycle (2 ms) shift in either boundary from an
+    unrelated change does not flake this gate.
+
+    Threshold lowered from 1.4x (#113) to 1.15x as part of #133's tau
+    correction -- measured ~1.21x at the production estimator config, stable
+    to three digits across delay=40..51 ms, well clear of 1.15."""
+    with_est = _delayed_run(51, use_estimator=True)
+    without_est = _delayed_run(51, use_estimator=False)
     assert not without_est.metrics.nose_strike, (
-        "38 ms must still survive on truth pitch, or the comparison below is vacuous"
+        "51 ms must still survive on truth pitch, or the comparison below is vacuous"
     )
-    assert with_est.metrics.peak_abs_pitch_deg > 1.4 * without_est.metrics.peak_abs_pitch_deg, (
+    assert with_est.metrics.peak_abs_pitch_deg > 1.15 * without_est.metrics.peak_abs_pitch_deg, (
         "expected the estimator to cost real margin at the same delay, not a rounding error"
     )
 


### PR DESCRIPTION
## What changed

Every pinned number in the ridden closed-loop delay budget — the ~21 ms estimator cost, the
38–39 ms closed-loop ceiling, the `AMPLITUDE_BREAKS_NS` sweep across disturbance amplitudes —
was measured at `estimator_tau_s`'s FFI default of **1.0 s**, never at the **`tau = 2 s`**
`sim/scenarios/hill.py:140` documents as the recommended production config. Nothing in
`tests/test_delay_budget_stage0b.py` or `scripts/analyse_delay_budget.py` had ever asked the
estimator for the config that actually ships.

Re-measured (bisected to 1 ms, same harness, verified bit-identical on repeat) at the production
tau. The correction runs **opposite** to what issue #133 hypothesized: a longer tau trusts the
delay-free gyro more and the phase-corrupted accelerometer less (see `WheelAccelEstimator`'s
comment in `crates/control-core/src/lib.rs` for why that branch is expensive), so it **costs
less** delay margin, not more.

- Estimator cost: **~21 ms → ~9 ms**, consistently across every swept disturbance amplitude
  (9/9/9 ms at 10/20/30 N·s, vs. the old 23/22/22 ms).
- Ridden closed-loop ceiling at the reference (20 N·s) impulse: **survives 38 → 51 ms, strikes
  39 → 52 ms**.
- Also fixes `scripts/analyse_estimator_phase.py`'s `OMEGA_C = 12.0` — inherited from the
  *driverless* gain derivation despite its own comment's claim to be ridden-plant-derived, which
  made its own `tau = tan|phase|/OMEGA_C` fit report a lead as a lag (flagged explicitly in
  #133's note). Re-derived from `analyse_delay_budget.py`'s own linearization: **4.4825 rad/s**,
  matching #132's independently-reported 4.48.

**A second-order finding fell out of re-running the budget**, reported rather than buried: the
design doc's §3 previously claimed the textbook `0.2/p` bound (38.2 ms) "agreed to 2%" with the
measured ceiling. That comparison was checking a plant-only bound against the (wrong-tau)
estimator-in-loop ceiling. At the corrected ceiling, `0.2/p` is **~26% low**, not a 2% match —
documented plainly in the doc; no new theory for the analytic/measured gap is offered here,
since that's its own analysis, not a byproduct of a tau fix.

## Why

The estimator's delay-margin cost is the headline number this design doc uses to argue AC-6 is
demoted and to set expectations for the eventual hardware go/no-go threshold. A number measured
against a config that will not ship is not measuring the thing it claims to measure — this
either overstates the risk (as it did here) or understates it, and there's no way to know which
without checking. Checking it found the former: real margin exists that the doc was not
crediting.

## Acceptance criteria (issue #133)

- **AC1 (time-domain half): done.** Re-measured `θ̂/θ`... this PR does the time-domain
  bisection at production tau and fixes the stale `OMEGA_C`. **Not done: the frequency-domain
  swept-sine re-measurement** (`analyse_estimator_phase.py`'s `frequency_response()` still
  defaults to `est_tau_s=1.0` internally and isn't parameterized for production tau) — see
  "Deliberately left out."
- **AC2 (defended reference disturbance): already satisfied**, pre-existing, by #142's landed
  work in design doc §4 (geometric derivation, not touched here).
- **AC3 (budget re-run, solvency stated): done.** Re-ran `scripts/analyse_delay_budget.py`'s
  constants and the design doc's §2/§3 accounting; solvency is honestly better than previously
  documented, and the growth in the *unattributed* portion of the budget (~11 ms → ~36 ms) is
  called out rather than hidden.
- **AC4 (update the pinned test): done.** `tests/test_delay_budget_stage0b.py` now passes
  `estimator_tau_s=2.0`; boundary values and the "costs a large fraction" ratio threshold
  (1.4x → 1.15x, still comfortably below the measured ~1.21x) are re-derived.

Given AC1 is only half-closed, this PR does **not** close #133 — it addresses it.

## Deliberately left out

- **AC1's frequency-domain re-sweep.** `analyse_estimator_phase.py`'s `path_factorial()` and
  `frequency_response()` call `simulate()` without threading `est_tau_s` through, so they always
  run at the function's internal default (1.0 s) regardless of the module-level `OMEGA_C` fix.
  Wiring a production-tau default through that pipeline and regenerating
  `estimator-phase.{npz,json,png}` (not checked into git — gitignored `sim/out/experiments/`) is
  a real, separate increment: it's a multi-minute pipeline touching `path_factorial`,
  `frequency_response`, `discriminate`, and `fix_sweep` together, not a one-line change.
- Any retune of gains in response to the newly-larger margin. This issue is about measuring
  honestly, not about spending the margin.
- The pre-existing, unrelated 1 ms drift in the **truth-pitch** branch's documented figures
  (`TRUTH_BREAK_S = 0.061` / the 20 N·s row's `truth_s`) — freshly measured truth-pitch boundary
  is 59/60 ms, not 60/61 ms as the file's prose claims. This is independent of the estimator
  (truth-pitch bypasses it entirely) and predates this PR; not touched here to keep the diff
  scoped to the tau correction. Worth a follow-up.

## Verification

- `cargo test --workspace`: clean.
- `python -m pytest tests/`: **333 passed, 5 xfailed** (no regressions; the 3 tests that
  initially failed locally were pre-existing "binary not built" gates, resolved by
  `cargo build --release` — not caused by this change).
- `python .github/policy_check.py`: all hard checks pass, no new advisories.
- Re-derived `OMEGA_C` and every new numeric constant directly from the sim (`mjd_transitionFD`
  linearization / bisection against the real Rust `PitchRegulator` + `VelocityLoop` via FFI) —
  nothing hand-copied or guessed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011aRqpTeF2TPFXjZVhwNxR1)_