### PR TITLE
Pin the five packages the image forgot, and record what I1 must still apply

### DIFF
--- a/crates/plant-mujoco/src/bin/replay.rs
+++ b/crates/plant-mujoco/src/bin/replay.rs
@@ -52,10 +52,11 @@ fn main() -> ExitCode {
             ctrl_bytes.len()
         );
     }
-    let ctrl: Vec<f64> = ctrl_bytes
-        .chunks_exact(8)
-        .map(|c| f64::from_le_bytes(c.try_into().expect("chunks_exact(8)")))
-        .collect();
+    // as_chunks, not chunks_exact(8): the chunk size is a constant, so the
+    // array size is known at compile time and the try_into/expect disappears.
+    // clippy flags the older form, and CI treats warnings as errors.
+    let (whole, _rest) = ctrl_bytes.as_chunks::<8>();
+    let ctrl: Vec<f64> = whole.iter().copied().map(f64::from_le_bytes).collect();
     if nu == 0 || !ctrl.len().is_multiple_of(nu) {
         panic!(
             "plant-replay: ctrl file holds {} f64s, not a whole number of \

--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -142,36 +142,6 @@ change are not obviously comparable, and nothing in the data says so. Tracked in
 
 ---
 
-## What `pins.env` carries besides the kernel
-
-Updated 2026-08-22. Five packages were added after every one of them had to be
-installed **by hand** on the bench Pi, because the image did not carry it. Each
-absence stopped work at the bench:
-
-| Package | Why its absence hurts |
-|---|---|
-| `python3-spidev` | The AS5047U joint encoders read over SPI0 from Python. The recorder cannot open a device without it. |
-| `wpasupplicant` | **The worst one to omit.** NetworkManager's wifi backend. Without it the staged wifi profile is dropped in *silence*, the Pi never joins, and a headless board looks dead. |
-| `build-essential` | A linker. `rustup` installs happily without one and then cannot link, so the failure surfaces at first `cargo build`, not at install. Also supplies `linux/can.h`. |
-| `curl` | `rustup` is fetched with it, and the image ships no `wget` either — with neither there is no way to bootstrap a toolchain at all. |
-| `git` | No way to get a repository onto the Pi. |
-
-**Three image requirements are NOT packages** and nothing applies them yet;
-each was done by hand on the current card, and they are recorded in `pins.env`
-so the choice is made rather than forgotten:
-
-1. **The spidev udev rule.** The image ships none, so nodes come up
-   `root:root 0600` and membership of group `spi` does not help — the group
-   *on the node* is root. `sudo` is not the fix: root has a different
-   environment from the one the control loop runs in, and the difference
-   resurfaces later disguised as a sensor fault.
-2. **The Rust toolchain.** M4 needs a 1 kHz Rust loop on this host. Debian's
-   `rustc` is deliberately not used — the repositories carry
-   `rust-toolchain.toml`, which only rustup honours.
-3. **`cpufrequtils` does not exist in trixie.** Do not add it.
-
----
-
 ## 5. Close Q12 — which kernel the firmware actually selects
 
 The highest-value step available before the image exists.

--- a/docs/runbook-pi-first-boot.md
+++ b/docs/runbook-pi-first-boot.md
@@ -142,6 +142,36 @@ change are not obviously comparable, and nothing in the data says so. Tracked in
 
 ---
 
+## What `pins.env` carries besides the kernel
+
+Updated 2026-08-22. Five packages were added after every one of them had to be
+installed **by hand** on the bench Pi, because the image did not carry it. Each
+absence stopped work at the bench:
+
+| Package | Why its absence hurts |
+|---|---|
+| `python3-spidev` | The AS5047U joint encoders read over SPI0 from Python. The recorder cannot open a device without it. |
+| `wpasupplicant` | **The worst one to omit.** NetworkManager's wifi backend. Without it the staged wifi profile is dropped in *silence*, the Pi never joins, and a headless board looks dead. |
+| `build-essential` | A linker. `rustup` installs happily without one and then cannot link, so the failure surfaces at first `cargo build`, not at install. Also supplies `linux/can.h`. |
+| `curl` | `rustup` is fetched with it, and the image ships no `wget` either — with neither there is no way to bootstrap a toolchain at all. |
+| `git` | No way to get a repository onto the Pi. |
+
+**Three image requirements are NOT packages** and nothing applies them yet;
+each was done by hand on the current card, and they are recorded in `pins.env`
+so the choice is made rather than forgotten:
+
+1. **The spidev udev rule.** The image ships none, so nodes come up
+   `root:root 0600` and membership of group `spi` does not help — the group
+   *on the node* is root. `sudo` is not the fix: root has a different
+   environment from the one the control loop runs in, and the difference
+   resurfaces later disguised as a sensor fault.
+2. **The Rust toolchain.** M4 needs a 1 kHz Rust loop on this host. Debian's
+   `rustc` is deliberately not used — the repositories carry
+   `rust-toolchain.toml`, which only rustup honours.
+3. **`cpufrequtils` does not exist in trixie.** Do not add it.
+
+---
+
 ## 5. Close Q12 — which kernel the firmware actually selects
 
 The highest-value step available before the image exists.

--- a/scripts/pi/pins.env
+++ b/scripts/pi/pins.env
@@ -91,4 +91,69 @@ BOOTLOADER_CHANNEL="default"        # NOT latest -- see above
 PINNED_PACKAGES="
 rt-tests=2.6-1.1
 can-utils=2023.03-1+b2
+python3-spidev=3.6-1+b6
+wpasupplicant=2:2.10-24
+build-essential=12.12
+curl=8.14.1-2+deb13u4
+git=1:2.47.3-0+deb13u1
 "
+
+# ---------------------------------------------------------------------------
+# WHY THE FIVE PACKAGES BELOW rt-tests AND can-utils ARE HERE
+#
+# Every one of them was installed BY HAND on the bench Pi between 2026-08-16
+# and 2026-08-22, because the image did not carry it. Each absence stopped
+# work at the bench. Versions verified 2026-08-22 twice: against the running
+# Pi, and against a `debian:trixie` arm64 container with this archive added --
+# the same shape verify_pins.sh runs in. All five matched exactly.
+#
+#   python3-spidev   The AS5047U joint encoders read over SPI0 from Python.
+#                    The bench recorder cannot open a device without it.
+#
+#   wpasupplicant    NetworkManager's wifi backend. THIS ONE IS THE WORST TO
+#                    OMIT: without it the staged wifi profile is dropped in
+#                    SILENCE, the Pi never joins the network, and a headless
+#                    board looks dead. It cost this project a session.
+#
+#   build-essential  A linker. rustup installs happily without one and then
+#                    cannot link a single binary, so the failure appears at
+#                    first `cargo build` rather than at install. Also supplies
+#                    linux/can.h, which any native SocketCAN code needs.
+#
+#   curl             rustup is fetched with it, and the image ships no wget
+#                    either, so with neither there is no way to bootstrap a
+#                    toolchain at all.
+#
+#   git              No way to get a repository onto the Pi without it.
+#
+# Do NOT thin this list back to "the measurement essentials". The card is a
+# bench host that gets worked on, not an appliance, and each removal above
+# was rediscovered the expensive way.
+# ---------------------------------------------------------------------------
+
+# Image requirements that are NOT packages. I1 must apply these; nothing does
+# today, and each was applied by hand on the current card.
+#
+#   1. SPI device permissions. The image ships no udev rule for spidev, so the
+#      nodes come up root:root 0600 and membership of group `spi` does not
+#      help -- the group ON THE NODE is root. A recorder fails with Permission
+#      denied before it reads one word from the sensor. The rule:
+#
+#          SUBSYSTEM=="spidev", GROUP="spi", MODE="0660"
+#            -> /etc/udev/rules.d/99-spidev.rules
+#
+#      and the operator account must be in group `spi`. Running the recorder
+#      under sudo is NOT the fix: root has a different environment from the
+#      one the control loop runs in, and the difference resurfaces later
+#      disguised as a sensor fault.
+#
+#   2. A Rust toolchain. M4 needs a 1 kHz control loop in Rust on this host.
+#      Debian's rustc is not used deliberately: the repositories carry
+#      `rust-toolchain.toml`, which only rustup honours. rustup is a
+#      curl-to-shell install and therefore NOT an apt pin, so it cannot live
+#      in PINNED_PACKAGES. Decide at I1 whether the image bakes it in or the
+#      runbook installs it. It is recorded here so the choice is made rather
+#      than forgotten.
+#
+#   3. cpufrequtils DOES NOT EXIST in trixie. Do not add it. The performance
+#      governor is set another way.


### PR DESCRIPTION
## What changed

Five packages added to `PINNED_PACKAGES`. **Every one was installed by hand on the bench Pi between 2026-08-16 and 2026-08-22, because the image did not carry it.** Each absence stopped work at the bench.

| Package | Why its absence hurts |
|---|---|
| `python3-spidev` | The AS5047U joint encoders read over SPI0 from Python. The recorder cannot open a device without it. |
| `wpasupplicant` | **The worst one to omit.** NetworkManager's wifi backend. Without it the staged wifi profile is dropped in *silence*, the Pi never joins, and a headless board looks dead. It cost a session. |
| `build-essential` | A linker. `rustup` installs happily without one and then cannot link a single binary, so the failure surfaces at first `cargo build`, not at install. Also supplies `linux/can.h`. |
| `curl` | `rustup` is fetched with it. The image ships no `wget` either, so with neither there is no way to bootstrap a toolchain at all. |
| `git` | No way to get a repository onto the Pi. |

## Also recorded: three image requirements that are not packages

Nothing applies these today, and each was done by hand on the current card.

1. **The spidev udev rule.** The image ships none, so nodes come up `root:root 0600`. Membership of group `spi` does not help — the group *on the node* is root. A recorder fails with Permission denied before it reads one word from the sensor. `sudo` is **not** the fix: root has a different environment from the one the control loop runs in, and the difference resurfaces later disguised as a sensor fault.
2. **The Rust toolchain decision.** M4 needs a 1 kHz Rust loop on this host. Debian's `rustc` is deliberately not used — the repositories carry `rust-toolchain.toml`, which only rustup honours. rustup is a curl-to-shell install, so it cannot be an apt pin. I1 decides whether the image bakes it in or the runbook installs it.
3. **`cpufrequtils` does not exist in trixie.** Do not add it.

## Verification

Versions verified **twice**, not recalled:

- against the running Pi (`dpkg-query`), and
- against a `debian:trixie` arm64 container with this archive added — the same shape `verify_pins.sh` runs in.

All five matched exactly. `verify_pins.sh` then passed on all seven pins, re-run after merging master's new bootloader-pin section into the file.

## Scope note

**No image is built yet.** `pi-image.yml` runs `verify-pins`, `verify-kernel` and the I0 `rpi-image-gen` spike, and publishes no artifact — `flash_pi.sh` still says to pass `--image` because I1 has not landed. This change does not build an image; it makes the pin file correct for when one is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164swyrSHnNDctrfVJzimPz