### PR TITLE
feat(controls): cross-build and publish the controller binary from CI (#182 I5, partial)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,3 +567,99 @@ jobs:
           GH_TOKEN="$WEB_DISPATCH_TOKEN" gh api repos/MikePaNtZ/overboard-web/dispatches \
             -f event_type=sim-artifact \
             -F client_payload[commit]="${{ github.sha }}"
+
+  # ---------------------------------------------------------------------
+  # Issue #182 I5, first half only: prove the binary that will eventually
+  # run on the Pi actually cross-builds and publishes on every mainline
+  # merge. The other half of I5 -- an on-device pull/verify/restart script
+  # and its systemd unit -- is deliberately NOT here; see the PR that added
+  # this job for why (`board-app-driverless` links `libmujoco.so` dynamically
+  # and nothing yet provisions that library on a card, which is I7's
+  # question to answer, not this job's).
+  #
+  # Native ubuntu-24.04-arm, not a cross-compile off ubuntu-latest -- same
+  # choice pi-image.yml already made and documented: no QEMU, no cross
+  # linker to maintain, and it is the same architecture the mujoco wheel
+  # this build links against actually ships for (manylinux aarch64 wheels
+  # exist for 3.10.0, verified against PyPI's own JSON API).
+  publish-controller-binary:
+    needs: [rust]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    permissions:
+      contents: write        # rolling release upload
+    env:
+      ARTIFACT_SHA: >-
+        ${{ github.event_name == 'pull_request'
+            && github.event.pull_request.head.sha
+            || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Same pin, same reason as the `rust` job: plant-mujoco's build.rs
+      # links against whatever `import mujoco` resolves to, so the linked
+      # library must come from the one pin the rest of the repo tests
+      # against, not whatever a bare `pip install mujoco` would resolve to.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install MuJoCo (native dep for plant-mujoco's build.rs)
+        run: pip install "$(grep '^mujoco==' requirements-sim.txt)"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # The only binary with motion authority (ICD SS6.3, DR-MODE-1) --
+      # board-app-ridden is deliberately never shipped to run unattended.
+      - name: Build board-app-driverless (release, native aarch64)
+        run: cargo build --release -p board-app-driverless --bin board-app-driverless
+
+      - name: Stage artifact + checksum + provenance
+        run: |
+          mkdir -p dist
+          cp target/release/board-app-driverless \
+            "dist/board-app-driverless-aarch64-unknown-linux-gnu"
+          cd dist
+          sha256sum "board-app-driverless-aarch64-unknown-linux-gnu" \
+            > "board-app-driverless-aarch64-unknown-linux-gnu.sha256"
+          cat "board-app-driverless-aarch64-unknown-linux-gnu.sha256"
+          python3 - <<PY
+          import json, os
+          json.dump({
+              "schema": 1,
+              "commit": os.environ["ARTIFACT_SHA"],
+              "commit_short": os.environ["ARTIFACT_SHA"][:7],
+              "target": "aarch64-unknown-linux-gnu",
+              "bin": "board-app-driverless",
+              "run_url": f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
+          }, open("board-app-driverless-provenance.json", "w"), indent=2)
+          PY
+
+      # Rolling release = one stable URL an on-device update mechanism can
+      # poll, matching the sim-latest pattern below. Upsert rather than
+      # delete-then-create for the same reason as that job: a deleted-then-
+      # recreated release has a window where the download URL 404s.
+      #
+      # Master-push only, same guard as sim-latest's publish step -- a fork
+      # PR gets a read-only token and would fail the upload rather than skip
+      # it, and a per-commit preview channel is not asked for by issue #182's
+      # I5 (unlike the sim artifacts, nothing today would consume one).
+      - name: Publish to rolling controller-latest release
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view controller-latest >/dev/null 2>&1 || \
+            gh release create controller-latest \
+              --title "Latest controller binary (mainline)" \
+              --notes "Auto-published by CI. aarch64 release build of board-app-driverless, the motion-authority controller binary (ICD SS6.3). Not yet consumed on-device -- issue #182 I5/I7."
+          gh release edit controller-latest \
+            --notes "Auto-published by CI from ${{ github.sha }}. aarch64 release build of board-app-driverless. Not yet consumed on-device -- issue #182 I5/I7."
+          gh release upload controller-latest --clobber \
+            dist/board-app-driverless-aarch64-unknown-linux-gnu \
+            dist/board-app-driverless-aarch64-unknown-linux-gnu.sha256 \
+            dist/board-app-driverless-provenance.json


### PR DESCRIPTION
## What

Adds a `publish-controller-binary` job to `.github/workflows/ci.yml`: builds `board-app-driverless` (the only binary with motion authority, ICD §6.3 / DR-MODE-1) in release mode **natively on `ubuntu-24.04-arm`** — matching `pi-image.yml`'s established no-QEMU choice rather than cross-compiling off an x86_64 runner — and, on push to `master`, uploads the binary plus a sha256 checksum and a small provenance JSON to a rolling `controller-latest` GitHub Release. Same upsert-a-rolling-release pattern `publish-sim-artifact` already uses for `sim-latest`.

This is the first half of issue #182's **I5 — controller binary pipeline** increment: "arm64 cross-build on every master merge → rolling `controller-latest` release."

## Why

Issue #182 (Stage-0B) lists I5 as one of its increments, and nothing implementing it existed: no arm64 build of any controller binary, no release channel for one, no way to get a binary onto a card without a reflash. I0–I4 have already landed (image builds and boots; several of its bugs — wifi, SSH host keys, rootfs expand — are already out as their own issues/PRs), and I6 (`platform-contract`, the runtime-fact checker) already exists as a crate. I5 was the next concrete, well-scoped gap.

**Verified, not assumed:** the pinned `mujoco==3.10.0` (`requirements-sim.txt`) ships `manylinux_2_27_aarch64` wheels — checked directly against PyPI's own JSON API (`pypi.org/pypi/mujoco/3.10.0/json`), not inferred. `plant-mujoco`'s `build.rs` probe therefore resolves the same way on `ubuntu-24.04-arm` as it already does on the `rust`/`sim` jobs' `ubuntu-latest` runners. `cargo build --release -p board-app-driverless` was run locally against that same pin and succeeds.

## What this satisfies

- A real aarch64 release build of the controller binary, produced in CI on every mainline merge.
- A stable rolling URL (`.../releases/download/controller-latest/...`) an on-device mechanism can later poll — checksum and provenance JSON included so a future consumer can verify what it pulled.
- Build step also runs on PRs (only the publish-to-release step is `master`-push-gated, mirroring `publish-sim-artifact`), so a change that breaks the aarch64 build is caught here, not discovered on a card.

## Deliberately left out — and why

**The other half of I5**: an on-device `overboard-update.sh` (pull, verify checksum, restart the unit) and its systemd unit. I looked at shipping it and stopped: `ldd` on the binary this job builds confirms it dynamically links `libmujoco.so.3.10.0`, and that library is not on any standard loader path (only found via `cargo run`'s dev-time loader path or the pip package's own directory today — see the existing "cannot run `sim-host` directly on macOS" dead end in this role's own notes, same root cause). Nothing yet provisions `libmujoco.so` onto a Pi image, and which binary should even run there, in which `--backend` mode, is explicitly I7's question ("sim-in-the-loop self-test on the Pi"), not I5's. Landing an update script that restarts a unit which cannot start would be exactly the unverifiable code this project's own runbook precedent already ruled out for `--hardware` mode. Flagging this as the concrete next increment rather than guessing at a packaging answer.

**I7 and I8** (sim-in-the-loop self-test, motor-in-the-loop bench test) remain entirely open — this PR does not touch RT scheduling, CAN egress, or the ring-buffer split between the isolated control core and MuJoCo.

## Verification

- `cargo build --workspace --all-targets` — clean.
- `cargo run -p xtask -- gate` — passes (crate-exclusion boundary intact, unrelated to this change).
- `python3 .github/policy_check.py` — all hard checks pass. `doc-drift` fired for `docs/design-claims-manifest.md` and `docs/web-artifact-pipeline.md` (both list `.github/workflows/ci.yml` in their `covers:` manifest) and was overridden with `DOC-OK:` in the commit message — this job is independent of the claims-manifest and sim-artifact pipelines either doc describes, and both docs are COO/Digital Content Production turf, not mine to edit.
- YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The `ubuntu-24.04-arm`-specific build itself can only be verified by this PR's own CI run (this container is x86_64) — that's the actual proof, not a claim made in advance.

Not closing #182 — most of the epic (the rest of I5, and all of I7/I8) is still open.


---
_Generated by [Claude Code](https://claude.ai/code/session_0158LsVHHMYXwAvVCmWz4qqm)_