### PR TITLE
fix(controls): strip baked-in SSH host keys from the Stage-0B image (#284)

### DIFF
--- a/scripts/pi/build_image.sh
+++ b/scripts/pi/build_image.sh
@@ -100,6 +100,25 @@ else
   exit 1
 fi
 
+section "no baked-in ssh host keys (#284)"
+
+# openssh-server's postinst generates host keys at package-install time,
+# inside THIS build container -- every image built from a given container
+# state would otherwise ship the identical private key, published as a
+# public CI artefact anyone can download and use to impersonate the board.
+# overboard-base.yaml's customize-hooks strip them from the rootfs; this is
+# the second line of defence in case that hook is ever weakened without
+# anyone noticing until a card ships.
+leaked_keys="$(find "$WORK/work" -path '*/etc/ssh/ssh_host_*' 2>/dev/null)"
+if [ -n "$leaked_keys" ]; then
+  echo "FATAL: /etc/ssh/ssh_host_* found in the built rootfs -- every card"
+  echo "       flashed from this image would share the same SSH identity."
+  echo "$leaked_keys" | sed 's/^/         /'
+  exit 1
+else
+  echo "OK: no ssh_host_* files in the built rootfs"
+fi
+
 section "collect artefacts"
 mkdir -p "$OUT"
 rm -f "$OUT"/*

--- a/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-ssh-hostkeys.service
+++ b/scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-ssh-hostkeys.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Overboard SSH host key generation
+# openssh-server's postinst generates host keys at PACKAGE-INSTALL time --
+# inside the build container, not on the card. Every image built from that
+# container would otherwise ship the identical private key, published as a
+# public CI artefact anyone can download and use to impersonate the board
+# (#284). overboard-base.yaml's customize-hooks strip /etc/ssh/ssh_host_*
+# from the built rootfs; this unit regenerates a fresh, unique pair before
+# sshd can start, which needs to exist for ssh.service to come up at all.
+#
+# `ssh-keygen -A` only creates key types that do not already exist, so this
+# is idempotent and safe to leave enabled on every boot -- unlike
+# overboard-firstboot.service there is no staged, single-use credential here
+# to shred, so no marker-file gating is needed.
+Before=ssh.service
+Wants=ssh.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ssh-keygen -A
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/pi/image/layer/overboard-base.yaml
+++ b/scripts/pi/image/layer/overboard-base.yaml
@@ -98,8 +98,26 @@ mmdebstrap:
       set -eu
       chroot "$1" dpkg-query -W -f='${Package}=${Version}\n' | sort > "$1/etc/overboard-packages.txt"
 
+    # -----------------------------------------------------------------------
+    # #284: openssh-server's postinst generates host keys at PACKAGE-INSTALL
+    # time, which just happened above, inside this build container -- so
+    # every image built from a given container state would ship the
+    # identical private key, published as a public CI artefact anyone can
+    # download and use to impersonate the board. Strip them here; the
+    # overboard-ssh-hostkeys unit (enabled below) generates a fresh, unique
+    # pair on the card's own first boot, before ssh.service can start.
+    # -----------------------------------------------------------------------
+    - |
+      set -eu
+      rm -f "$1"/etc/ssh/ssh_host_*
+      if ls "$1"/etc/ssh/ssh_host_* >/dev/null 2>&1; then
+        echo "FATAL: ssh host keys survived the strip hook" >&2
+        exit 1
+      fi
+
     # enable-units rather than `chroot systemctl enable`: the idiomatic helper
     # here, and it works when the chroot's systemd cannot be run natively.
     - $BDEBSTRAP_HOOKS/enable-units "$1" overboard-firstboot
     - $BDEBSTRAP_HOOKS/enable-units "$1" overboard-can0
     - $BDEBSTRAP_HOOKS/enable-units "$1" overboard-vcan0
+    - $BDEBSTRAP_HOOKS/enable-units "$1" overboard-ssh-hostkeys


### PR DESCRIPTION
## What changed

Issue #284, found on hardware 2026-08-16: `openssh-server`'s postinst generates SSH host keys at **package-install time**, inside the CI build container — so every card built from a given container state ships the identical private key, published as a public CI artefact anyone can download and use to impersonate the board.

- **`scripts/pi/image/layer/overboard-base.yaml`**: new `customize-hooks` entry strips `/etc/ssh/ssh_host_*` from the built rootfs, with a self-check that fails the hook itself if any key survives the `rm`.
- **`scripts/pi/image/layer/overboard-base.rootfs-overlay/etc/systemd/system/overboard-ssh-hostkeys.service`**: new first-boot unit, `Before=ssh.service`, that runs `ssh-keygen -A` to generate a fresh, unique pair on the card. `ssh-keygen -A` only creates key types that don't already exist, so this is idempotent and needs none of `overboard-firstboot.service`'s marker-file gating — there's no staged, single-use credential to shred here.
- **`scripts/pi/build_image.sh`**: a second-line-of-defence CI assertion (same style as the existing kernel-selection check) that fails the build if any `ssh_host_*` file is present anywhere in the built rootfs.

## Acceptance criteria (from #284)

- [x] The built image contains no `/etc/ssh/ssh_host_*` — the customize-hook removes them, and self-verifies.
- [x] Two cards flashed from one image present different host key fingerprints — `overboard-ssh-hostkeys.service` generates a fresh pair per card, per boot-until-present.
- [x] A CI assertion fails the build if any `ssh_host_*` file is present in the rootfs — `build_image.sh`'s new section.

## Verification

- `python3 scripts/pi/check_layer_headers.py`, `python3 scripts/pi/check_no_secrets.py`, `python3 scripts/pi/check_image_pin.py` — all clean.
- `python3 .github/policy_check.py` — all hard checks pass (pre-existing advisories only, none touched by this change).
- `bash -n scripts/pi/build_image.sh` — clean; the new hook's shell fragment parses standalone.
- Parsed `overboard-base.yaml`'s `customize-hooks` list with PyYAML after stripping the `METABEGIN`/`METAEND` header, confirmed 7 hooks including the new one, in order.
- **Could not verify end-to-end**: this sandbox has no privileged Docker / arm64 host to actually run `build_image.sh`'s 90-minute `rpi-image-gen` build, and has no `ssh-keygen` binary installed at all to smoke-test the unit's `ExecStart` locally. `/usr/bin/ssh-keygen` is the standard path shipped by Debian's `openssh-client` (a dependency of `openssh-server`, already pinned into this image via the `openssh-server` package in `overboard-base.yaml`) — verified the path exists as a matter of Debian packaging convention, not by running it. The `pi-image` workflow's `build-image` job will run the new build-time hook and CI assertion for real on this PR.

## Deliberately left out

- The `Before=ssh.service` ordering relies on `ssh.service` also being pulled into the `multi-user.target` transaction (the same pattern `overboard-firstboot.service` already uses successfully for `NetworkManager.service`) rather than an explicit `DefaultDependencies=no` / `sysinit.target` ordering — kept to the codebase's existing, proven unit style rather than inventing new low-level ordering I have no way to boot-test here.
- Did not touch `pins.env` or `PINNED_PACKAGES` — this issue is about key generation timing, not package pins.
- Companion issues #285 (rootfs never expands on first boot) and #286 (wifi backend missing, `wpasupplicant` unpinned) are separate, each its own PR — not bundled in here, though all three were found together on the same hardware bring-up session.

Closes #284.


---
_Generated by [Claude Code](https://claude.ai/code/session_0153q8XRrzUbBWsE8XJfYMRT)_