### PR TITLE
feat(controls): (kp, kd) feasibility map for the ridden gain margin (#132)

### DIFF
--- a/roles/senior-controls/log/2026-08-21-gain-margin-sweep-132.md
+++ b/roles/senior-controls/log/2026-08-21-gain-margin-sweep-132.md
@@ -1,0 +1,36 @@
+# 2026-08-21 — Issue #132: the (kp, kd) feasibility map (PR #293, not closing #132)
+
+Cron dispatch pass. Same routing convention as prior passes (PR #245, #276, #283): no open
+issue currently carries a literal `Owner: Senior Controls` body marker except #261 (already has
+an open PR, #263 — skipped) and #61 (`Dispatch: COO only`, reserved). Went by `role:senior-controls`
+labels plus turf paths instead. #182 and #168 both already have open PRs (#290, #291). That left
+#132 as the only `role:senior-controls`-labelled issue with no PR in flight.
+
+**Correcting the 2026-08-16 pass's read of #132.** That entry (above) called #132 "not
+independently actionable without hardware that does not exist yet," on the grounds that AC1
+needs a bench-fitted `kt`. True for AC1 — but #132's own comment thread (posted the same day the
+issue was filed) reframes the finding and lays out a five-step revised order, and steps 1
+(#137, torque re-denomination) and 2 (#133/#142, reference disturbance) are both already merged.
+**Step 3 — sweep `(kp, kd)` as a plane against gain margin and delay margin — is explicitly called
+out in that same comment as "all of it kt-independent."** The prior pass's summary of #132 didn't
+distinguish AC1 (blocked, Mechanical's) from the revised order's other steps (not blocked, mine).
+This pass did that step: `scripts/gain_margin_sweep.py` + `tests/test_gain_margin_sweep.py`,
+repo-only, no hardware needed.
+
+**Finding, not fixed:** at today's model state, the comment's own two guardrails no longer
+overlap. `p` (the ridden RHP pole) has moved from 5.24 to 5.564 rad/s since the comment was
+written — plausibly from an intervening Mechanical mass/inertia change, not investigated further
+here since that's their turf, not a defect to chase. That shifts the recommended crossover floor
+(`1.5p`) to ~8.35 rad/s, past the same comment's explicit "treat >~8 rad/s as unvalidated"
+ceiling. The script reports this explicitly (`recommended_band_is_empty`) rather than silently
+widening the ceiling to make the band non-empty. No gain changed as a result — this is a finding
+for the eventual retune, not a decision.
+
+**Deliberately left out, flagged rather than fixed:** the nonlinear disturbance-capacity axis
+(step 3's third dimension — needs a full closed-loop impulse run per grid point, real separate
+work), step 4's robustness-over-p sweep (a different independent variable), and AC1's bench `kt`
+fit (still Mechanical's, still blocked on hardware). Does not close #132.
+
+PR #293 opened against `master`, full python (356 passed, 7 xfailed) and rust suites green,
+`policy_check.py` hard checks pass. Per role instructions, opened and left for review — not
+merged, auto-merge not enabled.

--- a/scripts/gain_margin_sweep.py
+++ b/scripts/gain_margin_sweep.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Issue #132 -- the (kp, kd) feasibility map, entirely `kt`-independent.
+
+**Not a retune.** This produces a feasibility map over a grid of candidate
+ridden inner-loop gains; it does not choose or recommend shipping gains. See
+"What must not be concluded" below.
+
+## Where this sits in #132's revised order
+
+The issue's own comment thread reframed the finding (`|L(0)| = K*kp/p^2`,
+stable iff `K*kp > p^2`) and laid out a five-step order. Step 1, torque
+re-denomination, landed as #137: the control law now takes `kp_nm_per_rad` /
+`kd_nm_per_rad_s` directly (`crates/control-core/src/lib.rs`), so `kt` no
+longer appears anywhere in the loop gain -- `K` above collapses to 1 in the
+gains this script (and the shipped controller) actually use. Step 2, deriving
+a reference disturbance, landed as #133/#142. **This script is step 3**: sweep
+`(kp, kd)` as a plane against downward gain margin and linear delay margin,
+producing a feasibility map rather than a tune.
+
+**Deliberately out of scope here, left for follow-up work:**
+
+- The nonlinear disturbance-capacity axis (step 3's third dimension). Each
+  grid point would need a full closed-loop impulse-response run
+  (`sim/scenarios/impulse_response.py`) to measure it, which is expensive
+  over a two-parameter grid; this script only computes what a single
+  linearization answers cheaply (gain margin, crossover, phase/delay
+  margin). `scripts/analyse_delay_budget.py` already does the nonlinear
+  amplitude sweep at ONE gain pair (the shipped one) -- extending that to
+  every grid point is real, separate work.
+- Step 4, the robustness sweep over `p` (rider mass/CoM range, ballast vs
+  rider) -- a different independent variable, not this one.
+- The bench `kt` fit itself (#132 AC1) is Sr. Mechanical & Systems' turf, not
+  a repo-only computation, and this script does not need it: everything here
+  is in torque-native units per #137, so `kt` never enters.
+
+## Method
+
+One linearization, reused across the whole grid. The trim point (`A`, `B`,
+`Cp`) is a property of the PLANT, not the gains -- `settle_upright` finds
+upright equilibrium under some stabilising PD (any stabilising pair works,
+since the trim state is the same fixed point), so it is computed once via
+`scripts/analyse_delay_budget.py`'s own machinery and re-used, rather than
+re-linearizing per grid point. Only the loop transfer `L(jw) = kp*Cpos(x) +
+kd*Cvel(x)` depends on the swept `(kp, kd)`, and that is a cheap linear solve
+per frequency, per grid point.
+
+    scripts/gain_margin_sweep.py --out-dir sim/out/experiments
+
+## What must NOT be concluded from this
+
+No shipping gain change. This is a feasibility map over the LINEAR,
+delay-free, disturbance-blind plane -- it says where the loop is structurally
+sound and where it is not, not where it should operate. Per the issue's own
+guardrail, any retune needs the nonlinear disturbance-capacity axis (still
+unmeasured here) and the robustness-over-p sweep (also unmeasured here)
+before it is a shipping decision, and needs to stay inside the 40 A clamp
+once denominated back through a FITTED `kt` -- still a bench measurement,
+still not made here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from scripts.analyse_delay_budget import (  # noqa: E402
+    BALLAST_KG, BALLAST_M, CLAMP_A,
+    analytic_pole, linearize, margins, pitch_output_map, settle_upright,
+)
+from sim.scenarios.plant import build_model  # noqa: E402
+
+#: Shipped ridden inner-loop gains, torque-native (#137;
+#: `tests/test_closed_loop.py:172`). `200 A/rad, 30 A/(rad/s)` at the placeholder
+#: `kt = 0.7 N*m/A` -- carried here only as the grid's reference point, not as
+#: an input to anything: the loop transfer below takes `kp`/`kd` directly.
+SHIPPED_KP_NM_PER_RAD = 140.0
+SHIPPED_KD_NM_PER_RAD_S = 21.0
+
+#: Grid bounds. Lower edge below the RHP boundary at the shipped `kd` (so the
+#: infeasible region is visible on the map, not just its edge); upper edge
+#: comfortably past `omega_c = 2p` (~10.5 rad/s), which #132's own comment
+#: found to raise crossover too far into unmodelled tyre/rider-body resonance
+#: (6-19 rad/s) -- the map should show that this is a bad idea, not merely
+#: avoid asking.
+KP_GRID_NM_PER_RAD = np.linspace(60.0, 450.0, 14)
+KD_GRID_NM_PER_RAD_S = np.linspace(7.0, 75.0, 14)
+
+
+def loop_transfer(A, B, Cp, omega, kp_nm, kd_nm):
+    """`L(jw)` for torque-native gains -- no `kt` conversion anywhere.
+
+    Same construction as `analyse_delay_budget.loop_transfer`, generalised to
+    take the swept gains as arguments instead of the module-level shipped
+    pair, and with the `KT_NM_PER_A` factor dropped: `B` already maps the
+    actuator's torque command (N*m) to state derivative (the MJCF actuator IS
+    a torque source), and the gains here are already N*m/rad and
+    N*m/(rad/s), so multiplying by `kt` would double-apply the actuation
+    boundary's conversion. This is the concrete benefit #137 bought: this
+    function needs one fewer constant than its predecessor.
+    """
+    nv = len(Cp)
+    nx = A.shape[0]
+    Cpos = np.zeros(nx)
+    Cpos[:nv] = Cp
+    Cvel = np.zeros(nx)
+    Cvel[nv:2 * nv] = Cp
+
+    out = np.zeros(len(omega), dtype=complex)
+    I = np.eye(nx)
+    for k, w in enumerate(omega):
+        x = np.linalg.solve(1j * w * I - A, B[:, 0])
+        out[k] = kp_nm * (Cpos @ x) + kd_nm * (Cvel @ x)
+    return out
+
+
+def fit_reduced_gain_constant(A, B, Cp, omega, p, kp_ref, kd_ref) -> float:
+    """Calibrate the reduced 2-state pendulum's `b` (`#132`'s `K`) against the
+    FULL model, once, at the shipped gains -- rather than trying to read
+    `|L(0)|` off the full 14-state model directly.
+
+    A direct DC evaluation of the full model is unusable: the free joint
+    carries integrator DOFs with no restoring force at all (wheel spin, yaw,
+    forward translation), so `A` has an exact zero eigenvalue, and `L(jw)`
+    computed from the full model does not converge to a stable limit as
+    `w -> 0` (checked: it falls monotonically toward zero below `w ~ 0.1`
+    rather than settling -- the free modes dominate exactly where a DC
+    reading would be taken). Full closed-loop eigenvalues have the same
+    problem from the other side: state feedback on pitch alone leaves those
+    same free modes at (numerically near-)zero real part regardless of gains,
+    so "is the max eigenvalue negative" flags the empirically-safe shipped
+    gains as marginal.
+
+    `#132`'s own algebra models the pitch DOF alone as a 2nd-order pendulum,
+    `theta'' - p^2*theta = b*tau`, which is exactly what `analyse_delay_budget`
+    already validates against the nonlinear sim at ONE point (the shipped
+    gains: measured break times, not just a linear prediction). PD feedback
+    on that reduced model gives `L(jw) = b*(kp + j*kd*w) / -(w^2 + p^2)`, and
+    solving `|L(jwc)| = 1` at the crossover the FULL model already measured
+    (validated: `analyse_delay_budget.py` reports `omega_c = 4.48 rad/s`
+    here, matching the historical value) pins `b`:
+
+        b = (wc^2 + p^2) / sqrt(kp^2 + kd^2*wc^2)
+
+    Checked against the full model's own `|L(jw)|` from 0.1 rad/s to
+    crossover at the shipped gains: agreement is within ~5% throughout that
+    whole range, so the free modes the full-order DC/eigenvalue reads choke
+    on are a small correction to the pitch channel at these frequencies, not
+    a dominant one -- the reduction is trustworthy over the range this script
+    uses it for.
+    """
+    L = loop_transfer(A, B, Cp, omega, kp_ref, kd_ref)
+    m = margins(omega, L)
+    if m is None:
+        raise ValueError("reference gains have no crossover -- cannot calibrate b")
+    wc = m["omega_c_rad_s"]
+    return (wc * wc + p * p) / math.sqrt(kp_ref * kp_ref + kd_ref * kd_ref * wc * wc)
+
+
+def evaluate(A, B, Cp, omega, p, b, kp_nm, kd_nm) -> dict:
+    """One grid point: downward gain margin (reduced model, see `b` above),
+    crossover, phase and delay margin (full model -- `loop_transfer` is
+    well-behaved away from DC, unlike the gain-margin reading)."""
+    kp_min = p * p / b
+    row = {
+        "kp_nm_per_rad": float(kp_nm),
+        "kd_nm_per_rad_s": float(kd_nm),
+        "kp_min_nm_per_rad": kp_min,
+        "stable": bool(kp_nm > kp_min),
+    }
+    if not row["stable"]:
+        row.update(downward_gain_margin_db=None, omega_c_rad_s=None,
+                    phase_margin_deg=None, delay_margin_s=None)
+        return row
+
+    row["downward_gain_margin_db"] = 20.0 * math.log10(kp_nm / kp_min)
+    L = loop_transfer(A, B, Cp, omega, kp_nm, kd_nm)
+    m = margins(omega, L)
+    if m is None:
+        row.update(omega_c_rad_s=None, phase_margin_deg=None, delay_margin_s=None)
+    else:
+        row.update(m)
+    return row
+
+
+def sweep(A, B, Cp, omega, p, b, kp_grid=KP_GRID_NM_PER_RAD, kd_grid=KD_GRID_NM_PER_RAD_S):
+    return [evaluate(A, B, Cp, omega, p, b, kp, kd)
+            for kp, kd in itertools.product(kp_grid, kd_grid)]
+
+
+#: "Treat any sim result above ~8 rad/s crossover as unvalidated" -- #132's
+#: comment thread, stated alongside the 1.5p recommendation itself. Named
+#: here rather than folded into `recommended_band` so both halves of that
+#: one sentence stay next to each other in the diff if either ever changes.
+RESONANCE_CEILING_RAD_S = 8.0
+
+
+def recommended_band(p: float, ceiling: float = RESONANCE_CEILING_RAD_S):
+    """`(target_omega_c, band_is_empty)` for #132's recommended crossover.
+
+    Pulled out of `main()` so the "does the band still exist" question is
+    unit-testable on synthetic `p` values, independently of the model.
+    """
+    target = 1.5 * p
+    return target, target > ceiling
+
+
+def select_feasible(rows, target_omega_c: float, ceiling: float = RESONANCE_CEILING_RAD_S):
+    """Grid rows inside #132's recommended band: stable, `omega_c` between the
+    1.5p floor and the unvalidated-resonance ceiling, and positive phase
+    margin once there."""
+    return [r for r in rows if r["stable"] and r["omega_c_rad_s"] is not None
+            and target_omega_c <= r["omega_c_rad_s"] <= ceiling
+            and r["phase_margin_deg"] > 0.0]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", type=Path, default=REPO / "sim/out/experiments")
+    args = ap.parse_args()
+
+    model = build_model(BALLAST_KG, BALLAST_M, CLAMP_A)
+    dt = float(model.opt.timestep)
+    data = settle_upright(model)
+
+    A, B = linearize(model, data)
+    Cp = pitch_output_map(model, data)
+    p = analytic_pole(model)["p_rolling_support_rad_s"]
+
+    omega = np.logspace(-1, math.log10(math.pi / dt), 4000)
+
+    b = fit_reduced_gain_constant(A, B, Cp, omega, p,
+                                   SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+
+    rows = sweep(A, B, Cp, omega, p, b)
+    shipped = evaluate(A, B, Cp, omega, p, b,
+                        SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+
+    # #132's revised recommendation: prefer omega_c ~ 1.5p (10 dB, tolerates a
+    # 68% gain shortfall) over the originally-proposed 2p, because the higher
+    # target crosses into unmodelled tyre/rider-body resonance (6-19 rad/s).
+    # The SAME comment gives an explicit ceiling: "treat any sim result above
+    # ~8 rad/s crossover as unvalidated" -- so the recommended band is NOT
+    # "1.5p and up", it is [1.5p, ~8 rad/s]. `p` has moved since that comment
+    # was written (5.24 -> 5.564 rad/s here, an intervening model change --
+    # see the module docstring), so 1.5p now sits at ~8.35 rad/s: ABOVE the
+    # ceiling. That is a finding in its own right, reported explicitly below
+    # rather than silently widening the ceiling to make the band non-empty.
+    target_omega_c, band_is_empty = recommended_band(p)
+    feasible = select_feasible(rows, target_omega_c)
+    best = max(feasible, key=lambda r: r["phase_margin_deg"]) if feasible else None
+
+    report = {
+        "p_rolling_support_rad_s": p,
+        "fitted_reduced_gain_constant_b": b,
+        "target_omega_c_rad_s_at_1p5p": target_omega_c,
+        "resonance_ceiling_rad_s": RESONANCE_CEILING_RAD_S,
+        "recommended_band_is_empty": band_is_empty,
+        "shipped_gains": shipped,
+        "grid_shape": [len(KP_GRID_NM_PER_RAD), len(KD_GRID_NM_PER_RAD_S)],
+        "feasible_in_recommended_band_count": len(feasible),
+        "best_phase_margin_in_recommended_band": best,
+        "grid": rows,
+    }
+
+    print(json.dumps(report, indent=2))
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    out = args.out_dir / "gain_margin_sweep.json"
+    out.write_text(json.dumps(report, indent=2) + "\n")
+    print(f"\nwrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gain_margin_sweep.py
+++ b/tests/test_gain_margin_sweep.py
@@ -1,0 +1,168 @@
+"""Issue #132, revised order step 3 -- `scripts/gain_margin_sweep.py`.
+
+Checks the feasibility-map machinery itself: the reduced-model calibration is
+faithful to the full model, the map is deterministic and internally
+consistent (gain margin rises with `kp`, the RHP threshold does not depend on
+`kd`), and the shipped gains land close to #132's own reported 2.9 dB --
+"close", not exact, because the plant has moved since that comment was
+written (see the module docstring's note on `p`), and this test pins that
+tolerance rather than the stale exact figure.
+"""
+
+import math
+
+import numpy as np
+
+from scripts.analyse_delay_budget import (
+    BALLAST_KG, BALLAST_M, CLAMP_A, analytic_pole, linearize,
+    pitch_output_map, settle_upright,
+)
+from scripts.gain_margin_sweep import (
+    RESONANCE_CEILING_RAD_S, SHIPPED_KD_NM_PER_RAD_S, SHIPPED_KP_NM_PER_RAD,
+    evaluate, fit_reduced_gain_constant, loop_transfer, recommended_band,
+    select_feasible, sweep,
+)
+from sim.scenarios.plant import build_model
+
+
+def _linearize_ridden():
+    model = build_model(BALLAST_KG, BALLAST_M, CLAMP_A)
+    dt = float(model.opt.timestep)
+    data = settle_upright(model)
+    A, B = linearize(model, data)
+    Cp = pitch_output_map(model, data)
+    p = analytic_pole(model)["p_rolling_support_rad_s"]
+    omega = np.logspace(-1, math.log10(math.pi / dt), 4000)
+    return A, B, Cp, p, omega
+
+
+def test_shipped_gains_downward_margin_is_close_to_the_issues_own_figure():
+    """#132's comment measured 2.9 dB at (kp=200 A/rad, kd=30 A/(rad/s),
+    kt=0.7) -- 140/21 in today's torque-native units. The model has since
+    picked up mechanical changes (this repo's `p` here is 5.56 rad/s, not the
+    comment's 5.24), so this is a tolerance check, not a pin: it catches a
+    method error (wrong sign, wrong units, wrong crossover) without flaking
+    on every future mass/inertia tweak Sr. Mechanical & Systems makes."""
+    A, B, Cp, p, omega = _linearize_ridden()
+    b = fit_reduced_gain_constant(A, B, Cp, omega, p,
+                                   SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+    row = evaluate(A, B, Cp, omega, p, b, SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+
+    assert row["stable"]
+    assert 2.0 < row["downward_gain_margin_db"] < 3.5, (
+        f"expected close to #132's measured 2.9 dB, got {row['downward_gain_margin_db']:.2f} dB"
+    )
+    # Same cross-check as analyse_delay_budget.py's own history: crossover
+    # near 4.5 rad/s, phase margin in the low-to-mid 30s.
+    assert 4.0 < row["omega_c_rad_s"] < 5.0
+    assert 25.0 < row["phase_margin_deg"] < 45.0
+
+
+def test_reduced_model_agrees_with_the_full_model_up_to_crossover():
+    """The `b`-fit is only valid if the 2-state reduction actually tracks the
+    full 14-state model over the range this script reads it at. Checked at
+    five points from the omega floor to the shipped-gains crossover -- if a
+    future change (e.g. a much stiffer tyre model) breaks this agreement, the
+    gain-margin numbers this script reports would quietly stop meaning
+    anything, and this is the test that would catch it."""
+    A, B, Cp, p, omega = _linearize_ridden()
+    b = fit_reduced_gain_constant(A, B, Cp, omega, p,
+                                   SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+
+    for w in (0.1, 0.5, 1.0, 2.0, 4.0):
+        full = abs(loop_transfer(A, B, Cp, np.array([w]),
+                                  SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)[0])
+        reduced = b * math.sqrt(SHIPPED_KP_NM_PER_RAD ** 2
+                                 + (SHIPPED_KD_NM_PER_RAD_S * w) ** 2) / (w * w + p * p)
+        rel_err = abs(full - reduced) / full
+        assert rel_err < 0.10, f"at w={w}: full={full:.4f} reduced={reduced:.4f} ({rel_err:.1%} off)"
+
+
+def test_downward_gain_margin_rises_monotonically_with_kp():
+    """`kp_min` is a fixed threshold (RHP stability condition); margin above
+    it must strictly increase with `kp` at fixed `kd` -- the whole point of
+    calling it a margin."""
+    A, B, Cp, p, omega = _linearize_ridden()
+    b = fit_reduced_gain_constant(A, B, Cp, omega, p,
+                                   SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+
+    margins_db = [evaluate(A, B, Cp, omega, p, b, kp, SHIPPED_KD_NM_PER_RAD_S)["downward_gain_margin_db"]
+                  for kp in (110.0, 140.0, 200.0, 300.0)]
+    assert margins_db == sorted(margins_db)
+    assert margins_db[0] < margins_db[-1]
+
+
+def test_kp_min_does_not_depend_on_kd():
+    """Routh-Hurwitz on the reduced model: the marginal-`kp` threshold comes
+    only from the constant term of the closed-loop characteristic polynomial,
+    which `kd` never enters. If a future refactor accidentally folds `kd`
+    into `kp_min`, this is the test that notices."""
+    A, B, Cp, p, omega = _linearize_ridden()
+    b = fit_reduced_gain_constant(A, B, Cp, omega, p,
+                                   SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+
+    kp_min_a = evaluate(A, B, Cp, omega, p, b, 200.0, 10.0)["kp_min_nm_per_rad"]
+    kp_min_b = evaluate(A, B, Cp, omega, p, b, 200.0, 60.0)["kp_min_nm_per_rad"]
+    assert kp_min_a == kp_min_b
+
+
+def test_below_threshold_gains_are_reported_unstable_not_extrapolated():
+    """A `kp` at or below `kp_min` must not produce a (nonsensical, since
+    `log10` of a non-positive number is undefined) gain-margin figure."""
+    A, B, Cp, p, omega = _linearize_ridden()
+    b = fit_reduced_gain_constant(A, B, Cp, omega, p,
+                                   SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+    kp_min = p * p / b
+
+    row = evaluate(A, B, Cp, omega, p, b, 0.5 * kp_min, SHIPPED_KD_NM_PER_RAD_S)
+    assert not row["stable"]
+    assert row["downward_gain_margin_db"] is None
+    assert row["omega_c_rad_s"] is None
+
+
+def test_sweep_is_deterministic():
+    """Same convention as issue #24 AC4's determinism audit: two runs of the
+    same grid over the same linearization must be bit-identical."""
+    A, B, Cp, p, omega = _linearize_ridden()
+    b = fit_reduced_gain_constant(A, B, Cp, omega, p,
+                                   SHIPPED_KP_NM_PER_RAD, SHIPPED_KD_NM_PER_RAD_S)
+    small_kp = np.linspace(80.0, 200.0, 4)
+    small_kd = np.linspace(10.0, 40.0, 4)
+
+    first = sweep(A, B, Cp, omega, p, b, small_kp, small_kd)
+    second = sweep(A, B, Cp, omega, p, b, small_kp, small_kd)
+    assert first == second
+
+
+def test_recommended_band_reports_when_empty_rather_than_silently_widening():
+    """`recommended_band` is the testable half of the "does 1.5p still fit
+    under the ~8 rad/s unvalidated-crossover ceiling" question -- checked on
+    synthetic `p` values so this does not depend on the live model's current
+    pole and stays meaningful if the plant changes again."""
+    target, empty = recommended_band(p=4.0)  # 1.5*4.0 = 6.0, under the 8.0 ceiling
+    assert not empty
+    assert target == 6.0
+
+    target, empty = recommended_band(p=6.0)  # 1.5*6.0 = 9.0, over the 8.0 ceiling
+    assert empty
+    assert target == 9.0
+
+    # The boundary itself is inclusive-safe: exactly at the ceiling is not "empty".
+    target, empty = recommended_band(p=RESONANCE_CEILING_RAD_S / 1.5)
+    assert not empty
+
+
+def test_select_feasible_excludes_points_outside_the_recommended_band():
+    """A synthetic grid exercising `select_feasible`'s three gates
+    independently: unstable, below the crossover floor, and above the
+    resonance ceiling must all be excluded; only the point clearing all
+    three, with positive phase margin, should survive."""
+    rows = [
+        {"stable": False, "omega_c_rad_s": 9.0, "phase_margin_deg": 30.0},
+        {"stable": True, "omega_c_rad_s": 3.0, "phase_margin_deg": 30.0},
+        {"stable": True, "omega_c_rad_s": 9.0, "phase_margin_deg": 30.0},
+        {"stable": True, "omega_c_rad_s": 7.0, "phase_margin_deg": -5.0},
+        {"stable": True, "omega_c_rad_s": 7.0, "phase_margin_deg": 12.0},
+    ]
+    feasible = select_feasible(rows, target_omega_c=6.0, ceiling=8.0)
+    assert feasible == [rows[4]]


### PR DESCRIPTION
## What

Issue #132 found the ridden inner loop runs with only 2.9 dB of downward gain margin against its RHP boundary. The issue's own comment thread reframed the finding and laid out a five-step revised order. Steps 1 (#137, torque re-denomination) and 2 (#133/#142, reference disturbance) are already landed. **This PR is step 3**: sweep `(kp, kd)` as a plane against downward gain margin and linear delay/phase margin — a feasibility map, not a retune.

`scripts/gain_margin_sweep.py`:
- Reuses `scripts/analyse_delay_budget.py`'s own linearization machinery (one linearization of the ridden plant, since the trim point doesn't depend on the swept gains) rather than duplicating it.
- Entirely `kt`-independent: gains are torque-native (`kp_nm_per_rad`/`kd_nm_per_rad_s`) per #137, so `kt` never enters — no bench measurement is a prerequisite.
- Reads downward gain margin off a reduced 2-state pendulum model (the same reduction #132's comment used), with its gain constant `b` calibrated **once**, against the full model's own validated crossover. A direct DC or closed-loop-eigenvalue reading off the full 14-state model turned out to be unusable — the free joint's integrator DOFs (wheel spin, yaw, translation) make it singular/marginal in ways that flag the empirically-safe shipped gains as unstable. The reduction is checked against the full model's own `|L(jw)|` from the omega floor up to crossover (agreement within ~5%, asserted in tests).
- Crossover, phase margin and linear delay margin per grid point come straight from the full-order `loop_transfer`/`margins` (already validated machinery, unchanged).

`tests/test_gain_margin_sweep.py` (8 tests): shipped-gains margin lands close to #132's own reported 2.9 dB (tolerance, not a pin — the plant has moved since that comment, see below); the reduced-model fit tracks the full model; gain margin rises monotonically with `kp`; the RHP threshold `kp_min` doesn't depend on `kd` (Routh-Hurwitz); sub-threshold gains report `unstable` rather than extrapolating a nonsense margin; the sweep is deterministic; and the "recommended band" logic is unit-tested on synthetic `p` values independent of the live model.

## Finding

At today's model state, `p` (the ridden RHP pole) has moved from 5.24 to 5.564 rad/s since #132's comment was written. That shifts `1.5p` (the comment's own recommended crossover floor) to ~8.35 rad/s — **above** the same comment's explicit ceiling ("treat any sim result above ~8 rad/s crossover as unvalidated"). The two guardrails no longer overlap. The script reports this explicitly (`recommended_band_is_empty`) rather than silently widening the ceiling to make the band non-empty.

## Deliberately left out

- The nonlinear disturbance-capacity axis (revised-order step 3's third dimension) — each grid point would need a full closed-loop impulse-response run; expensive over a 2-parameter grid and real, separate work. `analyse_delay_budget.py` already covers this at the one shipped gain pair.
- Step 4, the robustness sweep over `p` (rider mass/CoM range, ballast vs. rider) — a different independent variable.
- The bench `kt` fit itself (#132 AC1) — Sr. Mechanical & Systems' turf, and not needed here.

## What must NOT be concluded

No shipping gain change. This is a linear, delay-free, disturbance-blind feasibility map — it shows where the loop is structurally sound, not where it should operate. Any retune still needs the nonlinear disturbance-capacity axis, the robustness-over-p sweep, and the 40 A clamp re-expressed through a fitted `kt` before it's a shipping decision.

## Testing

- `pytest tests/` — 356 passed, 7 xfailed (full suite, including the new file).
- `cargo test --workspace` — all green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `python3 .github/policy_check.py` — all hard checks pass (pre-existing advisories only, unrelated to this change).

Does not close #132 — AC1 (bench `kt` fit) is still open and is Mechanical's, not mine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XHvL1VyoXUs6RovVNg8qYf)_