### PR TITLE
fix(controls): hill.py's estimator-error mechanism claim was never the active config (#228)

### DIFF
--- a/roles/senior-controls/log/2026-08-14-hill-estimator-mechanism-attribution.md
+++ b/roles/senior-controls/log/2026-08-14-hill-estimator-mechanism-attribution.md
@@ -1,0 +1,28 @@
+# Issue #228 — hill.py's estimator mechanism claim was never the active config (PR #281)
+
+Issue #228 names `tests/test_terrain.py`, but that file makes no mechanism claim at all —
+checked its full git history (`git log --follow`), `CommandFeedforward` has never appeared
+there. The real misattribution is in `sim/scenarios/hill.py`'s module docstring and
+`tests/test_hill.py`'s `test_the_estimator_absorbs_the_slope_into_its_attitude_error`: both
+claimed the hill scenario runs on `CommandFeedforward` and derived the ≈slope-angle RMS error
+from that mechanism. `hill.py`'s `run()` never actually passes `estimator_accel_aiding` to
+`RustController`, so the scenario runs on `RustController`'s own default — mode 1
+(`WheelAccelEstimator`, wheel odometry) — not mode 2 as claimed.
+
+**Forced mode 2 on directly (real shipped gain, `ACCEL_FF_GAIN_M_S2_PER_A = 0.0584`) and
+measured `est_error_over_slope` ≈ 0.036 at 5% and 10% grade — nowhere near the ≈0.81/0.84 mode
+1 actually produces** (which matches the existing 0.6–1.3x test band and the docstring's
+"≈0.87x across 5–20%" line unchanged). So the retracted mechanism doesn't reproduce even under
+the estimator it names — not just misattributed to the wrong file, falsified as an explanation.
+
+Retracted the claim in both docstrings, kept the numbers (still real, still measured), stated
+which estimator is actually configured, and **flagged rather than guessed** at what in mode 1
+actually produces the near-slope-angle error. No control code, gain, or estimator config
+changed — documentation-only. Verified: full `pytest tests/` (333 passed, 5 xfailed, unchanged
+before/after), clean `policy_check.py`.
+
+**Deliberately left out:** issue #228's second ask (confirm a "steady/rolling inversion at
+12–14% under a 60A envelope" claim). Searched the full git history of `test_terrain.py`,
+`hill.py` and `terrain.py` and could not find that claim anywhere, past or present. Not closed
+as "does not reproduce" — could not locate it to test at all, which is weaker and different,
+so flagged rather than asserted either way.

--- a/sim/scenarios/hill.py
+++ b/sim/scenarios/hill.py
@@ -30,14 +30,31 @@ the good news it looks like. What actually breaks is *speed authority*:
 commanded 1.0 m/s down a 10% grade, the board finishes above 11 m/s, and the
 final speed is almost completely insensitive to the commanded speed.
 
