### PR TITLE
fix(controls): pin and ship wpasupplicant + python3-spidev (#286)

### DIFF
--- a/scripts/pi/image/layer/overboard-base.yaml
+++ b/scripts/pi/image/layer/overboard-base.yaml
@@ -53,6 +53,15 @@ mmdebstrap:
     # be inspected. Ship the tools the scripts actually call.
     - iw
     - rfkill
+    # network-manager above has nothing to drive the radio without this: the
+    # staged NetworkManager profiles reached `nmcli d` as `unavailable` and
+    # could never associate (issue #286, found on hardware 2026-08-16). The
+    # Debian package name is `wpasupplicant`, one word -- `wpa_supplicant`
+    # does not resolve.
+    - wpasupplicant
+    # Needed for any SPI encoder work, the next hardware step after CAN
+    # (issue #286).
+    - python3-spidev
     # Required by the STOCK image-rpios layer, not by us: its
     # `customize05-pkgs` hook shells out to apt inside the target, and a slim
     # base does not install apt there. Build round 4 died on

--- a/scripts/pi/pins.env
+++ b/scripts/pi/pins.env
@@ -83,12 +83,18 @@ BOOTLOADER_TIMESTAMP="1779807685"   # 2026-05-26T15:01:25Z
 BOOTLOADER_CHANNEL="default"        # NOT latest -- see above
 # ---------------------------------------------------------------------------
 
-# Bench and verification tooling. Versions verified against Debian trixie
-# arm64 on 2026-07-27 (see the verification log). CI is the check on whether
-# they are still satisfiable -- an unsatisfiable pin here is a RED BUILD by
+# Packages whose exact version is worth pinning explicitly: bench and
+# verification tooling (rt-tests, can-utils), plus anything a prior hardware
+# bring-up found missing entirely (wpasupplicant, python3-spidev -- issue
+# #286). `rt-tests`/`can-utils` were verified against Debian trixie arm64 on
+# 2026-07-27 (see the verification log); `wpasupplicant`/`python3-spidev`
+# against the trixie archive on 2026-08-17. CI is the check on whether they
+# are still satisfiable -- an unsatisfiable pin here is a RED BUILD by
 # design, and the correct response is to re-verify and move the pin, never to
 # unpin it.
 PINNED_PACKAGES="
 rt-tests=2.6-1.1
 can-utils=2023.03-1+b2
+wpasupplicant=2:2.10-24
+python3-spidev=3.6-1+b6
 "


### PR DESCRIPTION
## What changed

The Stage-0B image stages NetworkManager wifi profiles correctly (right SSID, `autoconnect=true`, priority 100) but has never shipped a wifi backend for NetworkManager to drive — `wpasupplicant` was missing entirely, so `nmcli d` reported `wlan0` as `unavailable` and the profiles were inert. Found on hardware 2026-08-16 (#286); this is what makes #285 (rootfs never expands) unrecoverable — a headless card with a full disk and no working network has no way in.

Two changes:
1. **`scripts/pi/image/layer/overboard-base.yaml`** — added `wpasupplicant` and `python3-spidev` to the `packages:` list, next to the existing `iw`/`rfkill` wifi-tooling block. This is what actually gets them installed on the image; `pins.env` alone doesn't drive package selection (verified by reading `build_image.sh` — the mmdebstrap `packages:` list is the only thing that does).
2. **`scripts/pi/pins.env`** — pinned both to explicit trixie/arm64 versions (`wpasupplicant=2:2.10-24`, `python3-spidev=3.6-1+b6`) in `PINNED_PACKAGES`, per AC-1 and per the issue's own ask. CI's `verify-pins` job resolves these against the live archive on every PR — that's the authority on whether the pin is right, not this PR. `python3-spidev`'s version matches what the issue reporter measured directly on hardware; `wpasupplicant`'s version I corroborated independently via web search against the Debian trixie archive (direct fetch of packages.debian.org is blocked from this sandbox, so I could not run `verify_pins.sh` myself before opening this — flagging that rather than claiming a verification I didn't do).

## Why not fixed differently

`cpufrequtils` (the issue's third finding) needed no change — `git grep` confirms zero references anywhere in the tree already, so that acceptance criterion is already satisfied.

## Acceptance criteria from #286

- [x] `pins.env` carries `wpasupplicant` and `python3-spidev` at explicit versions.
- [x] No reference to `cpufrequtils` survives anywhere in the tree (already true, confirmed).
- [ ] **"A freshly flashed card associates with a staged wifi profile on first boot, with no console intervention."** Cannot verify this from a sandbox with no Pi and no docker daemon — this needs the next hardware flash. Flagging rather than claiming it, per this project's rule against unverified facts.

## What I deliberately left out

- Did **not** attempt to bring the rest of the image's package list (`iw`, `rfkill`, `network-manager`, `openssh-server`, `avahi-daemon`, `apt`, `iproute2`, `stress-ng`) into `PINNED_PACKAGES`. `pins.env`'s header comment calls itself "the single source of truth for what goes on the card," which reads as broader than what it actually is: `PINNED_PACKAGES` only pins a subset (now: `rt-tests`, `can-utils`, `wpasupplicant`, `python3-spidev`), and the rest of the image's packages are unpinned, floating-version installs that `verify_pins.sh` never touches. That's a real, pre-existing gap against AC-1's literal wording ("every directly-installed package is pinned"), not something introduced or fixed here — flagging it rather than silently expanding this PR's scope to cover it.
- Did not attempt to run the actual image build or a QEMU boot (#261/PR #263, not yet merged, and QEMU can't emulate the wifi radio in any case) — this fix is functionally unverifiable outside a real flash.

## Checks run locally
- `python3 .github/policy_check.py` — clean (pre-existing advisories only, none new).
- `python3 scripts/pi/check_layer_headers.py` — clean.
- `python3 scripts/pi/check_image_pin.py` — clean.
- `scripts/pi/verify_pins.sh` — **not** run; needs the live Raspberry Pi archive + a `debian:trixie` container, neither reachable from this sandbox. CI's `verify-pins` job is the real check on the two new pins.

Relates to #182. Companion to #284/#285 (both already have open PRs, #287 and #288).


---
_Generated by [Claude Code](https://claude.ai/code/session_019NxHdkqR4sRNHrKd2WWo6X)_