### PR TITLE
feat(controls): platform contract manifest -- I6 of #182

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "platform-contract"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/plant-mujoco",
     "crates/sim-host",
     "crates/loop-profiler",
+    "crates/platform-contract",
     "crates/xtask",
 ]
 

--- a/crates/platform-contract/Cargo.toml
+++ b/crates/platform-contract/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "platform-contract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+
+# libc's sysconf/_SC_PAGESIZE binding is a Unix facility and the rest of the
+# real probe (`/proc`, `/sys`) is Linux-specific anyway. Target-gated so
+# `cargo build --workspace` still succeeds off Linux (issue #62's precedent,
+# see `crates/can-harness/Cargo.toml`); `src/lib.rs` cfg-gates the code that
+# uses it to match.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }

--- a/crates/platform-contract/src/lib.rs
+++ b/crates/platform-contract/src/lib.rs
@@ -1,0 +1,368 @@
+//! The runtime facts the control loop depends on, checked against the live
+//! system rather than assumed -- issue #182 I6, "the platform contract,
+//! asserted rather than documented".
+//!
+//! D1 (`docs/design-pi-image-stage0b.md`) argues a repo split was unsafe
+//! because "nothing detects a runtime-contract mismatch except running both
+//! halves together, and that it surfaces as a wrong, unattributable bench
+//! number." [`STAGE0B`] plus [`evaluate`] is that detection, independent of
+//! whether the repo ever splits: kernel flavour, page size, `isolcpus`
+//! layout and CAN bitrate are exactly the states a card can silently drift
+//! into (a re-flash with a different pin, a firmware update, a HAT on the
+//! wrong bus) and produce a latency or actuation number nobody can trust.
+//!
+//! Every field here duplicates a value pinned elsewhere in the repo --
+//! unavoidably: Rust cannot source `scripts/pi/pins.env`, and it is not this
+//! crate's job to parse the YAML/systemd-unit text those pins also live in.
+//! `scripts/pi/check_image_pin.py`'s own docstring names this exact shape of
+//! risk for the kernel pin: "Duplication is normally a mistake ... The
+//! difference between a duplicate that is fine and one that rots is whether
+//! anything checks." `tests::contract_matches_checked_in_pins` is that check
+//! for this crate -- it reads the source-of-truth files directly on every
+//! `cargo test` and fails if [`STAGE0B`] drifts from them.
+//!
+//! **Not yet wired to anything that runs on a Pi.** #182 I5 (the controller
+//! binary pipeline) has not landed -- `scripts/pi/image/layer/overboard-base.yaml`
+//! says so directly ("no Overboard binary is in this image at all"), so there
+//! is no path onto the card for *any* binary from this workspace yet, this
+//! one included. The checking logic is built and tested now so it is not
+//! blocked on I5; wiring it into a boot-time systemd unit or a hardware
+//! backend's `arm()` (AC-14's shape, once one exists) is that later work's
+//! own increment, not this one's.
+
+use std::fmt;
+
+#[cfg(target_os = "linux")]
+pub mod linux;
+
+/// The runtime facts a 500 Hz control loop on Stage-0B's hardware depends
+/// on, and what each one is measured or pinned against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Contract {
+    /// `uname -r`. Kept as the literal string measured on real hardware
+    /// (`docs/design-pi-image-stage0b-reference.md` Q11/Q12,
+    /// closed 2026-08-07 via `uname -a`), not derived from the kernel
+    /// package/version pin -- Raspberry Pi's package-name-to-`uname -r`
+    /// mapping is not a pure rename; Q12 found the boot *filename* half of
+    /// that mapping wrong once already (`kernel8_rt.img`, not `kernel8.img`).
+    pub kernel_release: &'static str,
+    /// The 4K-page cost `docs/design-pi-image-stage0b.md` accepts explicitly
+    /// in exchange for the packaged RT kernel (no 16K-page build exists).
+    pub page_size_bytes: usize,
+    /// Cores handed to `isolcpus=` for the control loop
+    /// (`scripts/pi/image/device/overboard-pi5/device.yaml`).
+    pub isolated_cpus: &'static [u32],
+    /// The ICD bus rate `overboard-can0.service` brings `can0` up at.
+    pub can0_bitrate_bps: u32,
+}
+
+/// The measured/pinned contract for Stage-0B's Pi 5 image.
+pub const STAGE0B: Contract = Contract {
+    kernel_release: "6.12.75+rpt-rpi-v8-rt",
+    page_size_bytes: 4096,
+    isolated_cpus: &[3],
+    can0_bitrate_bps: 500_000,
+};
+
+/// Outcome of comparing one field of a [`Contract`] against the live system.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldStatus {
+    Match,
+    Mismatch {
+        expected: String,
+        actual: String,
+    },
+    /// The system could not report this field at all. For most fields this
+    /// is itself a fault -- but for `can0_bitrate`, "no HAT fitted" is a
+    /// supported bench state (`overboard-can0.service`'s own boot-time
+    /// posture), not a corrupt system, so [`Report::ok_to_arm`] treats it
+    /// differently from the other three fields. See that method's doc.
+    Unavailable {
+        reason: String,
+    },
+}
+
+impl FieldStatus {
+    pub fn is_match(&self) -> bool {
+        matches!(self, FieldStatus::Match)
+    }
+}
+
+impl fmt::Display for FieldStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FieldStatus::Match => write!(f, "OK"),
+            FieldStatus::Mismatch { expected, actual } => {
+                write!(f, "MISMATCH (expected {expected}, got {actual})")
+            }
+            FieldStatus::Unavailable { reason } => write!(f, "UNAVAILABLE ({reason})"),
+        }
+    }
+}
+
+/// Result of checking a [`Contract`] against the running system.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Report {
+    pub kernel_release: FieldStatus,
+    pub page_size: FieldStatus,
+    pub isolated_cpus: FieldStatus,
+    pub can0_bitrate: FieldStatus,
+}
+
+impl Report {
+    /// True if the platform matches the contract closely enough to arm on.
+    ///
+    /// `kernel_release`, `page_size` and `isolated_cpus` must always be
+    /// readable on a Linux system, so `Unavailable` on any of them is a hard
+    /// failure, same as `Mismatch`. `can0_bitrate` is different: a missing
+    /// `can0` interface is `overboard-can0.service`'s own supported
+    /// no-HAT-fitted state (self-test over `vcan0` covers that case
+    /// instead), so `Unavailable` there does not refuse to arm -- only a
+    /// `can0` that exists at the *wrong* bitrate does.
+    pub fn ok_to_arm(&self) -> bool {
+        let can0_ok = !matches!(self.can0_bitrate, FieldStatus::Mismatch { .. });
+        self.kernel_release.is_match()
+            && self.page_size.is_match()
+            && self.isolated_cpus.is_match()
+            && can0_ok
+    }
+}
+
+impl fmt::Display for Report {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "platform-contract report:")?;
+        writeln!(f, "  kernel_release : {}", self.kernel_release)?;
+        writeln!(f, "  page_size      : {}", self.page_size)?;
+        writeln!(f, "  isolated_cpus  : {}", self.isolated_cpus)?;
+        writeln!(f, "  can0_bitrate   : {}", self.can0_bitrate)?;
+        write!(f, "  ok_to_arm      : {}", self.ok_to_arm())
+    }
+}
+
+/// Everything [`evaluate`] needs to read from the live system, behind a
+/// trait so the comparison logic is testable with no Pi, no root and no
+/// `isolcpus=` boot line -- the same reason `hal`/`sim-backend` sit behind a
+/// trait rather than being called directly.
+pub trait SystemProbe {
+    fn kernel_release(&self) -> Result<String, String>;
+    fn page_size_bytes(&self) -> Result<usize, String>;
+    fn isolated_cpus(&self) -> Result<Vec<u32>, String>;
+    /// `Ok(None)` means "no `can0` interface", which is not itself an error
+    /// -- see [`Report::ok_to_arm`].
+    fn can0_bitrate_bps(&self) -> Result<Option<u32>, String>;
+}
+
+/// Compares `contract` against whatever `probe` reports.
+pub fn evaluate<P: SystemProbe>(contract: &Contract, probe: &P) -> Report {
+    let kernel_release = match probe.kernel_release() {
+        Ok(actual) if actual == contract.kernel_release => FieldStatus::Match,
+        Ok(actual) => FieldStatus::Mismatch {
+            expected: contract.kernel_release.to_string(),
+            actual,
+        },
+        Err(reason) => FieldStatus::Unavailable { reason },
+    };
+
+    let page_size = match probe.page_size_bytes() {
+        Ok(actual) if actual == contract.page_size_bytes => FieldStatus::Match,
+        Ok(actual) => FieldStatus::Mismatch {
+            expected: contract.page_size_bytes.to_string(),
+            actual: actual.to_string(),
+        },
+        Err(reason) => FieldStatus::Unavailable { reason },
+    };
+
+    let isolated_cpus = match probe.isolated_cpus() {
+        Ok(actual) if actual.as_slice() == contract.isolated_cpus => FieldStatus::Match,
+        Ok(actual) => FieldStatus::Mismatch {
+            expected: format!("{:?}", contract.isolated_cpus),
+            actual: format!("{actual:?}"),
+        },
+        Err(reason) => FieldStatus::Unavailable { reason },
+    };
+
+    let can0_bitrate = match probe.can0_bitrate_bps() {
+        Ok(Some(actual)) if actual == contract.can0_bitrate_bps => FieldStatus::Match,
+        Ok(Some(actual)) => FieldStatus::Mismatch {
+            expected: contract.can0_bitrate_bps.to_string(),
+            actual: actual.to_string(),
+        },
+        Ok(None) => FieldStatus::Unavailable {
+            reason: "can0 interface not present".to_string(),
+        },
+        Err(reason) => FieldStatus::Unavailable { reason },
+    };
+
+    Report {
+        kernel_release,
+        page_size,
+        isolated_cpus,
+        can0_bitrate,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeProbe {
+        kernel_release: Result<String, String>,
+        page_size_bytes: Result<usize, String>,
+        isolated_cpus: Result<Vec<u32>, String>,
+        can0_bitrate_bps: Result<Option<u32>, String>,
+    }
+
+    impl SystemProbe for FakeProbe {
+        fn kernel_release(&self) -> Result<String, String> {
+            self.kernel_release.clone()
+        }
+        fn page_size_bytes(&self) -> Result<usize, String> {
+            self.page_size_bytes.clone()
+        }
+        fn isolated_cpus(&self) -> Result<Vec<u32>, String> {
+            self.isolated_cpus.clone()
+        }
+        fn can0_bitrate_bps(&self) -> Result<Option<u32>, String> {
+            self.can0_bitrate_bps.clone()
+        }
+    }
+
+    fn matching_probe() -> FakeProbe {
+        FakeProbe {
+            kernel_release: Ok(STAGE0B.kernel_release.to_string()),
+            page_size_bytes: Ok(STAGE0B.page_size_bytes),
+            isolated_cpus: Ok(STAGE0B.isolated_cpus.to_vec()),
+            can0_bitrate_bps: Ok(Some(STAGE0B.can0_bitrate_bps)),
+        }
+    }
+
+    #[test]
+    fn matching_system_is_ok_to_arm() {
+        let report = evaluate(&STAGE0B, &matching_probe());
+        assert!(report.ok_to_arm());
+        assert_eq!(report.kernel_release, FieldStatus::Match);
+        assert_eq!(report.page_size, FieldStatus::Match);
+        assert_eq!(report.isolated_cpus, FieldStatus::Match);
+        assert_eq!(report.can0_bitrate, FieldStatus::Match);
+    }
+
+    #[test]
+    fn wrong_kernel_refuses_to_arm() {
+        let mut probe = matching_probe();
+        probe.kernel_release = Ok("6.18.34+rpt-rpi-2712".to_string());
+        let report = evaluate(&STAGE0B, &probe);
+        assert!(!report.ok_to_arm());
+        assert!(matches!(
+            report.kernel_release,
+            FieldStatus::Mismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn wrong_isolcpus_refuses_to_arm() {
+        let mut probe = matching_probe();
+        probe.isolated_cpus = Ok(vec![2]);
+        let report = evaluate(&STAGE0B, &probe);
+        assert!(!report.ok_to_arm());
+        assert!(matches!(report.isolated_cpus, FieldStatus::Mismatch { .. }));
+    }
+
+    #[test]
+    fn wrong_page_size_refuses_to_arm() {
+        let mut probe = matching_probe();
+        probe.page_size_bytes = Ok(16384);
+        let report = evaluate(&STAGE0B, &probe);
+        assert!(!report.ok_to_arm());
+        assert!(matches!(report.page_size, FieldStatus::Mismatch { .. }));
+    }
+
+    #[test]
+    fn wrong_can0_bitrate_refuses_to_arm() {
+        let mut probe = matching_probe();
+        probe.can0_bitrate_bps = Ok(Some(1_000_000));
+        let report = evaluate(&STAGE0B, &probe);
+        assert!(!report.ok_to_arm());
+        assert!(matches!(report.can0_bitrate, FieldStatus::Mismatch { .. }));
+    }
+
+    #[test]
+    fn absent_can0_is_still_ok_to_arm() {
+        // No HAT fitted is a supported bench state (overboard-can0.service);
+        // the vcan0 self-test path exists specifically to cover it.
+        let mut probe = matching_probe();
+        probe.can0_bitrate_bps = Ok(None);
+        let report = evaluate(&STAGE0B, &probe);
+        assert!(report.ok_to_arm());
+        assert!(matches!(
+            report.can0_bitrate,
+            FieldStatus::Unavailable { .. }
+        ));
+    }
+
+    #[test]
+    fn unreadable_kernel_refuses_to_arm() {
+        let mut probe = matching_probe();
+        probe.kernel_release = Err("boom".to_string());
+        let report = evaluate(&STAGE0B, &probe);
+        assert!(!report.ok_to_arm());
+        assert!(matches!(
+            report.kernel_release,
+            FieldStatus::Unavailable { .. }
+        ));
+    }
+
+    #[test]
+    fn unreadable_isolcpus_refuses_to_arm() {
+        let mut probe = matching_probe();
+        probe.isolated_cpus = Err("no /proc/cmdline".to_string());
+        let report = evaluate(&STAGE0B, &probe);
+        assert!(!report.ok_to_arm());
+    }
+
+    /// The duplication guard described in this module's doc comment. Reads
+    /// the actual checked-in files -- not a second hand-copied constant --
+    /// so `STAGE0B` cannot silently drift from the values it restates.
+    #[test]
+    fn contract_matches_checked_in_pins() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("crates/platform-contract sits two levels under the repo root");
+
+        let pins = std::fs::read_to_string(repo_root.join("scripts/pi/pins.env"))
+            .expect("scripts/pi/pins.env should exist and be readable");
+        let expected_pin = format!("KERNEL_PACKAGE=\"linux-image-{}\"", STAGE0B.kernel_release);
+        assert!(
+            pins.contains(&expected_pin),
+            "STAGE0B.kernel_release ({}) no longer matches pins.env's KERNEL_PACKAGE -- \
+             update whichever one drifted",
+            STAGE0B.kernel_release,
+        );
+
+        let device_yaml = std::fs::read_to_string(
+            repo_root.join("scripts/pi/image/device/overboard-pi5/device.yaml"),
+        )
+        .expect("scripts/pi/image/device/overboard-pi5/device.yaml should exist and be readable");
+        let expected_isolcpus = STAGE0B
+            .isolated_cpus
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        assert!(
+            device_yaml.contains(&format!("isolcpus={expected_isolcpus}")),
+            "STAGE0B.isolated_cpus no longer matches device.yaml's isolcpus= line -- \
+             update whichever one drifted",
+        );
+
+        let can0_service = std::fs::read_to_string(repo_root.join(
+            "scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-can0.service",
+        ))
+        .expect("overboard-can0.service should exist and be readable");
+        assert!(
+            can0_service.contains(&format!("bitrate {}", STAGE0B.can0_bitrate_bps)),
+            "STAGE0B.can0_bitrate_bps no longer matches overboard-can0.service -- \
+             update whichever one drifted",
+        );
+    }
+}

--- a/crates/platform-contract/src/linux.rs
+++ b/crates/platform-contract/src/linux.rs
@@ -1,0 +1,102 @@
+//! The real [`SystemProbe`], reading the same places `uname -r`,
+//! `getconf PAGE_SIZE`, the kernel's own `isolcpus=` cmdline parser and
+//! `ip link show can0` themselves read.
+
+use crate::SystemProbe;
+use std::fs;
+
+/// Reads the live system via `/proc` and `/sys`. No caching, no root
+/// required -- every path here is world-readable.
+#[derive(Debug, Default)]
+pub struct RealProbe;
+
+impl SystemProbe for RealProbe {
+    fn kernel_release(&self) -> Result<String, String> {
+        fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|s| s.trim().to_string())
+            .map_err(|e| format!("/proc/sys/kernel/osrelease: {e}"))
+    }
+
+    fn page_size_bytes(&self) -> Result<usize, String> {
+        // SAFETY: sysconf with a valid, read-only query name has no
+        // preconditions beyond that; it never touches memory we own.
+        let n = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if n <= 0 {
+            Err(format!("sysconf(_SC_PAGESIZE) returned {n}"))
+        } else {
+            Ok(n as usize)
+        }
+    }
+
+    fn isolated_cpus(&self) -> Result<Vec<u32>, String> {
+        let cmdline =
+            fs::read_to_string("/proc/cmdline").map_err(|e| format!("/proc/cmdline: {e}"))?;
+        let token = cmdline
+            .split_whitespace()
+            .find_map(|tok| tok.strip_prefix("isolcpus="))
+            .ok_or_else(|| "no isolcpus= token in /proc/cmdline".to_string())?;
+        parse_cpu_list(token)
+    }
+
+    fn can0_bitrate_bps(&self) -> Result<Option<u32>, String> {
+        let path = "/sys/class/net/can0/can_bittiming/bitrate";
+        match fs::read_to_string(path) {
+            Ok(s) => s
+                .trim()
+                .parse::<u32>()
+                .map(Some)
+                .map_err(|e| format!("{path}: {e}")),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(format!("{path}: {e}")),
+        }
+    }
+}
+
+/// Parses the kernel cpu-list grammar `isolcpus=` (and several other boot
+/// parameters) uses: comma-separated entries, each a single core or an
+/// inclusive `a-b` range.
+fn parse_cpu_list(token: &str) -> Result<Vec<u32>, String> {
+    let mut out = Vec::new();
+    for part in token.split(',') {
+        if let Some((lo, hi)) = part.split_once('-') {
+            let lo: u32 = lo
+                .parse()
+                .map_err(|_| format!("bad isolcpus range '{part}'"))?;
+            let hi: u32 = hi
+                .parse()
+                .map_err(|_| format!("bad isolcpus range '{part}'"))?;
+            out.extend(lo..=hi);
+        } else {
+            out.push(
+                part.parse()
+                    .map_err(|_| format!("bad isolcpus entry '{part}'"))?,
+            );
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_core() {
+        assert_eq!(parse_cpu_list("3").unwrap(), vec![3]);
+    }
+
+    #[test]
+    fn parses_range() {
+        assert_eq!(parse_cpu_list("2-4").unwrap(), vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn parses_mixed_list() {
+        assert_eq!(parse_cpu_list("0,2-4,7").unwrap(), vec![0, 2, 3, 4, 7]);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(parse_cpu_list("not-a-number").is_err());
+    }
+}

--- a/crates/platform-contract/src/main.rs
+++ b/crates/platform-contract/src/main.rs
@@ -1,0 +1,33 @@
+//! Checks the running system against [`platform_contract::STAGE0B`] and
+//! exits non-zero if it does not match closely enough to arm on.
+//!
+//! Not wired into anything yet -- see the crate doc comment (`src/lib.rs`)
+//! for why: #182 I5, the controller binary pipeline, has not landed, so
+//! there is no path onto the Pi image for this binary (or any other from
+//! this workspace) today. This exists so the check itself is built and
+//! tested now rather than blocked on I5.
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    #[cfg(target_os = "linux")]
+    {
+        let probe = platform_contract::linux::RealProbe;
+        let report = platform_contract::evaluate(&platform_contract::STAGE0B, &probe);
+        println!("{report}");
+        if report.ok_to_arm() {
+            ExitCode::SUCCESS
+        } else {
+            eprintln!(
+                "platform-contract: refusing to arm -- the running platform does not match \
+                 the checked-in contract"
+            );
+            ExitCode::FAILURE
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        println!("platform-contract: no-op off Linux -- the contract it checks is Pi-5-specific");
+        ExitCode::SUCCESS
+    }
+}


### PR DESCRIPTION
## What changed

New crate `crates/platform-contract`: a checked-in runtime contract (kernel release, page size, `isolcpus` layout, `can0` bitrate) plus a `SystemProbe` trait and `evaluate()` that compares it against the live system, returning a per-field `Match`/`Mismatch`/`Unavailable` status and an `ok_to_arm()` verdict. A Linux `RealProbe` reads `/proc` and `/sys` the same way `uname -r`, `getconf PAGE_SIZE` and `ip link show can0` themselves do; the crate still builds off Linux (issue #62's target-gating precedent — see `crates/can-harness/Cargo.toml`).

## Why

Issue #182 I6: *"the platform contract, asserted rather than documented."* D1 (`docs/design-pi-image-stage0b.md`) argues the repo stays unsplit partly because "nothing detects a runtime-contract mismatch except running both halves together, and that surfaces as a wrong, unattributable bench number." This is that detection as a one-line, testable check, independent of the repo-layout question.

## Which acceptance criteria this satisfies

Issue #182's I6 increment: *"A checked-in manifest the controller verifies at arm time: `uname -r`, page size, `isolcpus` mask, `can0` bitrate — refuse to arm on mismatch."* All four fields are implemented, with `Report::ok_to_arm()` as the refuse-to-arm verdict.

`STAGE0B`'s values are sourced from measurement, not guessed: `kernel_release` is the literal string `uname -a` confirmed on real hardware (`docs/design-pi-image-stage0b-reference.md` Q11/Q12, closed 2026-08-07), `isolated_cpus`/`can0_bitrate_bps` come from `scripts/pi/image/device/overboard-pi5/device.yaml` and `overboard-can0.service` respectively, and `page_size_bytes` is the 4K-page cost the design doc accepts explicitly for this kernel.

Because those values are necessarily restated (Rust can't source `pins.env` or parse YAML/systemd-unit text at compile time), `tests::contract_matches_checked_in_pins` is a duplication guard in the same spirit as `scripts/pi/check_image_pin.py`'s existing one for the kernel pin: it reads the actual checked-in files on every `cargo test` and fails if `STAGE0B` drifts from them. **Verified it actually fails, not just green over nothing:** broke the constant locally, watched the test catch it, then reverted.

13 unit tests total (mismatch/match/unavailable per field, the `ok_to_arm` semantics around a HAT-absent `can0`, and the `isolcpus=` cpu-list parser). `cargo test -p platform-contract`, `cargo clippy -p platform-contract --all-targets -- -D warnings`, and `cargo fmt --check` all pass. Ran a workspace-wide build/test/clippy pass excluding the MuJoCo-dependent crates (this sandbox has no MuJoCo install, an environment limitation unrelated to this change; `platform-contract` has no dependency on `plant-mujoco` — confirmed via `cargo metadata`). `cargo run -p xtask -- gate` and `python3 .github/policy_check.py` both still pass.

## Deliberately left out

**Wiring this into a systemd unit or a hardware backend's `arm()` call.** #182 I5 (the controller binary pipeline / `controller-latest` release) has not landed — `scripts/pi/image/layer/overboard-base.yaml`'s own comment says so directly: *"no Overboard binary is in this image at all (#182 I5)."* There is currently no mechanism that puts any binary from this workspace onto the Pi image, this one included. Shipping a systemd unit that `ExecStart`s a binary path nothing will ever populate would be exactly the unverifiable/undeployable shape of change this project's culture already rules out (same reasoning as the `can-harness` vcan-in-CI precedent). The check is built and tested now so it is not blocked on I5; wiring it into a boot unit or into a real hardware backend's `arm()` (AC-14's shape, once such a backend exists — none does yet, confirmed by reading `board-app-ridden`/`board-app-driverless`) is that later work's own increment.

Not closing #182 with this PR — it is a multi-increment epic (I0–I4 already landed across many other merged PRs; I5, I7, I8 remain open and unowned by this change).

## Turf

`crates/` and `scripts/` only — both Senior Controls turf per `.github/CODEOWNERS` (verified with `policy_check.py --who`). No `docs/` edits (COO turf); `policy_check.py`'s advisory doc-drift scan came back clean for this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DwGf2513pwqQ188bYbX95n)_