-The mechanism is the one the handoff derived, and it survives the frame fix
-intact. `CommandFeedforward` predicts forward acceleration as `K_ff·I` and
-subtracts it from the accelerometer. On a slope, much of that current is
-fighting *gravity* rather than accelerating anything, so the feedforward
-attributes gravity-holding torque to acceleration. The resulting apparent-tilt
-error is, to first order, **the slope angle itself** — the estimator believes a
-board on a hill is level. Holding "level" on a hill means accelerating down it.
-Measured here: estimator RMS error tracks ≈0.87 × the slope angle across 5–20%.
+**Correction (issue #228): the paragraph below is what an earlier version of
+this file claimed, and it is wrong about which estimator produces the
+measured number.** `run()` never passes `estimator_accel_aiding` to
+`RustController`, so this scenario actually runs on `RustController`'s own
+default, **mode 1 (`WheelAccelEstimator`, wheel-odometry)** — `CommandFeedforward`
+(mode 2) is not configured here despite `estimator_tau_s`'s docstring below
+having claimed otherwise. Re-run with mode 2 forced on and the real shipped
+gain (`ACCEL_FF_GAIN_M_S2_PER_A = 0.0584`, from `host.rs`/`loop-profiler`):
+`est_error_over_slope` drops to ≈0.036 at both 5% and 10% grade, nowhere near
+the ≈0.8–0.84 this file actually measures under mode 1. So the mechanism
+described below does not reproduce even under the estimator it names — it is
+not merely misattributed, it is falsified as an explanation. What error
+mode 1 is actually attributing to slope-angle-sized tilt has **not been
+re-derived here**; that is open, flagged rather than guessed at.
+
+The original claim, kept for the record and as the thing now retracted:
+`CommandFeedforward` predicts forward acceleration as `K_ff·I` and subtracts
+it from the accelerometer. On a slope, much of that current is fighting
+*gravity* rather than accelerating anything, so the feedforward attributes
+gravity-holding torque to acceleration. The resulting apparent-tilt error is,
+to first order, **the slope angle itself** — the estimator believes a board on
+a hill is level. Holding "level" on a hill means accelerating down it.
+Measured here: estimator RMS error tracks ≈0.87 × the slope angle across 5–20%
+— **this number is still what mode 1 measures** (`test_hill.py`'s own
+5%/10% check: ≈0.81/0.84); only the causal story attached to it is retracted.
 
 So the gate is on **speed authority**, and nose strike is reported as the
 secondary, more violent outcome rather than the primary one. A scenario that
@@ -137,9 +154,14 @@ class HillParams:
     ballast_mass_kg: float = 70.0
     ballast_height_m: float = 0.75
     max_current_a: float = 40.0
-    #: Estimator crossover. The handoff's recommended config is tau = 2 s with
-    #: command feedforward, and this scenario defaults to it because a hill run
-    #: on truth pitch cannot show the failure that makes hills dangerous.
+    #: Estimator crossover, tau = 2 s. The handoff's recommended config paired
+    #: this with command feedforward, but `run()` below never passes
+    #: `estimator_accel_aiding` to the controller, so this scenario actually
+    #: runs on `RustController`'s own default, mode 1 (wheel odometry) --
+    #: corrected by issue #228, see the module docstring's mechanism note. A
+    #: hill run on truth pitch still can't show the failure that makes hills
+    #: dangerous, which is the reason a tau this long matters here regardless
+    #: of which aiding source ends up active.
     estimator_tau_s: float = 2.0
     use_estimator: bool = True
     #: 0 = commanded current, 1 = measured. Hardware must use 1; the default

--- a/tests/test_hill.py
+++ b/tests/test_hill.py
@@ -262,12 +262,19 @@ def test_the_estimator_is_what_loses_the_hill_not_the_motor():
 
 
 def test_the_estimator_absorbs_the_slope_into_its_attitude_error():
-    """The predicted first-order mechanism, measured.
+    """The apparent-tilt-approaches-slope-angle result, measured -- **not** the
+    mechanism issue #228 found this docstring previously claimed for it.
 
-    `CommandFeedforward` attributes gravity-holding current to acceleration, so
-    the apparent-tilt error approaches the slope angle itself and the estimator
-    believes a board on a hill is level. Holding "level" on a hill means
-    accelerating down it.
+    `run()` never passes `estimator_accel_aiding` to the controller, so this
+    scenario runs on `RustController`'s own default, mode 1 (`WheelAccelEstimator`,
+    wheel odometry) -- not `CommandFeedforward` (mode 2), which the code here
+    does not configure. Forcing mode 2 on with the real shipped gain
+    (`ACCEL_FF_GAIN_M_S2_PER_A = 0.0584`) measures `est_error_over_slope` ≈ 0.036
+    at both grades below, nowhere near the ~0.8-0.84x this test actually gates
+    on -- so the retracted mechanism does not reproduce even under the
+    estimator it names. What in mode 1 actually produces the near-slope-angle
+    error is open; not re-derived here, see `sim/scenarios/hill.py`'s module
+    docstring.
     """
     for grade in (5.0, 10.0):
         m = run(HillParams(grade_pct=grade, v_ref_m_s=1.0, duration_s=SHORT)).metrics
@@ -275,7 +282,9 @@ def test_the_estimator_absorbs_the_slope_into_its_attitude_error():
         assert 0.6 < m.est_error_over_slope < 1.3, (
             f"{grade}% grade: estimator error was {m.est_error_over_slope:.2f}x the "
             f"slope angle ({m.pitch_est_rms_deg:.2f} deg vs {m.slope_angle_deg:.2f} deg). "
-            "The mechanism predicts ~1x; a value far from it means the mechanism moved."
+            "This band is a measured characterisation of mode 1's behaviour, not a "
+            "derivation from a known mechanism -- a value outside it means mode 1's "
+            "behaviour moved, re-derive rather than widen."
         )
 
 


### PR DESCRIPTION
## What changed

Issue #228 names `tests/test_terrain.py`, but that file makes no mechanism claim at all — I checked its **full git history** (`git log --follow`) and `CommandFeedforward` has never appeared there, in any commit.

The real misattribution is in **`sim/scenarios/hill.py`'s module docstring** and **`tests/test_hill.py`'s `test_the_estimator_absorbs_the_slope_into_its_attitude_error`**: both claim the hill scenario runs on `CommandFeedforward` (current-proportional gravity misattribution) and derive the ≈slope-angle RMS error from that mechanism.

`hill.py`'s `run()` never passes `estimator_accel_aiding` to `RustController`, so it actually runs on `RustController`'s own default — **mode 1, `WheelAccelEstimator` (wheel odometry)** — confirmed by reading the code, not inferred.

I then forced mode 2 on directly (via `controller_factory`) with the real shipped gain (`ACCEL_FF_GAIN_M_S2_PER_A = 0.0584`, from `host.rs`/`loop-profiler`) and measured:

| grade | mode 1 (actual default) `est_error_over_slope` | mode 2 (CommandFeedforward, real gain) |
|---|---|---|
| 5% | 0.808 | 0.036 |
| 10% | 0.844 | 0.036 |

Mode 1's numbers match the existing test band (0.6–1.3x) and the docstring's "≈0.87x across 5–20%" line — **the measured number was always real**. Mode 2, under the mechanism the docstring blames, produces essentially zero error. So the retracted explanation doesn't reproduce even under the estimator it names — it isn't just misattributed to the wrong file, it's a falsified explanation of the number.

## What I did

- Retracted the false mechanism claim in both docstrings, kept the (unchanged, still-measured) numbers, stated which estimator is actually configured, and **flagged rather than guessed** at what in mode 1 actually produces the near-slope-angle error — I did not invent a replacement mechanism.
- **No control code, gain, or estimator configuration changed.** This is a documentation/comment-only correction.

## Verification

- `pytest tests/` — 333 passed, 5 xfailed, no change from before this edit (ran full suite before and after).
- `python3 .github/policy_check.py` — clean, only pre-existing advisories unrelated to these files.
- Both touched files are Senior Controls turf (`sim/`, `tests/`) per `policy_check.py --who`.

## Deliberately left out

Issue #228's second ask — confirm whether a "steady/rolling inversion at 12–14% under a 60A envelope" claim reproduces. I searched the full git history of `test_terrain.py`, `hill.py`, and `terrain.py` and could not find that specific claim anywhere, past or present. I'm not closing that half as "does not reproduce" — I could not locate it to test it at all, which is a different and weaker claim, so I'm flagging it rather than asserting either way.

Closes #228


---
_Generated by [Claude Code](https://claude.ai/code/session_016wemLehBchBLg9bPUB8cQY)_