### PR TITLE
fix(controls): make disturbance forces' world-frame convention explicit and enforced (#194)

### DIFF
--- a/crates/sim-host/src/host.rs
+++ b/crates/sim-host/src/host.rs
@@ -1239,7 +1239,10 @@ const HANDOFF_TILT_RAD: f32 = 35.0 * std::f32::consts::PI / 180.0;
 /// `impulse-response-rust` uses (issue #107 AC6: `NOMINAL_IMPULSE_NS` = 20
 /// N*s over 0.05 s), reused rather than invented; direction and application
 /// point mirror that binary's own `ImpulseParams` defaults too (force along
-/// -X, zero torque).
+/// -X, zero torque). **World frame** (issue #194): fired at `t=1.0s`, before
+/// any steer input, so this has never yet been able to land at a non-zero
+/// heading -- but the constant itself does not know that and does not rotate
+/// with heading if that ever changes.
 const STARTUP_KICK_T0_S: f64 = 1.0;
 const STARTUP_KICK_DURATION_S: f64 = 0.05;
 const STARTUP_KICK_FORCE_N: [f64; 3] = [-(20.0 / STARTUP_KICK_DURATION_S), 0.0, 0.0];
@@ -1270,7 +1273,15 @@ const STARTUP_KICK_FORCE_N: [f64; 3] = [-(20.0 / STARTUP_KICK_DURATION_S), 0.0, 
 /// direction/torque convention as the startup kick (force along -X, zero
 /// applied torque -- the pitching moment comes from the wheel-ground
 /// contact being below the force's application point, not from any
-/// deliberately-applied torque).
+/// deliberately-applied torque). **World frame, not body frame** (issue
+/// #194): this is operator-triggered and CAN land while the board is mid-carve
+/// at a non-zero heading (unlike the startup kick above, which cannot). It
+/// pushes along world -X regardless -- an exogenous "something hit the board"
+/// shove is what this exists to simulate, and that does not rotate with the
+/// board any more than a real kerb does. If a future need wants this to read
+/// as "push the nose" during a turn, that is a body-frame push and belongs at
+/// the call site (rotate before it reaches [`select_disturbance_force_torque`]),
+/// not a change to this constant.
 const FALL_KICK_DURATION_S: f64 = 0.05;
 const FALL_KICK_FORCE_N: [f64; 3] = [-(400.0 / FALL_KICK_DURATION_S), 0.0, 0.0];
 
@@ -1498,6 +1509,49 @@ pub struct Disturbance {
     pub force_n: [f64; 3],
     /// World-frame torque about the frame body's own origin, N*m.
     pub torque_nm: [f64; 3],
+}
+
+/// Picks which disturbance (if any) is live this tick, and returns its
+/// force/torque verbatim -- world frame, per [`apply_external_force`]'s own
+/// contract and every one of these sources' doc comments
+/// ([`Disturbance`], [`STARTUP_KICK_FORCE_N`], [`FALL_KICK_FORCE_N`]).
+///
+/// # Why this is its own function (issue #194)
+///
+/// Every disturbance this repo fires today -- the startup/fall kicks and the
+/// ADR-0011 kerb impulse -- is a physically world-anchored event: a kerb does
+/// not rotate with the board, and neither does an exogenous shove. Deliberately
+/// NOT taking a heading/yaw parameter is how that stays true rather than just
+/// documented: there is nothing here for a future edit to rotate by mistake,
+/// and the compiler enforces it, not a comment. A scenario that genuinely
+/// needs a body-frame push (e.g. a "nose shove" that must track the board
+/// mid-carve) does not exist today; when one does, it should rotate its own
+/// vector by the current heading before it reaches this function, not grow a
+/// silent frame flag here.
+///
+/// Precedence when windows overlap -- unchanged from the inline form this
+/// replaced: scheduled disturbance, then the startup kick, then the on-demand
+/// fall kick, then nothing. Windows are not expected to overlap in practice
+/// (the fall kick is operator-triggered and the other two are off by default
+/// or fixed to `t=1.0s`), so precedence over correctly rejecting an overlap is
+/// the acceptable simplification.
+fn select_disturbance_force_torque(
+    in_disturbance_window: bool,
+    disturbance: Option<Disturbance>,
+    in_kick_window: bool,
+    in_fall_kick_window: bool,
+) -> ([f64; 3], [f64; 3]) {
+    if in_disturbance_window {
+        let d =
+            disturbance.expect("in_disturbance_window is only set when cfg.disturbance is Some");
+        (d.force_n, d.torque_nm)
+    } else if in_kick_window {
+        (STARTUP_KICK_FORCE_N, [0.0; 3])
+    } else if in_fall_kick_window {
+        (FALL_KICK_FORCE_N, [0.0; 3])
+    } else {
+        ([0.0; 3], [0.0; 3])
+    }
 }
 
 impl Default for HostConfig {
@@ -2238,16 +2292,12 @@ pub fn run(cfg: HostConfig) -> Result<RunSummary, HostError> {
         let in_disturbance_window = cfg
             .disturbance
             .is_some_and(|d| (d.t0_s..d.t0_s + d.duration_s).contains(&t_known_s));
-        let (force, torque) = if in_disturbance_window {
-            let d = cfg.disturbance.expect("checked by is_some_and above");
-            (d.force_n, d.torque_nm)
-        } else if in_kick_window {
-            (STARTUP_KICK_FORCE_N, [0.0; 3])
-        } else if in_fall_kick_window {
-            (FALL_KICK_FORCE_N, [0.0; 3])
-        } else {
-            ([0.0; 3], [0.0; 3])
-        };
+        let (force, torque) = select_disturbance_force_torque(
+            in_disturbance_window,
+            cfg.disturbance,
+            in_kick_window,
+            in_fall_kick_window,
+        );
         backend.apply_external_force(force, torque);
 
         let obs = backend.wait_observe().map_err(HostError::Backend)?;
@@ -2871,6 +2921,65 @@ mod tests {
                 "yaw={yaw}: recovered ({p}, {r}), wanted ({pitch}, {roll})"
             );
         }
+    }
+
+    // --- Issue #194: disturbance forces are world-frame, on purpose ------
+
+    /// `select_disturbance_force_torque` takes no heading/yaw parameter --
+    /// this is checked by the compiler on every call, but this test pins the
+    /// consequence in the units the issue cares about: the same inputs
+    /// produce the exact same force/torque no matter what heading the board
+    /// is carrying "outside" the function. There is nothing to plumb a yaw
+    /// through even if a future edit wanted to.
+    #[test]
+    fn disturbance_force_is_independent_of_heading_by_construction() {
+        let d = Disturbance {
+            t0_s: 0.0,
+            duration_s: 1.0,
+            force_n: [12.0, -3.0, 0.0],
+            torque_nm: [0.0, 0.0, 4.0],
+        };
+        // "Heading" isn't even representable in this call -- the assertion
+        // is that the same (bool, Option<Disturbance>, bool, bool) tuple is
+        // the ENTIRE input, and it always returns the same output.
+        let first = select_disturbance_force_torque(true, Some(d), false, false);
+        let second = select_disturbance_force_torque(true, Some(d), false, false);
+        assert_eq!(first, second);
+        assert_eq!(first, (d.force_n, d.torque_nm));
+    }
+
+    /// Precedence when windows overlap, unchanged by the #194 extraction:
+    /// scheduled disturbance beats the startup kick beats the on-demand fall
+    /// kick beats nothing. A refactor-safety net, not new behaviour.
+    #[test]
+    fn disturbance_window_precedence_is_scheduled_then_startup_then_fall_then_none() {
+        let d = Disturbance {
+            t0_s: 0.0,
+            duration_s: 1.0,
+            force_n: [1.0, 0.0, 0.0],
+            torque_nm: [0.0, 0.0, 0.0],
+        };
+
+        // Scheduled disturbance wins even if the kick windows are also open.
+        assert_eq!(
+            select_disturbance_force_torque(true, Some(d), true, true),
+            (d.force_n, d.torque_nm)
+        );
+        // No scheduled disturbance: the startup kick wins over the fall kick.
+        assert_eq!(
+            select_disturbance_force_torque(false, None, true, true),
+            (STARTUP_KICK_FORCE_N, [0.0; 3])
+        );
+        // Only the fall kick window open.
+        assert_eq!(
+            select_disturbance_force_torque(false, None, false, true),
+            (FALL_KICK_FORCE_N, [0.0; 3])
+        );
+        // Nothing open: zero force, zero torque.
+        assert_eq!(
+            select_disturbance_force_torque(false, None, false, false),
+            ([0.0; 3], [0.0; 3])
+        );
     }
 
     // --- ADR-0011 criterion (b): the command-envelope reserve -----------

--- a/roles/senior-controls/log/2026-08-14-disturbance-force-world-frame.md
+++ b/roles/senior-controls/log/2026-08-14-disturbance-force-world-frame.md
@@ -1,0 +1,65 @@
+# Issue #194 — disturbance forces are world-frame, and that is now heading-dependent
+
+**PR:** fix/controls/disturbance-force-world-frame-194 (TBD number)
+
+## What was decided
+
+Every disturbance this repo fires today — the startup kick, the on-demand fall
+kick, and the ADR-0011 scheduled kerb impulse — is a physically world-anchored
+event (a kerb does not rotate with the board; neither does an exogenous
+shove). **World frame is the correct and already-intended convention for all
+of them.** No call site needs body-frame semantics today, so no rotation
+support was added. `apply_external_force`'s doc comment and the `Disturbance`
+struct's field docs already stated "world frame" explicitly before this PR —
+that part of the issue was already satisfied on master.
+
+## What changed
+
+- Extracted the inline force/torque selection in `host.rs::run()` into
+  `select_disturbance_force_torque`, a pure function that takes no
+  heading/yaw parameter at all — the contract is now enforced by the type
+  signature, not just a comment (matches this repo's general "encode it,
+  don't just document it" pattern, e.g. issue #208).
+- Two new unit tests: one pins that the function is heading-independent by
+  construction (same inputs -> same output, nothing to rotate even if a
+  future edit wanted to), one is a refactor-safety net for window precedence
+  (scheduled disturbance > startup kick > fall kick > none), unchanged from
+  the inline form it replaced.
+- `STARTUP_KICK_FORCE_N` / `FALL_KICK_FORCE_N` doc comments now state the
+  frame explicitly per-constant, not just at the mechanism. Also noted:
+  the startup kick has never been able to land at non-zero heading (fires at
+  t=1.0s, before any steer); the fall kick is operator-triggered and CAN land
+  mid-carve, which is the one live path the original issue flagged.
+- `sim/scenarios/impulse_response.py`'s `ImpulseParams.direction` docstring
+  now states the same world-frame convention and cross-references the Rust
+  side, so the contract reads the same on both languages' disturbance APIs.
+
+## Deliberately left out
+
+No body-frame rotation was added to `SimBackend`/`apply_external_force` —
+nothing on hand needs it. If a future scenario wants a "push the nose" that
+tracks the board mid-carve, that is a body-frame push and belongs at the call
+site (rotate the vector by current heading before calling
+`select_disturbance_force_torque`), not a hidden frame flag added here.
+
+## Verification
+
+`cargo test --workspace` clean (all crates), `cargo clippy -p sim-host
+--all-targets -- -D warnings` clean, `cargo fmt -p sim-host -- --check`
+clean, `pytest tests/test_impulse_response.py` (16 tests) clean,
+`python3 .github/policy_check.py` — all hard checks pass (10 roles, 42
+ownership rules); only pre-existing advisories, none introduced by this
+change.
+
+## Also noticed, out of scope
+
+Issue #271 ("Allow steering during a tail brake") describes code that does
+not exist anywhere on current `master` — no `EngageState` enum, no
+`TailBraking` state, nothing matching `tail.brak`/`TailBrak` in the whole
+tracked tree or in `git log -S` history on this branch. `grep`/`git grep`
+across `crates/`, `docs/decisions/ADR-0011-*.md`, and the full repo turned up
+nothing. Flagging rather than picking it up: either the issue is stale (the
+described feature was never actually landed, contrary to its "CEO decision
+2026-08-12" framing), or it references a branch this shallow clone cannot
+see. Worth a `verify-stale`-style check before anyone starts building the
+described `EngageState::TailBraking` match arm.

--- a/sim/scenarios/impulse_response.py
+++ b/sim/scenarios/impulse_response.py
@@ -99,7 +99,13 @@ class ImpulseParams:
     result depends on the impulse and not on the force profile."""
 
     direction: tuple[float, float, float] = (-1.0, 0.0, 0.0)
-    """Unit direction of the push. Forward (-X) to start; lateral is follow-on."""
+    """Unit direction of the push, WORLD frame -- written straight into
+    `data.xfrc_applied`, which MuJoCo interprets in world coordinates, and
+    never rotated by the board's heading. Forward (-X) to start; lateral is
+    follow-on. This is the same convention `crates/sim-host`'s
+    `apply_external_force`/`Disturbance` use for the Rust-hosted kerb and kick
+    disturbances (issue #194) -- both sides model an exogenous, physically
+    world-anchored shove, not one that tracks the board's nose."""
 
     application_height_m: float = 0.0
     """Height above the frame's centre of mass at which the push lands.


### PR DESCRIPTION
## What changed

Issue #194 flagged a latent contract risk: every disturbance this repo fires
(startup kick, on-demand fall kick, ADR-0011 scheduled kerb impulse) is
applied in **world frame**, which is physically correct (a kerb, or an
exogenous shove, does not rotate with the board) — but PR #193 made board
heading real, so a future edit that rotated one of these "to account for
heading" would have been an easy, silent, and wrong fix. Nothing measured
today is actually broken; this closes the gap before it bites, per the
issue's own framing.

- **Extracted** the inline force/torque selection in `host.rs::run()` into
  `select_disturbance_force_torque` — a pure function that takes **no
  heading/yaw parameter at all**. The contract ("these do not rotate with
  heading") is now enforced by the type signature, not just a comment.
- **Added two unit tests**: one pins heading-independence (same inputs ->
  same output; there's nothing to plumb a yaw through even if a future edit
  wanted to), one is a refactor-safety net for window precedence (scheduled
  disturbance > startup kick > fall kick > none), unchanged behavior from the
  inline form it replaced.
- **Documented the frame explicitly per-constant**: `STARTUP_KICK_FORCE_N`
  and `FALL_KICK_FORCE_N`'s doc comments now state "world frame" directly,
  not just at the `apply_external_force`/`Disturbance` mechanism level (which
  already said so). Noted which of the two can actually land at non-zero
  heading today: the startup kick fires at `t=1.0s` before any steer input
  and never has; the on-demand fall kick is operator-triggered and *can* land
  mid-carve — the one live path the issue flagged.
- **Python side**: `sim/scenarios/impulse_response.py`'s
  `ImpulseParams.direction` docstring now states the same world-frame
  convention and cross-references the Rust side, so both languages'
  disturbance APIs read the same contract.

## Acceptance

The issue posed this as a decision (world vs. body frame, possibly per call
site) plus two follow-ups conditioned on the answer. The decision: **world
frame is correct for every disturbance spec that exists today**, since all of
them model physically world-anchored events — so no per-call-site divergence
was needed, and no rotation code was needed. What was missing was making that
decision explicit and durable rather than implicit, which is what this PR
does.

## Deliberately left out

No body-frame rotation was added to `SimBackend`/`apply_external_force` —
nothing on hand needs it, and building it now would be speculative. If a
future scenario wants a "push the nose" that tracks the board mid-carve, that
is a body-frame push and belongs at the call site (rotate the vector by
current heading before calling `select_disturbance_force_torque`), not a
hidden frame flag added here.

## Verification

- `cargo test --workspace` — clean, all crates (new tests:
  `disturbance_force_is_independent_of_heading_by_construction`,
  `disturbance_window_precedence_is_scheduled_then_startup_then_fall_then_none`)
- `cargo clippy -p sim-host --all-targets -- -D warnings` — clean
- `cargo fmt -p sim-host -- --check` — clean
- `pytest tests/test_impulse_response.py` — 16 passed
- `python3 .github/policy_check.py` — all hard checks pass (10 roles, 42
  ownership rules); only pre-existing advisories, none introduced here

Closes #194.

## Also noticed, out of scope

Issue #271 ("Allow steering during a tail brake") describes code
(`EngageState::TailBraking`, a ballast no-op above `set_ballast_targets`)
that does not exist anywhere on current `master` — confirmed with
`git grep`/`grep` across `crates/`, `docs/decisions/ADR-0011-*.md`, and the
full tracked tree, and `git log -S"EngageState"` on this branch's history.
Flagging rather than picking it up: either the issue is stale (the described
feature was never actually landed, despite its "CEO decision 2026-08-12"
framing) or it references a branch this shallow clone can't see. Worth a
`verify-stale`-style check before anyone starts building the described state
machine from scratch.


---
_Generated by [Claude Code](https://claude.ai/code/session_015TU7K5im7QDpseGyUpVji9)_